### PR TITLE
Fix device_capabilities.md to remove spurious triple back-ticks

### DIFF
--- a/guides/device_capabilities.md
+++ b/guides/device_capabilities.md
@@ -136,7 +136,6 @@ end
 ```
 
 > **Platform note:** `types` uses iOS UTI strings on iOS (`"public.pdf"`) and MIME type strings on Android (`"application/pdf"`). To support both platforms with the same call, pass both forms — the platform ignores strings it doesn't recognise. See [Platform-specific props](components.md#platform-specific-props) for a cleaner pattern.
-```
 
 ## Camera preview
 


### PR DESCRIPTION
Remove the extra triple back-ticks which were breaking rendering of documentation