### PR TITLE
camera: rotate session to portrait so YOLO sees an upright scene

### DIFF
--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -829,9 +829,24 @@ private struct MobCameraPreviewView: UIViewRepresentable {
         view.cameraLayer.videoGravity = .resizeAspectFill
         // Connect immediately if the session is already running.
         view.cameraLayer.session = g_preview_session
+        rotatePreviewConnection(view: view)
         // Observe future session changes (start, stop, facing swap).
         context.coordinator.startObserving(view: view)
         return view
+    }
+
+    // Pin the preview to portrait so what the user sees matches the
+    // upright frame we ship to the model. Without this, the sensor's
+    // landscape-native output renders sideways in a portrait UI.
+    private func rotatePreviewConnection(view: CameraPreviewUIView) {
+        guard let conn = view.cameraLayer.connection else { return }
+        if #available(iOS 17.0, *) {
+            if conn.isVideoRotationAngleSupported(90) {
+                conn.videoRotationAngle = 90
+            }
+        } else if conn.isVideoOrientationSupported {
+            conn.videoOrientation = .portrait
+        }
     }
 
     func updateUIView(_ view: CameraPreviewUIView, context: Context) {}
@@ -849,7 +864,17 @@ private struct MobCameraPreviewView: UIViewRepresentable {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                self?.hostView?.cameraLayer.session = g_preview_session
+                guard let view = self?.hostView else { return }
+                view.cameraLayer.session = g_preview_session
+                if let conn = view.cameraLayer.connection {
+                    if #available(iOS 17.0, *) {
+                        if conn.isVideoRotationAngleSupported(90) {
+                            conn.videoRotationAngle = 90
+                        }
+                    } else if conn.isVideoOrientationSupported {
+                        conn.videoOrientation = .portrait
+                    }
+                }
             }
         }
 

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -2806,6 +2806,25 @@ static ERL_NIF_TERM nif_camera_start_frame_stream(ErlNifEnv *env, int argc,
       }
       [g_preview_session commitConfiguration];
 
+      // Rotate the connection to portrait so the model sees upright
+      // pixels. The sensor's native orientation is landscape-right;
+      // without this, YOLO sees a 90°-rotated scene and misclassifies
+      // everything (a jar becomes a horizontal bar that looks like
+      // "laptop"). 90° rotation maps landscape sensor → portrait
+      // upright. videoRotationAngle is iOS 17+; older builds get the
+      // deprecated videoOrientation as a fallback.
+      AVCaptureConnection *conn = [output connectionWithMediaType:AVMediaTypeVideo];
+      if (conn) {
+          if (@available(iOS 17.0, *)) {
+              if ([conn isVideoRotationAngleSupported:90.0])
+                  conn.videoRotationAngle = 90.0;
+          } else {
+              if ([conn isVideoOrientationSupported])
+                  conn.videoOrientation = AVCaptureVideoOrientationPortrait;
+          }
+          NSLog(@"[mob/camera] frame output rotated to portrait");
+      }
+
       if (!g_preview_session.isRunning) {
           [g_preview_session startRunning];
           NSLog(@"[mob/camera] session startRunning (from frame_stream)");


### PR DESCRIPTION
## Summary

iOS's camera sensor captures in landscape-right by default. With the phone held in portrait, both `AVCaptureVideoPreviewLayer` and the new `AVCaptureVideoDataOutput` delivered sideways frames — invisible to the user when only the preview was used, but devastating once we started feeding pixels to an ML model trained on upright COCO images. A jar held vertically in the UI arrived at YOLO as a horizontal bar and got classified as "laptop" or "cell phone" at low confidence.

Pin both the preview and the frame stream to 90° (`videoRotationAngle` on iOS 17+, `videoOrientation = .portrait` on older builds). With this in place, the same jar lands as **cup 96%** — high enough that the demo no longer needs a tuned-down confidence threshold to surface anything.

What you see on the preview is now what the model sees, and detection boxes align with their objects.

## Test plan
- [x] `mix test` — 741/741
- [x] `xcrun clang-format --dry-run -Werror ios/mob_nif.m` — clean
- [x] `swiftlint ios/` — only the pre-existing force_cast warning
- [x] Verified live on a physical iPhone: jar in frame classifies as `cup 96%`, laptop `93%`, mouse `64%` with default `conf_threshold: 0.25`

🤖 Generated with [Claude Code](https://claude.com/claude-code)