### PR TITLE
text_field: secure: true for masked password input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ---
 
+## [Unreleased]
+
+### Added
+- `text_field` now accepts a `secure: true` prop. iOS renders the field
+  as a SwiftUI `SecureField` (masked input) instead of the plain
+  `TextField`. The prop flows through the existing renderer
+  passthrough; cleartext still reaches the BEAM via `on_change` so apps
+  can hash/store the value as normal. Android consumes the same prop
+  via `PasswordVisualTransformation` once `mob_new`'s `MobBridge.kt.eex`
+  template is updated in a companion PR — until then the prop is a
+  graceful no-op on Android (renders as a regular field), no breakage.
+
+  Reveal-toggle ("eye" button) is intentionally deferred — its
+  interaction with SwiftUI focus retention requires a `ZStack`-and-opacity
+  rebuild of `MobTextField` and warrants its own change.
+
 ## [0.6.7]
 
 ### Added

--- a/ios/MobNode.h
+++ b/ios/MobNode.h
@@ -125,6 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, nonnull)
     NSString *keyboardTypeStr; // "default","number","decimal","email","phone","url"
 @property(nonatomic, copy, nonnull) NSString *returnKeyStr; // "done","next","go","search","send"
+@property(nonatomic, assign) BOOL isSecure;                 // mask input (SecureField on iOS)
 @property(nonatomic, copy, nullable) void (^onFocus)(void);
 @property(nonatomic, copy, nullable) void (^onBlur)(void);
 @property(nonatomic, copy, nullable) void (^onSubmit)(void);

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -1028,8 +1028,17 @@ private struct MobTextField: View {
         }
     }
 
+    @ViewBuilder
+    private var field: some View {
+        if node.isSecure {
+            SecureField(placeholder, text: $text)
+        } else {
+            TextField(placeholder, text: $text)
+        }
+    }
+
     var body: some View {
-        TextField(placeholder, text: $text)
+        field
             .focused($isFocused)
             .keyboardType(keyboardType)
             .submitLabel(submitLabel)

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -797,6 +797,10 @@ static MobNode *mob_node_from_dict(NSDictionary *dict) {
         if ([returnKey isKindOfClass:[NSString class]])
             node.returnKeyStr = returnKey;
 
+        id secure = props[@"secure"];
+        if ([secure isKindOfClass:[NSNumber class]])
+            node.isSecure = [secure boolValue];
+
         id onFocus = props[@"on_focus"];
         if (onFocus && [onFocus isKindOfClass:[NSNumber class]]) {
             int handle = [onFocus intValue];

--- a/test/mob/renderer_test.exs
+++ b/test/mob/renderer_test.exs
@@ -544,6 +544,22 @@ defmodule Mob.RendererTest do
       assert decoded["props"]["return_key"] == "next"
     end
 
+    test "secure boolean is passed through unchanged" do
+      tree = %{type: :text_field, props: %{value: "", secure: true}, children: []}
+      Renderer.render(tree, :android, MockNIF)
+      {:set_root, [json]} = Enum.find(MockNIF.calls(), fn {f, _} -> f == :set_root end)
+      decoded = :json.decode(json)
+      assert decoded["props"]["secure"] == true
+    end
+
+    test "secure defaults to absent when unset" do
+      tree = %{type: :text_field, props: %{value: ""}, children: []}
+      Renderer.render(tree, :android, MockNIF)
+      {:set_root, [json]} = Enum.find(MockNIF.calls(), fn {f, _} -> f == :set_root end)
+      decoded = :json.decode(json)
+      refute Map.has_key?(decoded["props"], "secure")
+    end
+
     test "register_tap receives {pid, tag} for tagged taps" do
       pid = self()
       tree = %{type: :button, props: %{text: "Tap", on_tap: {pid, :my_action}}, children: []}


### PR DESCRIPTION
## Summary

Adds a `secure: true` prop to `text_field`. iOS renders the field as a SwiftUI `SecureField` (masked input) instead of `TextField`. Cleartext still reaches the BEAM via `on_change` — apps hash/store the value as normal.

```elixir
%{type: :text_field, props: %{
  value: assigns.password,
  placeholder: "Password",
  secure: true,
  on_change: {self(), :password_changed}
}}
```

The prop flows through `Mob.Renderer.prepare_props/4`'s generic pass-through; no renderer changes were needed. Native side: `MobNode.isSecure` BOOL, parsed in `mob_nif.m`, branched on in `MobRootView.swift` via a `@ViewBuilder` field switch.

### Version / CHANGELOG

CHANGELOG entry under `## [Unreleased]`; no `mix.exs` bump. Matches the repo's pattern of feature-commits-without-bumps and a separate ride-along `Bump to X.Y.Z` commit at release-cut time (e.g. b974398).

### Android

This PR is iOS-only. Mob's library doesn't own Android Compose UI — that lives per-app, generated from `mob_new`'s `MobBridge.kt.eex` template. A companion PR against [GenericJam/mob_new](https://github.com/GenericJam/mob_new) adds `PasswordVisualTransformation` + `KeyboardType.Password` to the template.

Until that ships, `secure: true` is a graceful no-op on Android: the prop travels through the renderer but the Compose `TextField` ignores it. No breakage for unpatched apps.

### Why no reveal-toggle ("eye" button) yet

Worth its own PR. The iOS implementation needs `ZStack`-and-opacity to retain focus across `SecureField`/`TextField` swaps — the current `@ViewBuilder if/else` (and any naive toggle) tears the view down on every flip, dropping focus and dismissing the keyboard. Pairs with a `trailingIcon` slot in Compose. Out of scope here.

## Test plan

- [x] `mix test` — 794 passed (27 doctests, 767 tests), 43 excluded. Two new renderer tests cover `secure: true` serialising and absence-by-default.
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — clean (949 mods/funs, 0 issues)
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix erlfmt --check src/` — clean
- [x] `xcrun clang-format --dry-run -Werror ios/*.m ios/*.h` — clean
- [x] Verified on iOS sim (iPhone 17, iOS 26.2): `SecureField` renders dots; BEAM `:password` assign holds cleartext (`"hunter2"`); `Length: 7` label updates live.
- [x] Verified Android contract end-to-end with the matching `MobBridge.kt` patch applied locally: dots render, cleartext reaches BEAM, length label updates. (Template patch lands in the mob_new companion PR.)
- [ ] `swiftlint ios/` — not installed locally; the Swift diff is mechanical (single expression swapped for an `@ViewBuilder` computed property).

## Files

- `ios/MobNode.h` — `@property(nonatomic, assign) BOOL isSecure`
- `ios/mob_nif.m` — parses `props[@"secure"]` alongside `keyboard` / `return_key`
- `ios/MobRootView.swift` — `@ViewBuilder var field` picks `SecureField` or `TextField`; existing modifier chain applies uniformly to both
- `test/mob/renderer_test.exs` — pass-through and default-absent tests
- `CHANGELOG.md` — entry under `## [Unreleased]`