### PR TITLE
Fix: Column honours fill_height: true (iOS)

### DIFF
--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -221,7 +221,12 @@ struct MobNodeView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(node.childNodes.enumerated()), id: \.offset) { _, child in MobNodeView(node: child) }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                // fill_height: true lets a column flex to fill its parent so children
+                // with Spacer() or fill_height of their own can pin to the bottom.
+                // Without maxHeight the VStack hugs its content vertically and a
+                // trailing footer sits directly below the last child instead of the
+                // parent's bottom edge.
+                .frame(maxWidth: .infinity, maxHeight: node.fillHeight ? .infinity : nil, alignment: .topLeading)
                 .padding(node.paddingEdgeInsets)
                 .background(node.backgroundColor.map { Color($0) } ?? Color.clear)
                 .ifLet(node.onTap) { view, tap in


### PR DESCRIPTION
## Summary

The `.column` case in `MobNodeView` (`ios/MobRootView.swift`) only set
`maxWidth` on its frame. A `Column` with `fill_height: true` therefore
collapsed to the natural height of its children — only `Box` was honouring
`node.fillHeight`. This broke the canonical full-screen pattern:

```
<Column fill_width fill_height>
  <Header />
  <Scroll>...</Scroll>   # expected to flex
  <Footer />             # expected to pin to bottom
</Column>
```

On iOS the footer sat directly beneath the last child instead of the parent's
bottom edge.

## Change

`ios/MobRootView.swift`, `.column` case:

```diff
- .frame(maxWidth: .infinity, alignment: .leading)
+ .frame(maxWidth: .infinity,
+        maxHeight: node.fillHeight ? .infinity : nil,
+        alignment: .topLeading)
```

- `node.fillHeight` is already parsed by `mob_nif.m` (same prop `Box` uses);
  no NIF or renderer changes required.
- Alignment switched from `.leading` to `.topLeading` so children anchor at
  the top when the column flexes. When `maxHeight` is `nil` the VStack still
  hugs its content vertically, so the default path is unchanged.

## Backward compatibility

Pure addition. Default `fill_height` is `false`, matching today's intrinsic-
height behaviour. No call sites need updating.

## Out of scope

- **Android** — `android/` in this repo is JNI/Zig only. Compose-side parity
  (if needed) would live in the downstream host/demo app.
- **Swift tests** — there is no SwiftUI test target in this repo; per
  `CLAUDE.md` native UI changes are verified by `mix mob.deploy --native`
  plus a screenshot or `Mob.Test` interaction. Adding a test target is
  out of scope here.

## Testing

- [ ] Deploy a screen with `<Column fill_width fill_height>` containing a
      header, a flex region, and a footer inside a fixed-height parent;
      confirm the footer pins to the bottom.
- [ ] Confirm columns without `fill_height` still size to intrinsic height
      (no regression on existing screens).