### PR TITLE
docs: document background execution model

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,35 @@ see the [Mobile Surface Matrix](https://hexdocs.pm/mob/mobile_surface_matrix.htm
 Set realistic expectations before starting an app; spot plugin
 candidates if you want to fill a gap.
 
+## Background execution
+
+The BEAM runs on the device, but it does **not** keep running once the app is
+backgrounded. iOS suspends the whole process within seconds — schedulers stop,
+GenServers freeze, and any distribution / socket connections drop. Android does
+the same unless you run a foreground service (the persistent-notification kind).
+This is an OS constraint every mobile runtime lives with, not a Mob limitation.
+
+So a server can't push straight into a long-lived GenServer — the OS has to wake
+you first, via APNs (iOS) or FCM (Android). The shape is:
+
+```elixir
+# Register for a push token; your server stores it and sends through APNs/FCM.
+# See the mob_push package for the server side.
+Mob.Notify.register_push(socket)
+def handle_info({:push_token, :ios, token}, socket), do: ...
+
+# React to the OS suspending / resuming the app. A push wakes the app, the BEAM
+# resumes, your handler runs in a short window, then the OS suspends you again.
+Mob.Device.subscribe([:app])
+def handle_info({:mob_device, :did_enter_background}, socket), do: ...
+def handle_info({:mob_device, :will_enter_foreground}, socket), do: ...
+```
+
+`Mob.Device.foreground?/0` reports the current state. For true always-on (e.g. a
+live connection held open), an Android foreground service is the only path; iOS
+will not allow it. Otherwise treat the device as push-driven: server → APNs/FCM →
+OS wakes app → BEAM handles the event → BEAM suspends again.
+
 ## What's in the box
 
 The pre-built OTP runtime that ships with each app includes:


### PR DESCRIPTION
## What

Adds a **Background execution** section to the README describing how Mob apps
behave when backgrounded and how to respond to server-pushed events.

## Why

#18 asks whether a Mob app can run as a background process that responds to
messages from a server. The README documents the foreground UI loop and the
`Mob.Notify` / `mob_push` surface, but says nothing about what happens once the
OS suspends the app — which is the crux of that question.

## Contents

The new section explains, grounded in the existing API:

- The BEAM is suspended when the app is backgrounded (iOS within seconds;
  Android unless a foreground service runs) — an OS constraint, not a Mob one.
- The push-driven model: server → APNs/FCM → OS wakes the app → a handler runs
  in a short window → the OS suspends again.
- The concrete hooks already in Mob: `Mob.Notify.register_push/1`, the `:app`
  lifecycle events from `Mob.Device.subscribe/1`
  (`:did_enter_background` / `:will_enter_foreground`), `Mob.Device.foreground?/0`,
  and the `mob_push` package for the server side.
- That true always-on requires an Android foreground service and is not possible
  on iOS.

Docs-only; no code changes.

Addresses #18.
