### PR TITLE
feat: support collocated screen templates

### DIFF
--- a/lib/mob/screen.ex
+++ b/lib/mob/screen.ex
@@ -118,7 +118,43 @@ defmodule Mob.Screen do
                 "Add a handle_event/3 clause to handle it."
       end
 
+      @before_compile Mob.Screen
       defoverridable dump_state: 1, load_state: 2, handle_info: 2, terminate: 2, handle_event: 3
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    template = Path.rootname(env.file) <> ".mob.heex"
+
+    cond do
+      Module.defines?(env.module, {:render, 1}) ->
+        quote(do: :ok)
+
+      File.exists?(template) ->
+        source =
+          template
+          |> File.read!()
+          |> String.split("\n")
+          |> Enum.map_join("\n", &("    " <> &1))
+
+        render_ast =
+          Code.string_to_quoted!("""
+          def render(assigns) do
+            import Mob.Sigil
+
+            ~MOB\"\"\"
+          #{source}
+            \"\"\"
+          end
+          """)
+
+        quote do
+          @external_resource unquote(template)
+          unquote(render_ast)
+        end
+
+      true ->
+        quote(do: :ok)
     end
   end
 

--- a/test/mob/screen_collocation_test.exs
+++ b/test/mob/screen_collocation_test.exs
@@ -1,0 +1,37 @@
+defmodule Mob.ScreenCollocationTest do
+  use ExUnit.Case, async: true
+
+  test "use Mob.Screen compiles a sibling .mob.heex template into render/1" do
+    dir =
+      Path.join(System.tmp_dir!(), "mob_screen_collocation_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    module = Module.concat([:"CollocatedScreen#{System.unique_integer([:positive])}"])
+    source = Path.join(dir, "collocated_screen.ex")
+    template = Path.join(dir, "collocated_screen.mob.heex")
+
+    File.write!(template, """
+    <Column>
+      <Text text={assigns.title} />
+    </Column>
+    """)
+
+    File.write!(source, """
+    defmodule #{inspect(module)} do
+      use Mob.Screen
+
+      def mount(_params, _session, socket), do: {:ok, socket}
+    end
+    """)
+
+    Code.compile_file(source)
+
+    assert %{
+             type: :column,
+             props: %{},
+             children: [%{type: :text, props: %{text: "Hello"}, children: []}]
+           } = module.render(%{title: "Hello"})
+  end
+end


### PR DESCRIPTION
## Summary
- compile a sibling `.mob.heex` file into `render/1` for screens that use `Mob.Screen`
- preserve explicit `render/1` definitions when a screen already provides one
- cover the generated render path with a collocation regression test

## Tests
- `ELIXIR_COMPILER_OPTIONS="--no-parallel" mix test test/mob/screen_collocation_test.exs test/mob/screen_test.exs`
