### PR TITLE
Add Mob.Speech text-to-speech capability

### DIFF
--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -150,6 +150,8 @@ pub const BridgeMethods = extern struct {
     haptic: jni.JMethodID = null,
     clipboard_put: jni.JMethodID = null,
     clipboard_get: jni.JMethodID = null,
+    tts_speak: jni.JMethodID = null,
+    tts_stop: jni.JMethodID = null,
     share_text: jni.JMethodID = null,
     open_url: jni.JMethodID = null,
     request_permission: jni.JMethodID = null,
@@ -1778,6 +1780,50 @@ export fn nif_clipboard_get(
     }
     detachIfAttached(attached);
     return out;
+}
+
+// nif_tts_speak/2 — speaks Text via MobBridge.ttsSpeak(String, String). The
+// OptsJson string carries {"rate","pitch","voice"} (all optional). The Bridge
+// method is optional: apps generated before TTS existed won't have it, so we
+// return :ok without doing anything rather than failing.
+export fn nif_tts_speak(
+    env: ?*erts.ErlNifEnv,
+    argc: c_int,
+    argv: [*]const erts.ERL_NIF_TERM,
+) callconv(.c) erts.ERL_NIF_TERM {
+    _ = argc;
+    if (Bridge.tts_speak == null) return erts.ok(env);
+    const text_bin = getBinOrIolist(env, argv[0]) orelse return erts.badarg(env);
+    const text = binToCString(text_bin) orelse return erts.atom(env, "error");
+    defer freeCString(text);
+    const opts_bin = getBinOrIolist(env, argv[1]) orelse return erts.badarg(env);
+    const opts = binToCString(opts_bin) orelse return erts.atom(env, "error");
+    defer freeCString(opts);
+    var attached: c_int = 0;
+    const jenv = get_jenv(&attached) orelse return erts.atom(env, "error");
+    const jtext = jni.newStringUTF(jenv, text);
+    const jopts = jni.newStringUTF(jenv, opts);
+    jenv.*.CallStaticVoidMethod.?(jenv, Bridge.cls, Bridge.tts_speak, jtext, jopts);
+    jni.deleteLocalRef(jenv, jtext);
+    jni.deleteLocalRef(jenv, jopts);
+    detachIfAttached(attached);
+    return erts.ok(env);
+}
+
+// nif_tts_stop/0 — stops any in-progress speech via MobBridge.ttsStop().
+export fn nif_tts_stop(
+    env: ?*erts.ErlNifEnv,
+    argc: c_int,
+    argv: [*]const erts.ERL_NIF_TERM,
+) callconv(.c) erts.ERL_NIF_TERM {
+    _ = argc;
+    _ = argv;
+    if (Bridge.tts_stop == null) return erts.ok(env);
+    var attached: c_int = 0;
+    const jenv = get_jenv(&attached) orelse return erts.atom(env, "error");
+    jenv.*.CallStaticVoidMethod.?(jenv, Bridge.cls, Bridge.tts_stop);
+    detachIfAttached(attached);
+    return erts.ok(env);
 }
 
 // nif_set_theme/1 — push the resolved theme palette (as JSON) to Kotlin so
@@ -4650,6 +4696,9 @@ fn nifLoad(env: ?*erts.ErlNifEnv, priv: *?*anyopaque, info: erts.ERL_NIF_TERM) c
     if (!cacheRequired(jenv, "haptic", "(Ljava/lang/String;)V", &Bridge.haptic)) return -1;
     if (!cacheRequired(jenv, "clipboardPut", "(Ljava/lang/String;)V", &Bridge.clipboard_put)) return -1;
     if (!cacheRequired(jenv, "clipboardGet", "()Ljava/lang/String;", &Bridge.clipboard_get)) return -1;
+    // Optional: apps generated before TTS existed lack these MobBridge methods.
+    cacheOptional(jenv, "ttsSpeak", "(Ljava/lang/String;Ljava/lang/String;)V", &Bridge.tts_speak);
+    cacheOptional(jenv, "ttsStop", "()V", &Bridge.tts_stop);
     if (!cacheRequired(jenv, "shareText", "(Ljava/lang/String;)V", &Bridge.share_text)) return -1;
     if (!cacheRequired(jenv, "openUrl", "(Ljava/lang/String;)V", &Bridge.open_url)) return -1;
 
@@ -4798,6 +4847,8 @@ const nif_funcs = [_]erts.ErlNifFunc{
     .{ .name = "haptic", .arity = 1, .fptr = nif_haptic, .flags = 0 },
     .{ .name = "clipboard_put", .arity = 1, .fptr = nif_clipboard_put, .flags = 0 },
     .{ .name = "clipboard_get", .arity = 0, .fptr = nif_clipboard_get, .flags = 0 },
+    .{ .name = "tts_speak", .arity = 2, .fptr = nif_tts_speak, .flags = 0 },
+    .{ .name = "tts_stop", .arity = 0, .fptr = nif_tts_stop, .flags = 0 },
     .{ .name = "share_text", .arity = 1, .fptr = nif_share_text, .flags = 0 },
     .{ .name = "open_url", .arity = 1, .fptr = nif_open_url, .flags = 0 },
     .{ .name = "request_permission", .arity = 1, .fptr = nif_request_permission, .flags = 0 },

--- a/decisions/2026-05-27-tts-mob-speech.md
+++ b/decisions/2026-05-27-tts-mob-speech.md
@@ -1,0 +1,49 @@
+# Text-to-speech ships as a core NIF (Mob.Speech), not a plugin
+
+- Date: 2026-05-27
+- Status: accepted
+
+## Context
+
+Apps (e.g. an offline docs reader) want to read text aloud. iOS and Android
+both ship a system TTS engine (`AVSpeechSynthesizer` / `TextToSpeech`), but mob
+had no wrapper. The plugin system that will eventually host optional native
+capabilities is still phase-0 (design docs + stubs), so there's no in-lane way
+to ship TTS as a plugin yet.
+
+## Decision
+
+Add `Mob.Speech` as a **core capability NIF**, mirroring the existing
+`Mob.Camera` / `Mob.Clipboard` / `Mob.Audio` pattern:
+
+- `Mob.Speech.speak/3` + `stop_speaking/1` — socket-threading like `Mob.Haptic`;
+  options (`rate`/`pitch`/`voice`) whitelisted and `:json.encode`d.
+- NIFs `tts_speak/2` + `tts_stop/0` (`src/mob_nif.erl`), implemented in
+  `ios/mob_nif.m` (AVSpeechSynthesizer, lazy persistent synth) and
+  `android/jni/mob_nif.zig` → `MobBridge.ttsSpeak` (generated Kotlin in mob_new).
+
+Notable sub-decisions:
+
+- **Android bridge methods are `cacheOptional`, not `cacheRequired`.** Apps
+  generated before TTS lack `ttsSpeak`/`ttsStop` in their `MobBridge.kt`; a
+  required cache lookup would fail `on_load` and purge the *entire* NIF library.
+  Optional caching + a `Bridge.tts_* == null` guard means those apps simply
+  no-op TTS until regenerated, rather than breaking.
+- **`TextToSpeech` initializes asynchronously** (an `OnInitListener`), so the
+  Kotlin keeps one engine alive and queues the first utterance until `onInit`.
+- **`rate`/`pitch` are platform-scaled, not normalized.** iOS `rate` is 0–1,
+  Android `setSpeechRate` centers on 1.0 (~0.5–2.0). Documented as
+  "platform-scaled"; a normalization layer can come later if needed.
+- STT is **not** included — deferred (still a plugin candidate; see the surface
+  matrix).
+
+## Consequences
+
+- One blessed `Mob.Speech` API; TTS now shows ✅ in the capability matrix.
+- New native capabilities follow this full path: Elixir module + `mob_nif.erl`
+  (export/`-nifs`/clause, covered by `nif_stub_test`) + `ios/mob_nif.m` (+ funcs
+  table) + `android/jni/mob_nif.zig` (struct field + impl + `cacheOptional` +
+  funcs table) + a `MobBridge.kt.eex` method in mob_new.
+- Device-verified end-to-end on both platforms before merge (Android audible,
+  iOS screen + AVSpeechSynthesizer path). When the plugin system lands, TTS
+  could migrate out of core — revisit then.

--- a/guides/mobile_surface_matrix.md
+++ b/guides/mobile_surface_matrix.md
@@ -125,6 +125,7 @@ and orthogonal — composition over a fat component library.
 | Photo library picker | ✅ | ✓ | ✓ | `Mob.Photos.pick/2` |
 | Audio recording | ✅ | ✓ | ✓ | `Mob.Audio.start_recording/2` |
 | Audio playback | ✅ | ✓ | ✓ | `Mob.Audio.play/3`, stop, volume |
+| Text-to-speech | ✅ | ✓ | ✓ | `Mob.Speech.speak/3` + `stop_speaking/1` (AVSpeechSynthesizer / TextToSpeech) |
 | Speech recognition | ❌ | — | — | Plugin candidate (SFSpeechRecognizer / SpeechRecognizer) |
 | Voice activity detection | ❌ | — | — | Plugin candidate |
 | Audio effects (reverb, EQ) | ❌ | — | — | Plugin candidate |

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -1957,6 +1957,64 @@ static ERL_NIF_TERM nif_clipboard_get(ErlNifEnv *env, int argc, const ERL_NIF_TE
     return enif_make_atom(env, "empty");
 }
 
+// ── NIF: tts_speak/2 ──────────────────────────────────────────────────────────
+// Speaks UTF-8 text via AVSpeechSynthesizer. opts is a JSON object, all keys
+// optional: {"rate": float, "pitch": float, "voice": "en-US"}. Fire-and-forget;
+// a synthesizer is created lazily and kept alive so utterances can queue.
+
+static AVSpeechSynthesizer *g_tts_synth = nil;
+
+static ERL_NIF_TERM nif_tts_speak(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    ErlNifBinary text_bin, opts_bin;
+    if (!enif_inspect_binary(env, argv[0], &text_bin) &&
+        !enif_inspect_iolist_as_binary(env, argv[0], &text_bin))
+        return enif_make_badarg(env);
+    if (!enif_inspect_binary(env, argv[1], &opts_bin) &&
+        !enif_inspect_iolist_as_binary(env, argv[1], &opts_bin))
+        return enif_make_badarg(env);
+
+    NSString *text = [[NSString alloc] initWithBytes:text_bin.data
+                                              length:text_bin.size
+                                            encoding:NSUTF8StringEncoding];
+    NSData *optsData = [NSData dataWithBytes:opts_bin.data length:opts_bin.size];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (!g_tts_synth)
+          g_tts_synth = [[AVSpeechSynthesizer alloc] init];
+
+      AVSpeechUtterance *utt = [AVSpeechUtterance speechUtteranceWithString:text];
+
+      NSDictionary *opts = [NSJSONSerialization JSONObjectWithData:optsData options:0 error:nil];
+      if ([opts isKindOfClass:[NSDictionary class]]) {
+          NSNumber *rate = opts[@"rate"];
+          if ([rate isKindOfClass:[NSNumber class]])
+              utt.rate = [rate floatValue];
+          NSNumber *pitch = opts[@"pitch"];
+          if ([pitch isKindOfClass:[NSNumber class]])
+              utt.pitchMultiplier = [pitch floatValue];
+          NSString *voice = opts[@"voice"];
+          if ([voice isKindOfClass:[NSString class]]) {
+              AVSpeechSynthesisVoice *v = [AVSpeechSynthesisVoice voiceWithLanguage:voice];
+              if (v)
+                  utt.voice = v;
+          }
+      }
+
+      [g_tts_synth speakUtterance:utt];
+    });
+    return enif_make_atom(env, "ok");
+}
+
+// ── NIF: tts_stop/0 ───────────────────────────────────────────────────────────
+// Stops any in-progress speech immediately. Fire-and-forget.
+
+static ERL_NIF_TERM nif_tts_stop(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [g_tts_synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+    });
+    return enif_make_atom(env, "ok");
+}
+
 // ── NIF: open_url/1 ───────────────────────────────────────────────────────────
 // Hands a URL to the OS to open in the user's default browser/app.
 // Fire-and-forget; returns :ok immediately.
@@ -6602,6 +6660,8 @@ static ErlNifFunc nif_funcs[] = {
     {"audio_play_at", 3, nif_audio_play_at, 0},
     {"audio_stop_playback", 0, nif_audio_stop_playback, 0},
     {"audio_set_volume", 1, nif_audio_set_volume, 0},
+    {"tts_speak", 2, nif_tts_speak, 0},
+    {"tts_stop", 0, nif_tts_stop, 0},
     {"motion_start", 2, nif_motion_start, 0},
     {"motion_stop", 0, nif_motion_stop, 0},
     {"scanner_scan", 1, nif_scanner_scan, 0},

--- a/lib/mob/speech.ex
+++ b/lib/mob/speech.ex
@@ -1,0 +1,59 @@
+defmodule Mob.Speech do
+  @moduledoc """
+  Text-to-speech. No permission required on either platform.
+
+  ## Usage
+
+      def handle_event("read_aloud", _params, socket) do
+        Mob.Speech.speak(socket, socket.assigns.article_text)
+        {:noreply, socket}
+      end
+
+  Stop mid-utterance:
+
+      Mob.Speech.stop_speaking(socket)
+
+  ## Options
+
+  | Option   | Type    | Meaning                                  | Default |
+  |----------|---------|------------------------------------------|---------|
+  | `:rate`  | float   | Speech rate (0.0–1.0, platform-scaled)   | system  |
+  | `:pitch` | float   | Pitch multiplier (0.5–2.0)               | 1.0     |
+  | `:voice` | binary  | BCP-47 language/voice id (e.g. `"en-US"`)| system  |
+
+  Calling `speak/3` while speech is in progress enqueues the new utterance.
+  iOS uses `AVSpeechSynthesizer`; Android uses `TextToSpeech`.
+  """
+
+  @opt_keys [:rate, :pitch, :voice]
+
+  @doc """
+  Speak `text` aloud. Fire-and-forget; returns the socket unchanged so it can be
+  used inline without disrupting a `handle_event`/`handle_info` return value.
+
+      Mob.Speech.speak(socket, "Returns a list.", rate: 0.5)
+  """
+  @spec speak(Mob.Socket.t(), binary(), keyword()) :: Mob.Socket.t()
+  def speak(socket, text, opts \\ []) when is_binary(text) and is_list(opts) do
+    :mob_nif.tts_speak(text, :json.encode(speak_opts(opts)))
+    socket
+  end
+
+  @doc "Stop any in-progress speech immediately. Returns the socket."
+  @spec stop_speaking(Mob.Socket.t()) :: Mob.Socket.t()
+  def stop_speaking(socket) do
+    :mob_nif.tts_stop()
+    socket
+  end
+
+  @doc false
+  # Whitelist + stringify known options into a JSON-encodable map. Unknown keys
+  # are dropped so a typo can't reach the native layer as a surprise option.
+  # Public-but-undocumented so the encoding can be unit-tested without the NIF.
+  @spec speak_opts(keyword()) :: %{optional(String.t()) => term()}
+  def speak_opts(opts) do
+    opts
+    |> Keyword.take(@opt_keys)
+    |> Map.new(fn {k, v} -> {Atom.to_string(k), v} end)
+  end
+end

--- a/src/mob_nif.erl
+++ b/src/mob_nif.erl
@@ -45,6 +45,9 @@
     audio_play_at/3,
     audio_stop_playback/0,
     audio_set_volume/1,
+    %% Text-to-speech (no permission required)
+    tts_speak/2,
+    tts_stop/0,
     %% Motion sensors
     motion_start/2,
     motion_stop/0,
@@ -165,6 +168,8 @@
     audio_play_at/3,
     audio_stop_playback/0,
     audio_set_volume/1,
+    tts_speak/2,
+    tts_stop/0,
     motion_start/2,
     motion_stop/0,
     scanner_scan/1,
@@ -290,6 +295,8 @@ audio_play(_Path, _OptsJson) -> erlang:nif_error(not_loaded).
 audio_play_at(_Path, _OptsJson, _AtWallMs) -> erlang:nif_error(not_loaded).
 audio_stop_playback() -> erlang:nif_error(not_loaded).
 audio_set_volume(_Volume) -> erlang:nif_error(not_loaded).
+tts_speak(_Text, _OptsJson) -> erlang:nif_error(not_loaded).
+tts_stop() -> erlang:nif_error(not_loaded).
 motion_start(_Sensors, _Interval) -> erlang:nif_error(not_loaded).
 motion_stop() -> erlang:nif_error(not_loaded).
 scanner_scan(_FormatsJson) -> erlang:nif_error(not_loaded).

--- a/test/mob/speech_test.exs
+++ b/test/mob/speech_test.exs
@@ -1,0 +1,25 @@
+defmodule Mob.SpeechTest do
+  use ExUnit.Case, async: true
+
+  # The speak/3 and stop_speaking/1 paths call into mob_nif, which isn't loaded
+  # on the host (same as Mob.Haptic / Mob.Clipboard — untested for that reason).
+  # The testable logic is the option whitelisting/encoding feeding the NIF.
+
+  test "speak_opts whitelists known keys and stringifies them" do
+    assert Mob.Speech.speak_opts(rate: 0.5, pitch: 1.2, voice: "en-US") ==
+             %{"rate" => 0.5, "pitch" => 1.2, "voice" => "en-US"}
+  end
+
+  test "speak_opts drops unknown options so typos can't reach the native layer" do
+    assert Mob.Speech.speak_opts(rate: 0.5, bogus: 1, foo: :bar) == %{"rate" => 0.5}
+  end
+
+  test "speak_opts on an empty list JSON-encodes to an empty object" do
+    assert Mob.Speech.speak_opts([]) == %{}
+    assert IO.iodata_to_binary(:json.encode(Mob.Speech.speak_opts([]))) == "{}"
+  end
+
+  test "speak/3 requires binary text" do
+    assert_raise FunctionClauseError, fn -> Mob.Speech.speak(%{}, :not_a_binary) end
+  end
+end


### PR DESCRIPTION
## Summary
- New `Mob.Speech.speak/3` + `stop_speaking/1` — socket-threading like `Mob.Haptic`, options (`rate`/`pitch`/`voice`) whitelisted + `:json.encode`d.
- Native NIFs `tts_speak/2` + `tts_stop/0`:
  - **iOS** — `AVSpeechSynthesizer` (`ios/mob_nif.m`)
  - **Android** — `TextToSpeech` via `MobBridge.ttsSpeak` (`android/jni/mob_nif.zig`), cached with `cacheOptional` so apps generated before the bridge method don't fail `on_load`.
- The companion Kotlin bridge method (`ttsSpeak`/`ttsStop`) lands in **mob_new** (`MobBridge.kt.eex`) — separate PR.

## Test plan
- [x] `mix test` (incl. 4 new `Mob.SpeechTest` + `nif_stub_test` contract) — 0 failures
- [x] `mix format` / `mix credo --strict` / `mix erlfmt --check src/` / `clang-format` clean
- [x] **Device-verified end-to-end, both platforms:** Android (Zig compiled, audible speech), iOS (ObjC compiled, screen reflects spoken text via `AVSpeechSynthesizer`) — using a generated throwaway app reading a text file and speaking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)