### PR TITLE
fix(ios): deliver canvas finger-drag (on_drag) — parity with Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **iOS canvas now delivers finger-drag (`on_drag`) — at parity with Android.**
+  The SwiftUI `MobCanvasView` rendered draw ops but attached no drag recognizer,
+  so a canvas's `on_drag` handle (wired through the NIF to `node.onDrag`) was
+  never invoked — continuous finger-drag was dead on iOS, while Android's
+  `MobCanvas` had `detectDragGestures`. Added a canvas-scoped
+  `DragGesture(minimumDistance: 0)` that calls `node.onDrag` with
+  began/dragging/ended phases; the gesture's local-space location is already in
+  canvas logical units (the frame is sized to the declared width/height), so no
+  rescale is needed. Verified on a physical iPhone (iOS 26.5): a finger-drawing
+  screen with a color picker and thickness control routes drags and renders
+  strokes correctly.
+
+---
+
 ## [0.7.4] - 2026-06-20
 
 ### Fixed

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -645,12 +645,25 @@ private struct MobCanvasView: View {
         // units (points), and draw ops are drawn in that same space, so the
         // gesture's local-space location is already in canvas coordinates — no
         // pixel→logical rescale needed (unlike Android, where it is).
+        //
+        // minimumDistance: 0 is intentional: a finger-drawing canvas wants an
+        // immediate response and a stationary tap to register as a single point
+        // (a dot). This is a deliberate divergence from Android's
+        // detectDragGestures, which has a touch-slop threshold, so a bare tap
+        // fires a zero-length began/ended drag on iOS but nothing on Android.
         if node.onDrag != nil {
             canvas.gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        let phase = dragging ? "dragging" : "began"
-                        dragging = true
+                        // Flip the @State flag only once, on the first sample, so
+                        // a fast drag does not invalidate the view on every move.
+                        let phase: String
+                        if dragging {
+                            phase = "dragging"
+                        } else {
+                            dragging = true
+                            phase = "began"
+                        }
                         node.onDrag?(
                             value.translation.width, value.translation.height,
                             value.location.x, value.location.y, phase

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -623,8 +623,12 @@ private func boxAlignmentFromString(_ s: String) -> Alignment {
 private struct MobCanvasView: View {
     let node: MobNode
 
+    // Tracks whether the active drag has emitted its "began" sample yet, so the
+    // first onChanged reports phase "began" and the rest "dragging".
+    @State private var dragging = false
+
     var body: some View {
-        Canvas { ctx, size in
+        let canvas = Canvas { ctx, size in
             let ops = node.canvasOps as? [[String: Any]] ?? []
             for op in ops {
                 drawOp(op, in: &ctx, size: size)
@@ -634,6 +638,35 @@ private struct MobCanvasView: View {
             width: node.canvasWidth > 0 ? CGFloat(node.canvasWidth) : nil,
             height: node.canvasHeight > 0 ? CGFloat(node.canvasHeight) : nil
         )
+
+        // Finger-drag input: when the node registered an on_drag handle, attach a
+        // continuous drag recognizer (the iOS analog of Android MobCanvas's
+        // detectDragGestures). The Canvas frame is sized to the declared logical
+        // units (points), and draw ops are drawn in that same space, so the
+        // gesture's local-space location is already in canvas coordinates — no
+        // pixel→logical rescale needed (unlike Android, where it is).
+        if node.onDrag != nil {
+            canvas.gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let phase = dragging ? "dragging" : "began"
+                        dragging = true
+                        node.onDrag?(
+                            value.translation.width, value.translation.height,
+                            value.location.x, value.location.y, phase
+                        )
+                    }
+                    .onEnded { value in
+                        dragging = false
+                        node.onDrag?(
+                            value.translation.width, value.translation.height,
+                            value.location.x, value.location.y, "ended"
+                        )
+                    }
+            )
+        } else {
+            canvas
+        }
     }
 
     private func drawOp(_ op: [String: Any], in ctx: inout GraphicsContext, size: CGSize) {

--- a/test/mob/renderer_test.exs
+++ b/test/mob/renderer_test.exs
@@ -176,6 +176,22 @@ defmodule Mob.RendererTest do
       assert is_integer(decoded["props"]["on_tap"])
     end
 
+    test "on_drag {pid, tag} is replaced by integer handle" do
+      pid = self()
+      tree = %{type: :canvas, props: %{on_drag: {pid, :draw}}, children: []}
+      Renderer.render(tree, :ios, MockNIF)
+      {:set_root, [json]} = Enum.find(MockNIF.calls(), fn {f, _} -> f == :set_root end)
+      decoded = :json.decode(json)
+      assert is_integer(decoded["props"]["on_drag"])
+    end
+
+    test "register_tap is called for an on_drag handle" do
+      pid = self()
+      tree = %{type: :canvas, props: %{on_drag: {pid, :draw}}, children: []}
+      Renderer.render(tree, :ios, MockNIF)
+      assert Enum.any?(MockNIF.calls(), fn {f, _} -> f == :register_tap end)
+    end
+
     test "on_change {pid, tag} is replaced by integer handle" do
       pid = self()
       tree = %{type: :text_field, props: %{value: "hi", on_change: {pid, :name}}, children: []}


### PR DESCRIPTION
## Problem

On iOS, a `Canvas`'s `on_drag` handle did nothing. The NIF wires `props["on_drag"]`
to `node.onDrag` (`mob_nif.m`), but the SwiftUI `MobCanvasView` rendered the draw
ops and attached **no drag recognizer**, so `node.onDrag` was never invoked. The
only gesture wiring (`mobGestures`) covers long-press / double-tap / swipe — not
continuous drag. Net result: **finger-drawing worked on Android (`MobCanvas` had
`detectDragGestures`) but was dead on iOS.**

This surfaced building a finger-drawing screen: drags onto the canvas produced
nothing on iOS.

## Fix

Add a canvas-scoped `DragGesture(minimumDistance: 0)` to `MobCanvasView` that
calls `node.onDrag(dx, dy, x, y, phase)` with `began` / `dragging` / `ended`
phases (a `@State` flag distinguishes the first sample). The Canvas frame is
sized to the declared logical units (`canvasWidth`/`canvasHeight`) and draw ops
are drawn in that same space, so the gesture's `.local` location is already in
canvas coordinates — **no pixel→logical rescale** is needed (unlike Android,
where Compose hands back pixels). Only attached when `node.onDrag != nil`, so
non-interactive canvases are unaffected.

## Verification

Verified on a **physical iPhone (iOS 26.5)** via a Sloppy Joe finger-drawing
screen — a canvas plus a **color picker** and **thickness** control:
- real-finger drags route through `node.onDrag` → `mob_send_drag` →
  `{:drag, tag, %{x, y, dx, dy, phase}}` and render strokes live;
- per-stroke color and width are preserved;
- taps on the color/thickness buttons and drags on the canvas coexist.

Pairs with the Android side, which already had this via `detectDragGestures`.

## Docs

`CHANGELOG.md` `[Unreleased] → Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)