### PR TITLE
Add Mob.Device.open_settings/1 — open OS settings from a screen

### DIFF
--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -243,6 +243,7 @@ pub const BridgeMethods = extern struct {
     tts_stop: jni.JMethodID = null,
     share_text: jni.JMethodID = null,
     open_url: jni.JMethodID = null,
+    open_settings: jni.JMethodID = null,
     request_permission: jni.JMethodID = null,
     alert_show: jni.JMethodID = null,
     action_sheet_show: jni.JMethodID = null,
@@ -2077,6 +2078,29 @@ export fn nif_open_url(
     return erts.ok(env);
 }
 
+// nif_open_settings/1 — open an OS settings screen. target is "app" |
+// "notifications" | "exact_alarm" (the Kotlin side maps it to the Intent).
+// Cached optionally, so an app whose scaffolded MobBridge.kt predates
+// openSettings just no-ops instead of crashing.
+export fn nif_open_settings(
+    env: ?*erts.ErlNifEnv,
+    argc: c_int,
+    argv: [*]const erts.ERL_NIF_TERM,
+) callconv(.c) erts.ERL_NIF_TERM {
+    _ = argc;
+    const bin = getBinOrIolist(env, argv[0]) orelse return erts.badarg(env);
+    const target = binToCString(bin) orelse return erts.atom(env, "error");
+    defer freeCString(target);
+    if (Bridge.open_settings == null) return erts.ok(env);
+    var attached: c_int = 0;
+    const jenv = get_jenv(&attached) orelse return erts.atom(env, "error");
+    const jtarget = jni.newStringUTF(jenv, target);
+    jenv.*.CallStaticVoidMethod.?(jenv, Bridge.cls, Bridge.open_settings, jtarget);
+    jni.deleteLocalRef(jenv, jtarget);
+    detachIfAttached(attached);
+    return erts.ok(env);
+}
+
 // nif_share_text/1 — system share sheet (Intent ACTION_SEND text/plain).
 export fn nif_share_text(
     env: ?*erts.ErlNifEnv,
@@ -3338,6 +3362,7 @@ fn nifLoad(env: ?*erts.ErlNifEnv, priv: *?*anyopaque, info: erts.ERL_NIF_TERM) c
     cacheOptional(jenv, "ttsStop", "()V", &Bridge.tts_stop);
     if (!cacheRequired(jenv, "shareText", "(Ljava/lang/String;)V", &Bridge.share_text)) return -1;
     if (!cacheRequired(jenv, "openUrl", "(Ljava/lang/String;)V", &Bridge.open_url)) return -1;
+    cacheOptional(jenv, "openSettings", "(Ljava/lang/String;)V", &Bridge.open_settings);
 
     // Async device-capability methods. Most take (J, String) where J is
     // the pid as a long.
@@ -3463,6 +3488,7 @@ const nif_funcs = [_]erts.ErlNifFunc{
     .{ .name = "tts_stop", .arity = 0, .fptr = nif_tts_stop, .flags = 0 },
     .{ .name = "share_text", .arity = 1, .fptr = nif_share_text, .flags = 0 },
     .{ .name = "open_url", .arity = 1, .fptr = nif_open_url, .flags = 0 },
+    .{ .name = "open_settings", .arity = 1, .fptr = nif_open_settings, .flags = 0 },
     .{ .name = "request_permission", .arity = 1, .fptr = nif_request_permission, .flags = 0 },
     .{ .name = "files_pick", .arity = 1, .fptr = nif_files_pick, .flags = 0 },
     .{ .name = "audio_start_recording", .arity = 1, .fptr = nif_audio_start_recording, .flags = 0 },

--- a/decisions/2026-06-25-open-settings.md
+++ b/decisions/2026-06-25-open-settings.md
@@ -1,0 +1,41 @@
+# Mob.Device.open_settings/1 — open OS settings (cacheOptional, not cacheRequired)
+
+- Date: 2026-06-25
+- Status: accepted
+
+## Context
+
+Screens could hand a URI to the OS (`Mob.Device.open_url/1`) but could not
+deep-link into OS **settings screens**, which are Intent actions, not URIs.
+Needed for (a) recovering from a *permanently* denied runtime permission (send
+the user to the app's settings page) and (b) special-access permissions like
+`SCHEDULE_EXACT_ALARM`, whose only grant path is a system settings screen.
+
+## Decision
+
+Add `Mob.Device.open_settings(target \\ :app)` where `target` is `:app`,
+`:notifications`, or `:exact_alarm`, mirroring the `open_url` NIF path across all
+layers (Elixir, `src/mob_nif.erl` export/nifs/stub, `android/jni/mob_nif.zig`
+struct + nif + native nif-table + cache, `ios/mob_nif.m` nif + table). Invalid
+targets return `{:error, :invalid}` (no NIF call), matching `lock_orientation/1`.
+
+The Android Kotlin bridge method (`MobBridge.openSettings(String)`) is cached
+with **`cacheOptional`, not `cacheRequired`**, and `nif_open_settings`
+null-guards `Bridge.open_settings`. Reason: the Kotlin `MobBridge` is app-owned
+(scaffolded from the `mob_new` template) and drifts — a `cacheRequired` entry for
+a method a stale `MobBridge.kt` lacks would fail `nif_load`, which makes the
+**entire `mob_nif` module `undef` at boot** (the 0.7.6 regression class, fixed in
+0.7.7). `cacheOptional` + the null guard degrade to a silent no-op instead.
+
+iOS exposes only the single app settings page (`UIApplicationOpenSettingsURLString`),
+so `target` is validated but otherwise ignored there.
+
+## Consequences
+
+- The Kotlin `openSettings` method must be added to the `mob_new` template and
+  scaffolded into apps. Until an app refreshes its `MobBridge.kt`,
+  `open_settings/1` is a silent no-op on Android (by design, never a crash).
+- `nif_stub_test` guards the erl export/nifs/stub agreement automatically; the
+  native nif-table entry is verified by booting on a device (host `mix test`
+  cannot catch a native-table mismatch).
+- Consumers need mob at or above the release that carries this (target 0.7.8).

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -2043,6 +2043,25 @@ static ERL_NIF_TERM nif_open_url(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     return enif_make_atom(env, "ok");
 }
 
+// ── NIF: open_settings/1 ──────────────────────────────────────────────────────
+// Opens this app's settings page. The target arg (app|notifications|exact_alarm)
+// is honored on Android; iOS exposes only the single app settings page, so the
+// target is validated but otherwise ignored. Fire-and-forget; returns :ok.
+
+static ERL_NIF_TERM nif_open_settings(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    ErlNifBinary bin;
+    if (!enif_inspect_binary(env, argv[0], &bin) &&
+        !enif_inspect_iolist_as_binary(env, argv[0], &bin))
+        return enif_make_badarg(env);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      NSURL *url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+      if (url)
+          [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+    });
+    return enif_make_atom(env, "ok");
+}
+
 // ── NIF: share_text/1 ─────────────────────────────────────────────────────────
 // Opens the iOS share sheet with plain text. Fire-and-forget.
 
@@ -5954,6 +5973,7 @@ static ErlNifFunc nif_funcs[] = {
     {"clipboard_get", 0, nif_clipboard_get, 0},
     {"share_text", 1, nif_share_text, 0},
     {"open_url", 1, nif_open_url, 0},
+    {"open_settings", 1, nif_open_settings, 0},
     {"request_permission", 1, nif_request_permission, 0},
     {"files_pick", 1, nif_files_pick, 0},
     {"audio_start_recording", 1, nif_audio_start_recording, 0},

--- a/lib/mob/device.ex
+++ b/lib/mob/device.ex
@@ -218,6 +218,34 @@ defmodule Mob.Device do
     :ok
   end
 
+  @doc """
+  Opens an OS settings screen for this app.
+
+  `target` is one of:
+
+    * `:app` — the app's details / permissions page (both platforms). The
+      go-to when a runtime permission was *permanently* denied and the user
+      must re-enable it by hand.
+    * `:notifications` — the app's notification settings (Android). iOS has no
+      granular deep-link, so it opens the app page.
+    * `:exact_alarm` — the "Alarms & reminders" special-access screen
+      (Android 12+). iOS opens the app page.
+
+  iOS exposes only the single app settings page, so `target` is honored on
+  Android and falls back to the app page on iOS. Fire-and-forget: a valid target
+  returns `:ok` immediately (an unavailable screen is a no-op, not a raise); an
+  unknown target returns `{:error, :invalid}` without touching the NIF.
+  """
+  @spec open_settings(:app | :notifications | :exact_alarm) :: :ok | {:error, :invalid}
+  def open_settings(target \\ :app)
+
+  def open_settings(target) when target in [:app, :notifications, :exact_alarm] do
+    :mob_nif.open_settings(Atom.to_string(target))
+    :ok
+  end
+
+  def open_settings(_target), do: {:error, :invalid}
+
   # ── GenServer ─────────────────────────────────────────────────────────────
 
   @impl true

--- a/src/mob_nif.erl
+++ b/src/mob_nif.erl
@@ -18,6 +18,7 @@
     clipboard_get/0,
     share_text/1,
     open_url/1,
+    open_settings/1,
     %% Permissions
     request_permission/1,
     %% Biometric
@@ -139,6 +140,7 @@
     clipboard_get/0,
     share_text/1,
     open_url/1,
+    open_settings/1,
     request_permission/1,
     files_pick/1,
     audio_start_recording/1,
@@ -256,6 +258,7 @@ clipboard_put(_Text) -> erlang:nif_error(not_loaded).
 clipboard_get() -> erlang:nif_error(not_loaded).
 share_text(_Text) -> erlang:nif_error(not_loaded).
 open_url(_Url) -> erlang:nif_error(not_loaded).
+open_settings(_Target) -> erlang:nif_error(not_loaded).
 request_permission(_Cap) -> erlang:nif_error(not_loaded).
 files_pick(_MimeTypes) -> erlang:nif_error(not_loaded).
 audio_start_recording(_OptsJson) -> erlang:nif_error(not_loaded).

--- a/test/mob/device_test.exs
+++ b/test/mob/device_test.exs
@@ -101,6 +101,16 @@ defmodule Mob.DeviceTest do
     end
   end
 
+  describe "open_settings/1" do
+    test "rejects an unknown target before touching the NIF" do
+      # Unknown targets short-circuit to {:error, :invalid} (no clause matches the
+      # guard), so this is safe to assert on the host without a loaded NIF.
+      assert Device.open_settings(:bogus) == {:error, :invalid}
+      assert Device.open_settings("app") == {:error, :invalid}
+      assert Device.open_settings(nil) == {:error, :invalid}
+    end
+  end
+
   describe "subscription fan-out" do
     test "subscriber receives events for its categories", %{dispatcher: d} do
       :ok = GenServer.call(d, {:subscribe, self(), [:app]})


### PR DESCRIPTION
Adds `Mob.Device.open_settings(target)` so a screen can deep-link into OS settings
(Intent actions, not URIs that `open_url/1` handles). Motivated by recovering from
a *permanently* denied runtime permission and by special-access perms like
`SCHEDULE_EXACT_ALARM`.

`target` is `:app` | `:notifications` | `:exact_alarm`; invalid → `{:error, :invalid}`
(like `lock_orientation/1`). Mirrors the `open_url` NIF path across `lib/mob/device.ex`,
`src/mob_nif.erl` (export/nifs/stub), `android/jni/mob_nif.zig`, `ios/mob_nif.m`.

**Key choice:** the Android Kotlin `openSettings` method is cached with
`cacheOptional`, not `cacheRequired`, and `nif_open_settings` null-guards the bridge
method. The Kotlin `MobBridge` is app-owned/scaffolded and drifts; a `cacheRequired`
entry a stale `MobBridge.kt` lacks would fail `nif_load` and make the whole module
undef at boot (the 0.7.6 regression class). `cacheOptional` degrades to a no-op.
See `decisions/2026-06-25-open-settings.md`.

iOS exposes only the app settings page, so `target` is ignored there.

Pairs with `GenericJam/mob_new` PR (the Kotlin `openSettings` template). Both ship
together; target release **0.7.8**.

## Status
Host checks green: 939 tests (incl. `nif_stub_test` agreement + a `device_test` for
the invalid-target path), `mix format`, `credo --strict`, `erlfmt`, `clang-format`,
`zig fmt`, `compile --warnings-as-errors`. **Device verification of the native path
is pending** (the test device is currently detached) — not yet exercised on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
