### PR TITLE
MOB-5: ~MOB @foo raises a clear error when assigns is not in scope

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -45,7 +45,7 @@ The sigil borrows three authoring idioms from Phoenix HEEx, so screens read the 
 
 ### `@assigns` shorthand
 
-Inside any `{...}` expression, `@foo` rewrites to `assigns.foo` (this happens at compile time). It works in attribute values, `{expr}` children, and the `:if`/`:for` directives below. Nested access like `@user.name` works too.
+Inside a `{...}` expression, `@foo` rewrites to `assigns.foo` at compile time. It works in attribute values, `{expr}` children, and the `:if`/`:for` directives below. Nested access like `@user.name` works too.
 
 ```elixir
 def render(assigns) do
@@ -59,6 +59,18 @@ end
 ```
 
 `@title` is exactly `assigns.title` — the two forms are interchangeable, so reach for whichever reads better.
+
+> **`@foo` only works where `assigns` is in scope** — that is, a screen's or component's `render(assigns)`. Reusable helper functions (the [function composites](#pure-elixir-composite-components) below) take **positional arguments**, and there is no `assigns` inside them, so interpolate the argument directly:
+>
+> ```elixir
+> # Screen render — assigns is in scope:
+> def render(assigns), do: ~MOB(<Text text={@title} />)
+>
+> # Helper — NO @; use the argument:
+> def label(title), do: ~MOB(<Text text={title} />)   # not @title
+> ```
+>
+> Reaching for `@foo` inside a helper is the most common mistake here. It raises a `CompileError` naming the fix (`{title}` instead of `@title`) rather than a cryptic "undefined variable assigns". If your `render` parameter is named something other than `assigns` (e.g. `socket`), `@foo` won't find it either — name it `assigns`.
 
 ### `:if` — conditional rendering
 

--- a/lib/mob/sigil.ex
+++ b/lib/mob/sigil.ex
@@ -38,6 +38,19 @@ defmodule Mob.Sigil do
 
       ~MOB(<Text text={@title} />)   # same as text={assigns.title}
 
+  `@foo` only works where a variable named `assigns` is in scope — i.e. a
+  screen's or component's `render(assigns)`. Reusable helper functions take
+  positional arguments instead, so use the argument directly there:
+
+      # Screen render — assigns is in scope, @ works:
+      def render(assigns), do: ~MOB(<Text text={@title} />)
+
+      # Helper — no assigns; interpolate the argument, don't use @:
+      def label(title), do: ~MOB(<Text text={title} />)
+
+  Using `@foo` where no `assigns` exists raises a `CompileError` naming the
+  fix, rather than a cryptic "undefined variable assigns".
+
   ## Control attributes — `:if` and `:for`
 
   Two LiveView-style directives wrap an element without extra ceremony.
@@ -393,15 +406,34 @@ defmodule Mob.Sigil do
     expr_str
     |> String.trim()
     |> Code.string_to_quoted!(file: caller.file, line: caller.line)
-    |> expand_assigns()
+    |> expand_assigns(caller)
   end
 
   # Rewrite every `@name` (the unary `@` operator on a bare identifier) to
   # `assigns.name`, mirroring HEEx. Nested forms like `@user.name` rewrite
   # too, since prewalk reaches the inner `@user` node first.
-  defp expand_assigns(ast) do
+  #
+  # `@foo` only makes sense where a variable named `assigns` is in scope — a
+  # screen/component `render(assigns)`. In an ordinary helper (positional args,
+  # the idiomatic composite pattern) there is no `assigns`, and a bare rewrite
+  # would compile to a cryptic "undefined variable assigns". So before
+  # rewriting, verify `assigns` is bound in the caller (same guard Phoenix's
+  # `~H` uses) and raise a message that names the fix. Only `@`-using templates
+  # trigger this — a static `~MOB(<Text text="hi"/>)` needs no assigns.
+  defp expand_assigns(ast, caller) do
     Macro.prewalk(ast, fn
       {:@, _meta, [{name, _, ctx}]} when is_atom(name) and (is_atom(ctx) or is_nil(ctx)) ->
+        unless Macro.Env.has_var?(caller, {:assigns, nil}) do
+          raise CompileError,
+            file: caller.file,
+            line: caller.line,
+            description:
+              "~MOB: @#{name} requires a variable named \"assigns\" in scope " <>
+                "(e.g. inside `render(assigns)`). In a helper function, take the " <>
+                "value as an argument and interpolate it directly — `{#{name}}` " <>
+                "instead of `@#{name}`."
+        end
+
         # Build `assigns.name` with a nil-context `assigns` var so it
         # resolves to the caller's binding (same as a literal `assigns`
         # parsed from source), not a hygienic Mob.Sigil-scoped variable.

--- a/test/mob/sigil_test.exs
+++ b/test/mob/sigil_test.exs
@@ -299,6 +299,48 @@ defmodule Mob.SigilTest do
     end
   end
 
+  # ── @assign guard: assigns must be in scope ───────────────────────────────────
+
+  describe "@assign guard" do
+    test "@foo with no assigns in scope raises a CompileError naming the fix" do
+      err =
+        assert_raise CompileError, fn ->
+          Code.compile_string(~S[import Mob.Sigil; ~MOB(<Text text={@title} />)])
+        end
+
+      msg = Exception.message(err)
+      assert msg =~ ~s(requires a variable named "assigns")
+      # The message points at the concrete fix: interpolate the argument.
+      assert msg =~ "{title}"
+    end
+
+    test ":if={@flag} with no assigns in scope also raises" do
+      assert_raise CompileError, ~r/requires a variable named "assigns"/, fn ->
+        Code.compile_string(~S[import Mob.Sigil; ~MOB(<Text text="x" :if={@flag} />)])
+      end
+    end
+
+    test "a static template (no @) compiles fine without assigns" do
+      # No @ ⇒ no guard ⇒ no assigns needed.
+      assert Code.compile_string(~S[import Mob.Sigil; ~MOB(<Text text="hi" />)]) == []
+    end
+
+    test "a helper using a positional arg (no @) needs no assigns" do
+      # The idiomatic composite pattern: interpolate the argument directly.
+      [{mod, _}] =
+        Code.compile_string(~S'''
+        defmodule Mob.SigilTest.GuardPositional do
+          import Mob.Sigil
+          def label(title), do: ~MOB(<Text text={title} />)
+        end
+        ''')
+
+      assert mod.label("Hi").props.text == "Hi"
+      :code.purge(mod)
+      :code.delete(mod)
+    end
+  end
+
   # ── :if control attribute ─────────────────────────────────────────────────────
 
   describe ":if directive" do


### PR DESCRIPTION
Fixes **MOB-5**. Follow-up to the 0.7.11 LiveView-ergonomics release.

## Problem

0.7.11 added `@foo` → `assigns.foo` sugar in `~MOB`. But the idiomatic way to factor mob UI — including the guide's own example — is **plain functions with positional args**:

```elixir
def card(title, children), do: ~MOB"<Text text={title} />"
```

There's no `assigns` in such a function. The moment a user follows the new "@assigns shorthand" docs and writes `@title` inside one, it expands to `assigns.title` → cryptic **"undefined variable assigns"**. (Same trap if a `render` param is named `socket` instead of `assigns`.) A user hit exactly this: a wave of "no assigns" errors, then "unused assigns" warnings while trying to bridge the two styles.

## What Phoenix does

`Phoenix.Component.sigil_H` guards with `Macro.Env.has_var?(__CALLER__, {:assigns, nil})` and raises *"~H requires a variable named assigns..."* — a clear compile error instead of a raw undefined-variable. mob's sigil has `__CALLER__` too, so it can do the same.

## Fix

- **`Mob.Sigil`:** before rewriting `@foo`, check `Macro.Env.has_var?(caller, {:assigns, nil})`. If `assigns` isn't bound, raise a `CompileError` naming the fix — *"`@title` requires a variable named `assigns` in scope … use `{title}` instead of `@title`."* Applies to attrs, `{expr}` children, and `:if`/`:for`. Only `@`-using templates trigger it; a static `~MOB(<Text text="hi"/>)` in a positional-arg helper still compiles (unlike `~H`, which always needs assigns).
- **Docs:** scope `@` to `render(assigns)`, steer composites to positional `{var}`, and add the common-mistake note (including "name the render param `assigns`").

## Tests
`@foo` with no assigns raises (asserts the message names `{title}`); `:if={@flag}` with no assigns raises; a static template compiles without assigns; a positional-arg helper (`{title}`) compiles + runs without assigns. Existing `@assign` tests (which bind `assigns` locally) stay green. Full suite: 964 pass; format + credo clean.

## Not included
No version bump — release timing is the maintainer's call (would be 0.7.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)