### PR TITLE
docs: worked component-authoring examples in components guide

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -442,61 +442,202 @@ def terminate(_reason, socket) do
 end
 ```
 
-## Pure-Elixir composite components
+## Defining your own components
 
 You can build reusable components out of the built-in widgets with no native
-code, in two forms.
+code, in two forms: **function composites** (a plain function you call) and
+**tag composites** (a custom `<Tag>` you register). Both are stateless, pure
+Elixir, and hot-pushable. Events raised from inside either kind route to the
+**screen's** `handle_info/2`, exactly like a built-in widget does.
 
-**Function composites** — a plain function returning a render tree, invoked
-through `{...}` interpolation in the sigil:
+### Function composites
+
+A function composite is a function that returns a render tree. You call it
+through `{...}` interpolation inside the sigil. This is the lightest way to
+factor out a chunk of UI you repeat.
+
+Here is a complete screen that defines a `stat_card/3` composite and uses it.
+The tap target is built in `render/1` and passed in as an argument, so the
+button inside the composite delivers to this screen's `handle_info/2`:
 
 ```elixir
-def card(title, children) do
-  ~MOB"""
-  <Column background={:surface_raised} corner_radius={12} padding={:space_md}>
-    <Text text={title} text_size={:lg} text_color={:on_surface} />
-    {children}
-  </Column>
-  """
-end
+defmodule MyApp.DashboardScreen do
+  use Mob.Screen
 
-def render(assigns) do
-  ~MOB"""
-  <Column>
-    {card("Settings", settings_rows(assigns))}
-  </Column>
-  """
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, Mob.Socket.assign(socket, :taps, 0)}
+  end
+
+  # A function composite: returns a render tree, so it drops into the screen
+  # via {...}. `on_tap` is a pre-built {pid, tag} tuple passed in by the caller.
+  defp stat_card(label, value, on_tap) do
+    ~MOB"""
+    <Box background={:surface_raised} corner_radius={:radius_md} padding={:space_md}>
+      <Column gap={4}>
+        <Text text={label} text_size={:sm} text_color={:muted} />
+        <Text text={to_string(value)} text_size={:2xl} text_color={:on_surface} />
+        <Button text="Tap me" on_tap={on_tap} />
+      </Column>
+    </Box>
+    """
+  end
+
+  @impl true
+  def render(assigns) do
+    bump = {self(), :bump}
+
+    ~MOB"""
+    <Column padding={:space_lg} gap={12}>
+      <Text text="Dashboard" text_size={:xl} text_color={:on_surface} />
+      {stat_card("Taps", @taps, bump)}
+    </Column>
+    """
+  end
+
+  @impl true
+  def handle_info({:tap, :bump}, socket) do
+    {:noreply, Mob.Socket.update(socket, :taps, &(&1 + 1))}
+  end
 end
 ```
 
-**Tag composites** — the same idea with tag syntax (`<DemoCard title="...">`).
-Register an *expander* for the tag atom, either through a plugin manifest's
-`ui_components` `expand:` entry:
+Two things to notice:
+
+- `@taps` inside `{stat_card(...)}` is `assigns.taps` (the `@` shorthand works
+  in any `{...}` expression, including a composite call).
+- The composite is a plain function call in `render/1`, which runs in the screen
+  process, so events from the `<Button>` inside it reach this screen. Building
+  the `{self(), :bump}` tuple in `render/1` and passing it in keeps the
+  composite reusable and follows the pre-compute-the-tuple convention.
+
+### Tag composites
+
+A tag composite gives you custom tag syntax, like `<Card title="...">`. You
+register an *expander* for the tag, then write the tag in any screen.
+
+The sigil turns a PascalCase tag into a snake_case atom (`<Card>` becomes
+`:card`, `<LabeledButton>` becomes `:labeled_button`), and the expander is
+looked up by that atom. An expander is a function `expand(props, children, ctx)`
+that returns a render tree (`~MOB` output).
+
+**Step 1 — write the expanders.** `Card` wraps its children in a titled
+surface; `LabeledButton` raises a tap event:
+
+```elixir
+defmodule MyApp.UI.Card do
+  @moduledoc "`<Card title=\"...\">children</Card>` — a titled raised surface."
+  import Mob.Sigil
+
+  @spec expand(map(), [map()], map()) :: map()
+  def expand(props, children, _ctx) do
+    title = Map.get(props, :title, "")
+
+    ~MOB"""
+    <Column background={:surface_raised} corner_radius={:radius_md} padding={:space_md}>
+      <Text text={title} text_size={:lg} text_color={:on_surface} />
+      <Spacer size={8} />
+      {children}
+    </Column>
+    """
+  end
+end
+
+defmodule MyApp.UI.LabeledButton do
+  @moduledoc ~S(`<LabeledButton label="..." on_press="save" />` — a button with an auto-injected tap target.)
+  import Mob.Sigil
+
+  @spec expand(map(), [map()], map()) :: map()
+  def expand(props, _children, _ctx) do
+    label = Map.get(props, :label, "")
+    # `on_press` arrives already shaped as {screen_pid, :save} (see "Event
+    # ergonomics" below), so we pass it straight to the button's on_tap.
+    on_press = Map.fetch!(props, :on_press)
+
+    ~MOB"""
+    <Button text={label} on_tap={on_press} />
+    """
+  end
+end
+```
+
+`~MOB` is auto-imported inside `use Mob.Screen`, but an expander is a plain
+module, so it needs `import Mob.Sigil`.
+
+**Step 2 — register the tags.** Through a plugin manifest's `ui_components`:
 
 ```elixir
 ui_components: [
-  %{tag: "DemoCard", atom: :demo_card, expand: {MobDemoKit.Card, :expand}}
+  %{tag: "Card",          atom: :card,           expand: {MyApp.UI.Card, :expand}},
+  %{tag: "LabeledButton", atom: :labeled_button, expand: {MyApp.UI.LabeledButton, :expand}}
 ]
 ```
 
-…or at runtime (plain Hex UI kits with no manifest — call from the host's
+…or at runtime, for a plain Hex UI kit with no manifest (call from the host's
 `on_start/0`) via `Mob.Composite.register/2`:
 
 ```elixir
-Mob.Composite.register(:demo_card, {MobDemoKit.Card, :expand})
+Mob.Composite.register(:card, {MyApp.UI.Card, :expand})
+Mob.Composite.register(:labeled_button, {MyApp.UI.LabeledButton, :expand})
 ```
 
-The expander contract is `expand(props, children, ctx)` — it returns a node
-map or list of nodes (the `~MOB` sigil output), which is re-expanded to a
-fixpoint so composites can build on composites. Event ergonomics: any `on_*`
-prop written as a bare string or atom (`on_select="combo_select"`) arrives in
-`props` already shaped as `{screen_pid, tag}` — no `self()` threading in
-either the kit or the screen that uses it.
+**Step 3 — use them in a screen.** Note there is no `self()` anywhere in this
+markup:
 
-Composites are stateless and pure Elixir, so they're hot-pushable. See
-`Mob.Composite` and the "Pure-Elixir composite components" section of
-[`MOB_PLUGINS.md`](../MOB_PLUGINS.md) for the full design; the `mob_demo_kit`
-plugin in `mob_plugin_demo` (`<DemoCard>`/`<DemoCombobox>`) is the worked,
+```elixir
+defmodule MyApp.ProfileScreen do
+  use Mob.Screen
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, Mob.Socket.assign(socket, :status, "not saved yet")}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~MOB"""
+    <Column padding={:space_lg} gap={12}>
+      <Card title="Profile">
+        <Text text="Tap save to record it." text_color={:muted} />
+        <Spacer size={8} />
+        <LabeledButton label="Save" on_press="save" />
+      </Card>
+      <Card title="Status">
+        <Text text={@status} text_color={:primary} />
+      </Card>
+    </Column>
+    """
+  end
+
+  @impl true
+  def handle_info({:tap, :save}, socket) do
+    {:noreply, Mob.Socket.assign(socket, :status, "saved")}
+  end
+end
+```
+
+**The expander contract.** `expand(props, children, ctx)` returns a node map or
+a list of nodes, which is re-expanded to a fixpoint so composites can build on
+other composites. `ctx` carries the screen process as `ctx.screen`.
+
+**Event ergonomics (auto-injected targets).** Any `on_*` prop you write on a
+composite tag as a bare string or atom (`on_press="save"`) arrives in the
+expander's `props` already shaped as `{screen_pid, :save}`. That is why
+`ProfileScreen` never writes `self()`, and why the screen receives
+`{:tap, :save}` in `handle_info/2`.
+
+This auto-injection applies only to a composite tag's **own** props. A built-in
+widget you place directly (a `<TextField>` or `<Button>` in a screen's own
+markup, even one nested inside a composite's children) still needs an explicit
+`{self(), tag}` tuple, because its props are not run through an expander. That
+is why `DashboardScreen` above builds `bump = {self(), :bump}` for its plain
+`<Button>`, while `ProfileScreen` can write `<LabeledButton on_press="save">`
+unadorned: `LabeledButton` is a composite tag, so its `on_press` is shaped for
+you.
+
+For the full design see `Mob.Composite` and the "Pure-Elixir composite
+components" section of [`MOB_PLUGINS.md`](../MOB_PLUGINS.md). The `mob_demo_kit`
+plugin in `mob_plugin_demo` (`<DemoCard>` / `<DemoCombobox>`) is a worked,
 device-verified example.
 
 ## Using `Mob.Style` for reusable styles

--- a/guides/components.md
+++ b/guides/components.md
@@ -442,6 +442,8 @@ def terminate(_reason, socket) do
 end
 ```
 
+<a id="pure-elixir-composite-components"></a>
+
 ## Defining your own components
 
 You can build reusable components out of the built-in widgets with no native


### PR DESCRIPTION
## What

Fills a gap in `guides/components.md`: the guide documented every built-in component well but only had a thin fragment for **authoring your own** components and dropping them into a screen.

Replaces the old "Pure-Elixir composite components" section with a "Defining your own components" section containing two complete, runnable screen modules:

- **Function composite** (`MyApp.DashboardScreen`): defines `stat_card/3`, uses it via `{...}` interpolation, and wires a `<Button>` inside the composite back to the screen's `handle_info/2`.
- **Tag composite** (`<Card>` + `<LabeledButton>`): the two expander modules (modeled on `MobDemoKit.Card`), both registration paths (manifest `ui_components` and runtime `Mob.Composite.register/2`), and a consuming `MyApp.ProfileScreen`.

## Why it matters

Two things that were previously implicit and easy to get wrong are now explicit:

- The **tag-to-atom rule** (`<Card>` -> `:card`, verified against `Mob.Sigil`'s `Macro.underscore`), so registration atoms line up.
- **Where `on_*` auto-injection applies**: only a composite tag's own props are shaped to `{screen_pid, tag}`. A plain `<Button>`/`<TextField>` placed directly (even inside a composite's children) still needs an explicit `{self(), tag}`. The two examples deliberately contrast these.

## Scope

Docs only, single file (`guides/components.md`). No code changes. Section heading renamed from "Pure-Elixir composite components" to "Defining your own components"; confirmed nothing links to the old anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)