### PR TITLE
docs(components): clarify the tag-whitelist warning + Component vs Composite

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -464,6 +464,16 @@ code, in two forms: **function composites** (a plain function you call) and
 Elixir, and hot-pushable. Events raised from inside either kind route to the
 **screen's** `handle_info/2`, exactly like a built-in widget does.
 
+> **Reached for `use Mob.Component`?** Easy mix-up: it's a *different* feature.
+> `Mob.Component` is the behaviour for **native view components**, a stateful BEAM
+> process paired with a platform-native view (declared via `Mob.UI.native_view/2`),
+> whose `render/1` returns a **props map for a native factory** rather than a `~MOB`
+> tree. That's an advanced, native-code path (see the [Plugins guide](plugins.md)). If
+> you just want a reusable widget or custom `<Tag>` built out of the **built-in**
+> components, with no native code, that's the `Mob.Composite` path below. The names are
+> close; for pure-Elixir tags the one you want is **Composite**, and its module returns
+> a `~MOB` tree from `expand/3`.
+
 ### Function composites
 
 A function composite is a function that returns a render tree. You call it
@@ -595,6 +605,22 @@ Mob.Composite.register(:card, {MyApp.UI.Card, :expand})
 Mob.Composite.register(:labeled_button, {MyApp.UI.LabeledButton, :expand})
 ```
 
+**Expect a compile-time warning on a registered tag; it's harmless.**
+Registration happens at *runtime* (from `on_start/0` or a plugin manifest), so
+the `~MOB` macro can't see it while compiling a screen. Every custom tag
+therefore prints a warning the first time it's compiled:
+
+```
+~MOB: <Card> is not in the Mob tag whitelist — pass-through as :card
+```
+
+That is informational, not an error. The sigil compiles `<Card>` to the atom
+`:card` and defers resolution to whatever expander is registered under that atom
+at render time. As long as you registered one in Step 2, the tag renders; the
+warning is just the compiler telling you it recognized a non-built-in tag and
+passed it through. (A genuinely unregistered tag renders nothing, which is the
+real "it doesn't work" symptom to look for.)
+
 **Step 3 — use them in a screen.** Note there is no `self()` anywhere in this
 markup:
 
@@ -702,7 +728,7 @@ end
 
 ### Sub-component event isolation (planned, not yet implemented)
 
-A future `Mob.Component` wrapper will allow a subtree of the render tree to have its own `handle_info/2`, routing events to that component process instead of the screen. Until then, use the `tag` field to distinguish events from different parts of the same screen:
+Per-subtree event isolation, where a render subtree owns its own `handle_info/2` so its events route to a dedicated process instead of the screen, is planned but not yet implemented. (Distinct from `Mob.Composite`, the tag-composite mechanism under "Defining your own components" above, which exists today for reusable widgets and custom tags; and from `Mob.Component`, the existing native-view behaviour.) Until then, use the `tag` field to distinguish events from different parts of the same screen:
 
 ```elixir
 top_save_tap    = {self(), :top_save}


### PR DESCRIPTION
## Why

Follow-up to the 0.7.12 component-authoring guide (#…). That release documented *how* to write a tag composite, which answers the mechanics of [issue #53](https://github.com/GenericJam/mob/issues/53). But it left unaddressed the two things the reporter actually got stuck on:

1. **The whitelist warning read as a failure.** They quoted `~MOB: <ReadingTile> is not in the Mob tag whitelist — pass-through as :reading_tile` as evidence it "doesn't work." That warning fires at *compile time* for **every** custom tag, because registration is a *runtime* action (`Mob.Composite.register/2` in `on_start/0`, or a plugin manifest) the sigil macro can't see. It's informational. The guide never said so.
2. **`Mob.Component` vs `Mob.Composite`.** They reached for `use Mob.Component`. That's a real but *different* feature — the behaviour for **native view components** (stateful BEAM process + platform-native view; `render/1` returns a native props map, not a `~MOB` tree). The tag-composite path they wanted is `Mob.Composite` (`expand/3`). The near-identical names are a trap, and nothing steered them off it.

## What

Three edits to `guides/components.md`, all in/around the existing "Defining your own components" section:

- A callout at the section intro disambiguating `Mob.Component` (native views, advanced) from `Mob.Composite` (pure-Elixir tags — what most people want).
- A note right before "use them in a screen" explaining the whitelist warning is expected and harmless for a registered tag, with the real "it doesn't work" symptom to look for (an *un*registered tag renders nothing).
- Reworded the "Sub-component event isolation (planned)" note so it no longer calls the planned feature "a future `Mob.Component` wrapper" — that name already belongs to the existing native-view behaviour, so the old wording contradicted itself.

Docs-only; no code paths touched.

## Note on #53

This makes the issue fully answerable from the guide alone. Suggest replying to #53 pointing at the updated "Tag composites" section with a corrected `ReadingTile` snippet (plain module + `import Mob.Sigil` + `expand/3`, registered at `:expand`), then closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)