### PR TITLE
MOB-30: refresh mobile_surface_matrix.md (magnetometer/compass/orientation-lock/BLE)

### DIFF
--- a/guides/mobile_surface_matrix.md
+++ b/guides/mobile_surface_matrix.md
@@ -105,7 +105,7 @@ and orthogonal — composition over a fat component library.
 | Network info (cell vs wifi, type) | ❌ | — | — | Plugin candidate (NetInfo equivalent) |
 | Network reachability | ❌ | — | — | Plugin candidate |
 | Screen brightness | ❌ | — | — | Plugin candidate |
-| Screen orientation lock | ❌ | — | — | Plugin candidate |
+| Screen orientation lock | ✅ | ✓ | ✓ | `Mob.Device.lock_orientation/1` + `unlock_orientation/0` (Android `setRequestedOrientation`; iOS supported-orientations + geometry request) |
 | Idle timer / screen wake | ❌ | — | — | Plugin candidate |
 | Exit app | ✅ | n/a | ✓ | Android only; iOS forbids programmatic exit |
 
@@ -142,8 +142,8 @@ and orthogonal — composition over a fat component library.
 
 | Capability | Status | iOS | Android | Notes |
 |--|--|--|--|--|
-| Bluetooth Classic | ✅ | n/a | ✓ | `MobBluetooth` plugin (extracted; Hfp / Spp / Hid sub-modules) |
-| Bluetooth Low Energy (BLE) | ❌ | — | — | Plugin candidate — common request |
+| Bluetooth Classic | ✅ | n/a | ✓ | `MobBluetooth` plugin (extracted; Hfp / Spp sub-modules) — central/host role, Android only |
+| Bluetooth Low Energy (BLE) | 🟡 | ✓ | ✓ | `MobBluetooth.Le` (mob_bluetooth 0.3.0) — GATT **peripheral** role only (advertise + notify + receive writes), iOS + Android; BLE central (scan/connect) is a future addition |
 | NFC | ❌ | — | — | Plugin candidate (Core NFC / Android NFC) |
 | WiFi info / scanning | ❌ | — | — | Plugin candidate; OS restrictions apply |
 | USB host | ✅ | n/a | ✓ | `Mob.VendorUsb` — bulk read/write, custom devices |
@@ -161,12 +161,12 @@ and orthogonal — composition over a fat component library.
 |--|--|--|--|--|
 | Accelerometer | ✅ | ✓ | ✓ | `Mob.Motion.start(:accelerometer, ...)` |
 | Gyroscope | ✅ | ✓ | ✓ | `Mob.Motion.start(:gyro, ...)` |
-| Magnetometer | ❌ | — | — | Plugin candidate; `CMMotionManager` / `Sensor.TYPE_MAGNETIC_FIELD` |
+| Magnetometer | ✅ | ✓ | ✓ | `Mob.Motion.start(:magnetometer, ...)` — µT-calibrated `mag` + fused `heading` (0.7.14); keys present only when `:magnetometer` requested |
 | Barometer | ❌ | — | — | Plugin candidate |
 | Proximity | ❌ | — | — | Plugin candidate |
 | Ambient light | ❌ | — | — | Plugin candidate |
 | Pedometer / step counter | ❌ | — | — | Plugin candidate |
-| Compass / heading | ❌ | — | — | Plugin candidate |
+| Compass / heading | ✅ | ✓ | ✓ | Fused `heading` (degrees from magnetic north) via `Mob.Motion` `:magnetometer` — same request as above |
 
 ## Location
 


### PR DESCRIPTION
Refreshes the hand-maintained capability matrix, which had drifted behind shipped work. Closes **MOB-30**.

## Rows corrected (verified against current code, not just the issue text)

| Row | Was | Now | Evidence |
|--|--|--|--|
| Screen orientation lock | ❌ | ✅ ✓/✓ | `Mob.Device.lock_orientation/1` + `unlock_orientation/0` (device.ex) |
| Bluetooth Low Energy | ❌ | 🟡 ✓/✓ | `MobBluetooth.Le` (mob_bluetooth 0.3.0) — GATT **peripheral** role (advertise + notify + receive writes), iOS + Android; BLE central/scan is future |
| Magnetometer | ❌ | ✅ ✓/✓ | `Mob.Motion` `:magnetometer` — µT `mag` + fused `heading`, shipped 0.7.14 (MOB-6) |
| Compass / heading | ❌ | ✅ ✓/✓ | fused heading via the same path |

Also corrected the **Bluetooth Classic** note: `mob_bluetooth` has no `Hid` sub-module (only `Hfp`/`Spp`), and clarified its central/host, Android-only scope.

## Sweep

Per the issue's "sweep every ❌/🟡 row" ask, the remaining missing rows were checked against current `lib/` and cross-referenced with the MOB backlog — sensors (barometer/proximity/ambient/pedometer), NFC, WiFi, screen brightness, keep-awake, network state, speech-recognition, contacts/calendar, etc. all still map to open MOB issues and remain absent from core. No further changes.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)