### PR TITLE
docs: fix undefined tap/1 in getting_started example (closes #46)

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -632,7 +632,7 @@ defmodule MyApp.HomeScreen do
     ~MOB"""
     <Column padding={24} gap={16}>
       <Text text={"Count: #{assigns.count}"} text_size={:xl} />
-      <Button text="Tap me" on_tap={tap(:increment)} />
+      <Button text="Tap me" on_tap={{self(), :increment}} />
     </Column>
     """
   end
@@ -646,8 +646,9 @@ end
 ```
 
 `mount/3` initialises assigns. `render/1` returns the component tree via the `~MOB`
-sigil. `handle_info/2` updates state in response to user events. After each update,
-the framework calls `render/1` again and pushes the diff to the native layer.
+sigil. An `on_tap={{self(), :increment}}` sends `{:tap, :increment}` to the screen
+when the button is pressed, which `handle_info/2` matches to update state. After each
+update, the framework calls `render/1` again and pushes the diff to the native layer.
 
 ---
 


### PR DESCRIPTION
## What

The "Your first screen" example in `guides/getting_started.md` used:

```elixir
<Button text="Tap me" on_tap={tap(:increment)} />
```

There is no `tap/1` function — `use Mob.Screen` imports `Mob.Sigil` (which has no `tap` helper), so a newcomer pasting the getting-started example hits a compile error: `undefined function tap/1`. Reported as **#46**.

## Fix

Use the canonical inline tuple, which the example's existing `handle_info({:tap, :increment}, ...)` already handles:

```elixir
<Button text="Tap me" on_tap={{self(), :increment}} />
```

This matches the form already used in `Mob.Sigil`'s own docstring (`lib/mob/sigil.ex:23`), `guides/screen_lifecycle.md`, and `guides/device_capabilities.md` — getting_started was the only doc with the broken form. Also added one clause to the walkthrough prose explaining the `{self(), :increment}` → `{:tap, :increment}` wiring, since that mapping was previously unexplained.

## Verification

Compiled the corrected module (`use Mob.Screen` + the `~MOB` sigil) and called `render/1` — it compiles and produces a valid render tree, where the old form was a hard compile error. Docs-only; no code paths touched.

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)