### PR TITLE
iOS: make the screenshot NIF opt-in for release builds

### DIFF
--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -5354,9 +5354,12 @@ static ERL_NIF_TERM nif_swipe_xy(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 // ── In-process screenshot + scroll control (agent driving over dist) ─────────
 //
 // screenshot/3, scroll_info/1, scroll_to/3 give a remotely-connected agent
-// pixels and deterministic scroll without adb/xcrun. They use only public
-// UIKit APIs (UIGraphicsImageRenderer, UIScrollView.contentOffset) but live in
-// the debug-only harness block alongside the other driving NIFs.
+// pixels and deterministic scroll without adb/xcrun, using only public UIKit
+// APIs (UIGraphicsImageRenderer, UIScrollView.contentOffset). scroll_* stay in
+// the debug-only harness; screenshot/3 is carved out just below so a host can
+// opt it into release with -DMOB_ENABLE_SCREENSHOT — an agent needs to SEE the
+// screen to error-correct even in a shipped build, while still being unable to
+// DRIVE it (the synthetic-input NIFs above stay stripped in release).
 
 // Recursively collect every UIScrollView under `view` into `acc`.
 static void mob_collect_scroll_views(UIView *view, NSMutableArray<UIScrollView *> *acc) {
@@ -5405,7 +5408,16 @@ static UIScrollView *mob_find_scroll_view(NSString *identifier) {
     }
     return best;
 }
+#endif // !MOB_RELEASE — end of the debug-only synthetic-input + scroll harness
 
+// Screen capture — public UIKit only (UIGraphicsImageRenderer + drawViewHierarchy),
+// no private selectors, so it is App-Store-safe. Carved out of the harness so a host
+// can opt it into release builds via -DMOB_ENABLE_SCREENSHOT (mob_dev config
+// `ios_release_screenshot: true`); OFF by default. It captures the app's own key window
+// with no OS prompt or indicator, so shipping a remotely-triggerable capture must be a
+// conscious build choice, never a silent default. In release this lets an agent SEE the
+// screen to error-correct while remaining unable to DRIVE it (tap/type stay stripped).
+#if !MOB_RELEASE || defined(MOB_ENABLE_SCREENSHOT)
 static ERL_NIF_TERM nif_screenshot(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     char fmt[8] = {0};
     int quality = 90;
@@ -5464,7 +5476,9 @@ static ERL_NIF_TERM nif_screenshot(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
     memcpy(bin.data, imageData.bytes, imageData.length);
     return enif_make_binary(env, &bin);
 }
+#endif // !MOB_RELEASE || MOB_ENABLE_SCREENSHOT
 
+#if !MOB_RELEASE // resume the debug-only harness (scroll + element frames)
 static ERL_NIF_TERM nif_scroll_info(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     ErlNifBinary idb;
     if (!enif_inspect_binary(env, argv[0], &idb))
@@ -6280,7 +6294,11 @@ static ErlNifFunc nif_funcs[] = {
     {"clear_text", 0, nif_clear_text, 0},
     {"long_press_xy", 3, nif_long_press_xy, 0},
     {"swipe_xy", 4, nif_swipe_xy, 0},
+#endif
+#if !MOB_RELEASE || defined(MOB_ENABLE_SCREENSHOT)
     {"screenshot", 3, nif_screenshot, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+#endif
+#if !MOB_RELEASE
     {"scroll_info", 1, nif_scroll_info, 0},
     {"scroll_to", 3, nif_scroll_to, 0},
     {"element_frames", 0, nif_element_frames, ERL_NIF_DIRTY_JOB_CPU_BOUND},

--- a/test/mob/release_screenshot_test.exs
+++ b/test/mob/release_screenshot_test.exs
@@ -1,0 +1,65 @@
+defmodule Mob.ReleaseScreenshotTest do
+  use ExUnit.Case, async: true
+
+  # Security invariant, pinned at the source (the native harness can't be exercised on
+  # the host — same rationale as Mob.NifDeclarationTest). The iOS test harness is
+  # compiled out of release builds (`#if !MOB_RELEASE`) because its synthetic-input NIFs
+  # (tap/type/…) use PRIVATE UIKit/IOKit selectors the App Store auto-rejects.
+  # `screenshot/3` uses only public APIs (UIGraphicsImageRenderer + drawViewHierarchy),
+  # so it is carved into a release-OPT-IN guard (`MOB_ENABLE_SCREENSHOT`) — a host can
+  # ship it so an agent can SEE the screen to error-correct in a release build.
+  #
+  # This test pins the boundary: screenshot MAY be opted into release, but the private
+  # synthetic-input NIFs must NEVER be — they stay strictly `#if !MOB_RELEASE`. If a
+  # future edit slipped one into the opt-in guard, a release build could ship
+  # private-selector code and get the app pulled from the store.
+  @objc Path.expand("../../ios/mob_nif.m", __DIR__)
+
+  # NIFs whose iOS implementations synthesize input via private selectors/IOHIDEvent.
+  @private_input ~w(tap tap_xy type_text key_press delete_backward clear_text
+                    long_press_xy swipe_xy ax_action ax_action_at_xy)
+
+  # Map each `{"name", arity, nif_…}` registration entry to its nearest enclosing
+  # `#if` condition, tracking nesting with a stack so it's robust across the file.
+  defp registration_guards do
+    @objc
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.reduce({%{}, []}, fn line, {acc, stack} ->
+      cond do
+        m = Regex.run(~r/^\s*#\s*if\S*\s+(.*)$/, line) ->
+          {acc, [Enum.at(m, 1) | stack]}
+
+        Regex.match?(~r/^\s*#\s*endif/, line) ->
+          {acc, Enum.drop(stack, 1)}
+
+        m = Regex.run(~r/^\s*\{"([a-z_0-9]+)",\s*\d+,\s*nif_/, line) ->
+          {Map.put(acc, Enum.at(m, 1), List.first(stack) || ""), stack}
+
+        true ->
+          {acc, stack}
+      end
+    end)
+    |> elem(0)
+  end
+
+  test "screenshot is release-opt-in (guarded by MOB_ENABLE_SCREENSHOT)" do
+    guards = registration_guards()
+    assert guards["screenshot"], "screenshot NIF not found in the registration table"
+
+    assert guards["screenshot"] =~ "MOB_ENABLE_SCREENSHOT",
+           "screenshot must sit behind a MOB_ENABLE_SCREENSHOT opt-in guard; got: #{guards["screenshot"]}"
+  end
+
+  test "private synthetic-input NIFs stay strictly debug-only, never release-opt-in" do
+    guards = registration_guards()
+
+    for name <- @private_input, guard = guards[name] do
+      refute guard =~ "MOB_ENABLE_SCREENSHOT",
+             "#{name} uses private selectors and must NOT be release-opt-in; guard was: #{guard}"
+
+      assert guard =~ "!MOB_RELEASE",
+             "#{name} must stay behind `#if !MOB_RELEASE`; guard was: #{guard}"
+    end
+  end
+end


### PR DESCRIPTION
## Why

The iOS test harness is compiled out of release builds via `#if !MOB_RELEASE` because its **synthetic-input** NIFs (`tap`, `tap_xy`, `type_text`, `key_press`, `swipe_xy`, `ax_action`…) drive the UI through **private** UIKit/IOKit selectors (`UIWindow.sendEvent`, `_setHIDEvent:`, `IOHIDEventCreateDigitizerFingerEvent`) that the App Store auto-rejects.

`screenshot/3` was collateral damage. It uses **only public APIs** — `UIGraphicsImageRenderer` + `drawViewHierarchyInRect:afterScreenUpdates:` on the app's own key window — so it's App-Store-safe, but it lived in the same block. Result: release builds can't screenshot at all. An agent driving a shipped app over dist (or Sloppy Joe's watch preview) gets `:not_loaded` and can't *see* the screen to error-correct.

## What

Carve `nif_screenshot` and its registration-table entry into their own guard:

```c
#if !MOB_RELEASE || defined(MOB_ENABLE_SCREENSHOT)
```

- **Default unchanged**: still stripped in release. Every existing build behaves identically.
- **Opt-in**: a host defines `-DMOB_ENABLE_SCREENSHOT` to ship it. That flag is plumbed from a `mob_dev` config key (`ios_release_screenshot: true`) in the companion mob_dev PR.
- The private synthetic-input NIFs stay strictly `#if !MOB_RELEASE` — they can **never** ship in a release build. So a release build can **SEE** the screen (opt-in) but never **DRIVE** it.

## Why opt-in rather than always-on

`screenshot` captures the app's own key window with **no OS permission, prompt, or recording indicator** (unlike ReplayKit-based `mob_screencast`). That's fine for its purpose, but it means shipping a *remotely-triggerable* "capture my own window" NIF should be a **conscious** build-time decision by the host dev, never a silent framework default. The flag makes it exactly that.

## Test

`test/mob/release_screenshot_test.exs` is a source-guard (same strategy as `Mob.NifDeclarationTest` — the native harness can't run on the host). It walks the registration table's `#if` nesting and asserts:
- `screenshot` sits behind a `MOB_ENABLE_SCREENSHOT` opt-in guard, and
- every private synthetic-input NIF stays strictly `!MOB_RELEASE` and is **never** release-opt-in.

Verified it fails if a private-input NIF is moved into the opt-in guard. Full suite green (993 passed); clang-format / mix format / credo / `--warnings-as-errors` clean.

## Follow-ups
- Companion **mob_dev** PR plumbs `ios_release_screenshot` config → `MOB_ENABLE_SCREENSHOT`.
- Android ships its screenshot NIF in release unconditionally today; gating it behind the same opt-in (its NIF is in the `mob_new` Kotlin template) is a separate change to honor the same principle.