### PR TITLE
fix: cold-start launch notifications dropped before nif_load (Android + iOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Cold-start launch notifications are no longer dropped (Android + iOS).**
+  `mob_set_launch_notification` (Android) and `mob_set_launch_notification_json`
+  (iOS) bailed out when called before `nif_load` had created their mutex — which
+  is exactly when the cold-start path runs (MainActivity.onCreate / the app
+  delegate store the tapped notification before the BEAM boots). The payload
+  was silently discarded, so tap-to-open from a killed app never worked; a
+  warm/backgrounded tap (delivered via `onNewIntent` / the running delegate)
+  was unaffected. Both setters now store before the mutex exists, the same
+  pre-mutex pattern `mob_set_opened_document` has always used — safe because
+  nothing reads the global until `take_launch_notification`, which can only
+  run post-`nif_load`.
+
 ## [0.7.20] - 2026-07-11
 
 ### Changed

--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -2238,17 +2238,24 @@ export fn nif_share_text(
 // ── Launch notification (written from Kotlin on cold start) ──────────────
 // MobBridge.setLaunchNotification(json) → mob_set_launch_notification(json).
 // Apps call Mob.Device.take_launch_notification/0 → nif_take_launch_notification
-// to consume it. Guarded by g_launch_notif_mutex (lazily created in nif_load).
+// to consume it. Guarded by g_launch_notif_mutex once nif_load created it;
+// stores before that are unguarded on purpose (see below).
 
 var g_launch_notif_json: ?[*:0]u8 = null;
 var g_launch_notif_mutex: ?*erts.ErlNifMutex = null;
 
 pub export fn mob_set_launch_notification(json: ?[*:0]const u8) callconv(.c) void {
-    const mutex = g_launch_notif_mutex orelse return;
-    erts.enif_mutex_lock(mutex);
-    defer erts.enif_mutex_unlock(mutex);
+    // Store even before nif_load created the mutex: on a cold start from a
+    // notification tap, MainActivity.onCreate calls this before the BEAM
+    // thread starts, and nothing reads the global until take_launch_notification
+    // (post-nif_load), so there's no concurrent access in that window. The
+    // previous `orelse return` silently dropped exactly that cold-start
+    // payload — tap-to-open from a killed app never worked. Same pattern as
+    // mob_set_opened_document below.
+    if (g_launch_notif_mutex) |mutex| erts.enif_mutex_lock(mutex);
     if (g_launch_notif_json) |old| jni.free(@as(?*anyopaque, @ptrCast(old)));
     g_launch_notif_json = if (json) |j| jni.strdup(j) else null;
+    if (g_launch_notif_mutex) |mutex| erts.enif_mutex_unlock(mutex);
 }
 
 export fn nif_take_launch_notification(

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -2383,12 +2383,18 @@ void mob_send_push_token(const char *hex_token) {
 }
 
 void mob_set_launch_notification_json(const char *json) {
-    if (!g_launch_notif_mutex)
-        return;
-    enif_mutex_lock(g_launch_notif_mutex);
+    // Store even before nif_load created the mutex: on a cold start from a
+    // notification tap, the app delegate calls this before the BEAM starts,
+    // and nothing reads the global until take_launch_notification
+    // (post-nif_load), so there's no concurrent access in that window. The
+    // previous early return silently dropped exactly that cold-start payload
+    // — tap-to-open from a killed app never worked.
+    if (g_launch_notif_mutex)
+        enif_mutex_lock(g_launch_notif_mutex);
     free(g_launch_notification_json);
     g_launch_notification_json = json ? strdup(json) : NULL;
-    enif_mutex_unlock(g_launch_notif_mutex);
+    if (g_launch_notif_mutex)
+        enif_mutex_unlock(g_launch_notif_mutex);
 }
 
 static ERL_NIF_TERM nif_take_launch_notification(ErlNifEnv *env, int argc,


### PR DESCRIPTION
Both platform stores for the launch notification bail out when called before `nif_load` has created their mutex:

- Android: `mob_set_launch_notification` — `const mutex = g_launch_notif_mutex orelse return;`
- iOS: `mob_set_launch_notification_json` — `if (!g_launch_notif_mutex) return;`

But the mutex is created in `nif_load`, and the cold-start path runs strictly **before** that: on a notification tap that launches a killed app, `MainActivity.onCreate` (Android) / the app delegate (iOS) store the payload before the BEAM thread boots. The payload is silently discarded every time — **tap-to-open from a killed app has never worked on either platform**. Warm/backgrounded taps (`onNewIntent` / running delegate) are unaffected, which makes the bug easy to miss in testing.

The fix mirrors `mob_set_opened_document`, which has always stored pre-mutex and documents why it's safe: nothing reads the global until `take_launch_notification`, which can only run after `nif_load`, so the unguarded window has no concurrent reader. Post-load stores still lock. (`zig ast-check` passes; the objc change is the same two-line guard restructure.)

Found while wiring FCM push in a mob app (BuyFrost): an adversarial review noticed the opened-document sibling's comment describes exactly this cold-launch window, exposing the launch-notification variant as a latent bug rather than a design choice.

CHANGELOG entry added under Unreleased.