### PR TITLE
MOB-95: mark issues.md #6's CameraX/ML Kit rows fixed

### DIFF
--- a/issues.md
+++ b/issues.md
@@ -363,7 +363,7 @@ The fix is a single linker flag at build time:
 | `libepmd.so`            | OTP runtime | rebuild OTP tarball with the flag |
 | `libmobtest.so`         | Mob's NDK build (`android/jni/`) | add to CMakeLists |
 | `libsqlite3_nif.so`     | exqlite Hex dep | upstream fix or local re-link |
-| `libimage_processing_util_jni.so` | androidx.camera | **FIXED (MOB-95)** — bumped 1.3.4 → 1.6.1 |
+| `libimage_processing_util_jni.so` | androidx.camera | **FIXED (MOB-95)** — bumped 1.3.4 → 1.4.2 |
 | `libbarhopper_v3.so`    | com.google.mlkit:barcode-scanning | **FIXED (MOB-95)** — bumped 17.2.0 → 17.3.0 |
 
 > **Partial resolution (MOB-95).** The CameraX and ML Kit rows are fixed —
@@ -373,6 +373,17 @@ The fix is a single linker flag at build time:
 > all three copies had to move in lockstep). The other five libraries (OTP
 > runtime ×3, `libmobtest.so`, `libsqlite3_nif.so`) are untouched — this
 > issue stays open for those.
+>
+> **Device-verified pin choice: CameraX 1.4.2, not the current-stable
+> 1.6.x line.** 1.6.1 fails a real Gradle build against this toolchain
+> (compileSdk 34 / AGP 8.2.0) — it and its transitive `androidx.media3`
+> deps require compileSdk 36 + AGP 8.9.1+, a much bigger, separate
+> toolchain bump. 1.4.2 (the latest patch in the line that introduced
+> the 16 KB fix) needs neither; confirmed via `mix mob.deploy --native`
+> against `mob_plugin_demo` on a physical Moto G — build succeeded, app
+> booted, `MobCamera`/`MobScanner` modules loaded, zero native-linkage
+> errors. Revisit 1.6.x once mob's Android toolchain itself moves to
+> AGP 8.9.1+ / compileSdk 36 — a separate, larger piece of work.
 
 **Recommendation: bundle the fix into the next OTP tarball schema bump.**
 We already plan to re-cut the iOS-device tarball when EPMD source got
@@ -390,7 +401,8 @@ added; that same release cycle is the natural place to add
   post-processing step in the deployer's APK packaging. The
   `zipalign -p 16384` form is a real flag in NDK 27+.
 - ~~**CameraX / ML Kit**: bump to a version that ships 16 KB-aligned
-  binaries.~~ **DONE (MOB-95)** — CameraX 1.3.4 → 1.6.1, ML Kit
+  binaries.~~ **DONE (MOB-95)** — CameraX 1.3.4 → 1.4.2 (not 1.6.1 —
+  see the device-verified pin-choice note above), ML Kit
   barcode-scanning 17.2.0 → 17.3.0.
 
 **Priority** — low. Warning, not an error. Apps run correctly today

--- a/issues.md
+++ b/issues.md
@@ -363,8 +363,16 @@ The fix is a single linker flag at build time:
 | `libepmd.so`            | OTP runtime | rebuild OTP tarball with the flag |
 | `libmobtest.so`         | Mob's NDK build (`android/jni/`) | add to CMakeLists |
 | `libsqlite3_nif.so`     | exqlite Hex dep | upstream fix or local re-link |
-| `libimage_processing_util_jni.so` | androidx.camera | bump CameraX dep |
-| `libbarhopper_v3.so`    | com.google.mlkit:barcode-scanning | bump ML Kit dep |
+| `libimage_processing_util_jni.so` | androidx.camera | **FIXED (MOB-95)** — bumped 1.3.4 → 1.6.1 |
+| `libbarhopper_v3.so`    | com.google.mlkit:barcode-scanning | **FIXED (MOB-95)** — bumped 17.2.0 → 17.3.0 |
+
+> **Partial resolution (MOB-95).** The CameraX and ML Kit rows are fixed —
+> bumped in `mob_camera`/`mob_scanner`'s `priv/mob_plugin.exs` gradle_deps
+> and in `mob_new`'s `build.gradle.eex` template (core still links CameraX
+> directly for the camera preview, separately from what the plugins declare;
+> all three copies had to move in lockstep). The other five libraries (OTP
+> runtime ×3, `libmobtest.so`, `libsqlite3_nif.so`) are untouched — this
+> issue stays open for those.
 
 **Recommendation: bundle the fix into the next OTP tarball schema bump.**
 We already plan to re-cut the iOS-device tarball when EPMD source got
@@ -381,8 +389,9 @@ added; that same release cycle is the natural place to add
   `zipalign -p 16384` (page-aligns `.so` LOAD segments) as a
   post-processing step in the deployer's APK packaging. The
   `zipalign -p 16384` form is a real flag in NDK 27+.
-- **CameraX / ML Kit**: bump to a version that ships 16 KB-aligned
-  binaries. Most current Google libraries already do.
+- ~~**CameraX / ML Kit**: bump to a version that ships 16 KB-aligned
+  binaries.~~ **DONE (MOB-95)** — CameraX 1.3.4 → 1.6.1, ML Kit
+  barcode-scanning 17.2.0 → 17.3.0.
 
 **Priority** — low. Warning, not an error. Apps run correctly today
 in compatibility mode. Worth doing alongside the next OTP rebuild


### PR DESCRIPTION
## Summary
Doc-only update to `issues.md` #6 reflecting the CameraX + ML Kit version bumps (mob_camera #3, mob_scanner #2, mob_new #33) that fix 2 of the 7 flagged 16 KB page-alignment libraries. The other 5 (OTP runtime ×3, libmobtest.so, libsqlite3_nif.so) are untouched — issue stays open for those.

## Test plan
- [x] `mix test` — 993 passed (38 excluded, pre-existing onboarding-suite exclusions)
- [x] Pre-push hook — all green

Linear: MOB-95

🤖 Generated with [Claude Code](https://claude.com/claude-code)