### PR TITLE
docs: mermaid diagrams follow the hexdocs light/dark theme

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -77,18 +77,51 @@ defmodule Mob.MixProject do
     <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        mermaid.initialize({ startOnLoad: false });
-        let id = 0;
-        for (const codeEl of document.querySelectorAll("pre code.mermaid")) {
-          const preEl = codeEl.closest("pre");
-          const graphEl = document.createElement("div");
-          const graphId = "mermaid-graph-" + id++;
-          mermaid.render(graphId, codeEl.textContent).then(({ svg, bindFunctions }) => {
-            graphEl.innerHTML = svg;
-            if (bindFunctions) bindFunctions(graphEl);
-            preEl.replaceWith(graphEl);
-          });
+        // ex_doc marks dark mode by toggling `dark` on <body> (its stylesheet
+        // is written against `body.dark`). Reading the class rather than
+        // prefers-color-scheme covers all three of ex_doc's settings —
+        // light, dark, and system — because ex_doc re-toggles the class
+        // itself when the OS scheme changes under "system".
+        const isDark = () => document.body.classList.contains("dark");
+
+        // Capture each diagram's source BEFORE the first render replaces the
+        // <pre>, otherwise a later theme switch has nothing to re-render from.
+        const diagrams = [];
+        document.querySelectorAll("pre code.mermaid").forEach((codeEl, i) => {
+          const host = document.createElement("div");
+          host.className = "mermaid-diagram";
+          codeEl.closest("pre").replaceWith(host);
+          diagrams.push({ host: host, source: codeEl.textContent, id: "mermaid-graph-" + i });
+        });
+
+        if (diagrams.length === 0) return;
+
+        // Renders are async, so a fast light→dark→light toggle can land its
+        // results out of order. Stamp each pass and drop stale ones.
+        let pass = 0;
+        function renderAll() {
+          const token = ++pass;
+          mermaid.initialize({ startOnLoad: false, theme: isDark() ? "dark" : "default" });
+          for (const d of diagrams) {
+            // mermaid requires a unique graph id per render call.
+            mermaid.render(d.id + "-" + token, d.source).then(({ svg, bindFunctions }) => {
+              if (token !== pass) return;
+              d.host.innerHTML = svg;
+              if (bindFunctions) bindFunctions(d.host);
+            });
+          }
         }
+
+        renderAll();
+
+        // <body>'s class list also churns for search focus and sticky scroll,
+        // so only re-render when the theme itself actually flipped.
+        let wasDark = isDark();
+        new MutationObserver(function () {
+          if (isDark() === wasDark) return;
+          wasDark = isDark();
+          renderAll();
+        }).observe(document.body, { attributes: true, attributeFilter: ["class"] });
       });
     </script>
     """


### PR DESCRIPTION
Closes #42 (@clsource).

ex_doc marks dark mode by toggling `dark` on `<body>` — its stylesheet is written against `body.dark`. Reading that class rather than `prefers-color-scheme` covers all three of ex_doc's settings (light, dark, **and** system), because ex_doc re-toggles the class itself when the OS scheme changes under "system".

## Three things the naive version gets wrong

- **Source was destroyed.** The old code replaced each `<pre>` with the rendered SVG, so a theme switch had nothing to re-render from. Source is now captured up front.
- **Async races.** `mermaid.render` is async, so a fast light→dark→light toggle can land results out of order and strand the diagram on the wrong theme. Each pass is stamped; stale results are dropped.
- **`<body>` class churn.** ex_doc also toggles `search-focused` and `scroll-sticky` there, so a bare `MutationObserver` would re-render diagrams on unrelated DOM activity. Only an actual change in dark-ness triggers a re-render.

## Relationship to #35

Supersedes it. #35 was closed by its own author ("maybe is better other approach") — it forced the dark theme unconditionally, which breaks light mode. #35 also reported diagrams not rendering at all; **that half is already fixed on master** — generated markup is `<pre><code class="mermaid">` and the existing selector matches it, confirmed in the built docs.

## Verification

Done in a real browser against the built docs, not by eye:

| Step | Result |
|---|---|
| Initial light render | SVG present, text fill `#333`, no leftover `pre code.mermaid` |
| Toggle `body.dark` | Re-renders as pass 2, fill `#ccc` |
| Toggle back | Re-renders as pass 3, fill `#333` |
| Add `search-focused` + `scroll-sticky` | **No** re-render (id unchanged) |

No orphan mermaid error divs after three passes, so no failed renders or leaks. `mix format`, `mix credo --strict` clean.

## One caveat

This only reaches hexdocs.pm via a **published release** — doc-only changes without a version bump never ship, per `RELEASE.md`. Merging this alone won't fix the live docs; it needs to ride a release. I have not bumped the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)