### PR TITLE
feat(navigation): allow directional resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+## [0.7.34] - 2026-08-29
+
+### Added
+- **Directional resets.** `Mob.Socket.reset_to/4` takes
+  `transition: :push | :pop | :reset`. A reset always replaces the navigation
+  stack; the option only changes the animation, for cases like a custom tab bar
+  where replacing the stack still represents directional movement. `:reset`
+  (cross-fade) remains the default, so existing callers are unaffected.
+  `Mob.Test.reset_to/4` takes the same option, so the behaviour can be driven
+  on a device.
+
+### Changed
+- The `:reset` navigation action carries a fourth element, the transition.
+  `Mob.ScreenCase.navigated_to/1` and the router understand both shapes; the
+  three-element form still arrives from `Mob.Test.reset_to/3` and from any
+  socket built before a hot code push.
+- An unrecognised transition now raises `ArgumentError` at
+  `Mob.Socket.reset_to/4` rather than reaching the platform, which accepts any
+  atom and silently falls back to no animation. `:none` is rejected for the
+  same reason it is not merely a typo: it suppresses the navigation-version
+  bump, so SwiftUI would diff the incoming tree into the outgoing screen's view
+  identities — a text field at the same position keeping the old screen's text
+  and focus across a stack that no longer exists.
+
+### Fixed
+- **A navigation action the router does not recognise no longer takes the app
+  down.** It was an unmatched function clause in the owner process, which owns
+  navigation and links every live screen — so one bad action killed all of
+  them. Reachable during a hot code push, where module loading is not atomic
+  and a screen already running new code can hand an action to a router still
+  running old code. Now logged and ignored, and the current screen repaints.
+
 ## [0.7.33] - 2026-08-29
 
 First four steps of the screen-process architecture (MOB-108). Rationale in

--- a/guides/navigation.md
+++ b/guides/navigation.md
@@ -120,7 +120,7 @@ Pop all screens back to the root of the current stack:
 Mob.Socket.pop_to_root(socket)
 ```
 
-### `reset_to/2,3`
+### `reset_to/2,3,4`
 
 Replace the entire navigation stack with a new root. No back button, no history. Used for auth transitions:
 

--- a/guides/navigation.md
+++ b/guides/navigation.md
@@ -131,6 +131,13 @@ def handle_event("tap", %{"tag" => "logged_in"}, socket) do
 end
 ```
 
+The reset always replaces the stack. Its animation can be overridden when the
+same stack operation represents directional movement, such as custom tabs:
+
+```elixir
+Mob.Socket.reset_to(socket, MyApp.PortfolioScreen, %{}, transition: :push)
+```
+
 ### `switch_tab/2`
 
 Switch to a named tab in a tab bar or drawer layout:
@@ -145,6 +152,9 @@ The framework automatically picks the right animation based on the navigation ac
 - **Push** — slide in from right (iOS) / slide up (Android)
 - **Pop** — reverse slide
 - **Reset** — cross-fade (no directional animation, no back history)
+
+`reset_to/4` can override only the animation with `transition: :push` or
+`transition: :pop`; it still discards navigation history.
 
 ## Passing data on pop
 

--- a/lib/mob/app.ex
+++ b/lib/mob/app.ex
@@ -236,7 +236,7 @@ defmodule Mob.App do
   Declare a navigation stack.
 
   `name` is the atom identifier used with `push_screen/2,3`, `pop_to/2`,
-  and `reset_to/2,3`. The `:root` option is the module mounted when the stack
+  and `reset_to/2,3,4`. The `:root` option is the module mounted when the stack
   is first entered.
 
   Options:

--- a/lib/mob/router.ex
+++ b/lib/mob/router.ex
@@ -627,9 +627,16 @@ defmodule Mob.Router do
     end
   end
 
+  # The three-element form predates the transition option. It still arrives from
+  # `Mob.Test.reset_to/3`, and from any socket built before a hot code push, so
+  # it keeps working and means what it always did.
   defp apply_nav_action({:reset, dest, params}, state, mode) do
+    apply_nav_action({:reset, dest, params, :reset}, state, mode)
+  end
+
+  defp apply_nav_action({:reset, dest, params, transition}, state, mode) do
     with {:ok, new_module, route_params} <- safe_resolve(dest, state) do
-      reset_resolved(new_module, Map.merge(route_params, params), state, mode)
+      reset_resolved(new_module, Map.merge(route_params, params), transition, state, mode)
     end
   end
 
@@ -671,13 +678,13 @@ defmodule Mob.Router do
     end
   end
 
-  defp reset_resolved(new_module, mount_params, state, mode) do
+  defp reset_resolved(new_module, mount_params, transition, state, mode) do
     case start_screen(new_module, mount_params, state) do
       {:ok, entry, state} ->
         discarded = [state.current | Mob.Nav.history(state.nav)]
         state = Enum.reduce(discarded, state, &stop_screen/2)
         state = make_current(%{state | nav: Mob.Nav.put_history(state.nav, [])}, entry)
-        do_paint(entry, :reset, state, mode)
+        do_paint(entry, transition, state, mode)
         state
 
       {:error, _reason} ->

--- a/lib/mob/router.ex
+++ b/lib/mob/router.ex
@@ -665,6 +665,21 @@ defmodule Mob.Router do
     end
   end
 
+  # A shape this router does not know. Reachable during a hot code push, where
+  # module loading is not atomic: a screen already running new code can hand an
+  # action to a router still running old code. Unmatched, that is a
+  # FunctionClauseError in the owner — navigation and every live screen down,
+  # which is the failure safe_resolve/2 and safe_call/1 exist to prevent.
+  # Repaint and carry on instead.
+  defp apply_nav_action(action, state, mode) do
+    Logger.error(
+      "[mob] unrecognised navigation action #{inspect(action)} was ignored. " <>
+        "If this followed a hot code push, restart the app to clear it."
+    )
+
+    repaint_current(state, mode)
+  end
+
   defp push_resolved(new_module, mount_params, state, mode) do
     case start_screen(new_module, mount_params, state) do
       {:ok, entry, state} ->

--- a/lib/mob/screen_case.ex
+++ b/lib/mob/screen_case.ex
@@ -205,7 +205,8 @@ defmodule Mob.ScreenCase do
 
     * in-BEAM: the destination of the nav action recorded on the socket by
       `Mob.Socket.push_screen/3` and friends. Destination-bearing actions
-      (`{:push, Dest, _}`, `{:reset, Dest, _}`, `{:pop_to, Dest}`) return
+      (`{:push, Dest, _}`, `{:reset, Dest, _}`, `{:reset, Dest, _, _}`,
+      `{:pop_to, Dest}`) return
       `Dest`; destinationless ones (`{:pop}`, `{:pop_to_root}`,
       `{:switch_tab, tab}`) return the raw action unchanged.
     * on device: the screen currently showing (`Mob.Test.screen/1`).
@@ -215,6 +216,7 @@ defmodule Mob.ScreenCase do
     case Map.get(socket.__mob__, :nav_action) do
       {:push, dest, _params} -> dest
       {:reset, dest, _params} -> dest
+      {:reset, dest, _params, _transition} -> dest
       {:pop_to, dest} -> dest
       other -> other
     end

--- a/lib/mob/socket.ex
+++ b/lib/mob/socket.ex
@@ -13,7 +13,7 @@ defmodule Mob.Socket do
   """
 
   @type platform :: :android | :ios
-  @type transition :: :push | :pop | :reset | :none
+  @type transition :: :push | :pop | :reset
 
   @type t :: %__MODULE__{
           assigns: map(),
@@ -177,20 +177,36 @@ defmodule Mob.Socket do
 
   Used for auth transitions (post-login → home with no back button to login).
   Pass `transition: :push` or `transition: :pop` when the reset still represents
-  directional movement, such as switching between custom tabs.
+  directional movement, such as switching between custom tabs. The default,
+  `:reset`, cross-fades.
+
+  Raises `ArgumentError` on any other transition — including `:none`, which
+  would replace the stack while telling the platform no navigation happened,
+  leaving the incoming screen wearing the outgoing one's view identities.
   """
-  @spec reset_to(t(), atom() | module(), map(), keyword()) :: t()
+  @spec reset_to(t(), atom() | module(), map(), [{:transition, transition()}]) :: t()
   def reset_to(socket, dest, params \\ %{}, opts \\ []) do
     transition = validate_transition!(Keyword.get(opts, :transition, :reset))
     put_mob(socket, :nav_action, {:reset, dest, params, transition})
   end
 
-  @valid_transitions [:push, :pop, :reset, :none]
+  @valid_transitions [:push, :pop, :reset]
 
-  # Checked here rather than left to the native layer. `set_transition/1`
-  # accepts any atom and the platform falls back to no animation for one it
-  # does not recognise, so a typo would silently produce the wrong motion with
-  # nothing to point at. Raising names the caller.
+  # Checked here rather than left to the native layer, for two different
+  # reasons.
+  #
+  # An unrecognised atom is merely wrong-looking: `set_transition/1` accepts any
+  # atom and the platform falls back to no animation, so a typo would silently
+  # produce the wrong motion with nothing to point at.
+  #
+  # `:none` is worse, and is rejected rather than allowed. It is the one value
+  # that suppresses the navigation-version bump (`ios/mob_nif.m`'s
+  # `mob_bump_frame_generation`, `MobViewModel.navVersion`, and the `.id()` on
+  # the root view). A reset stops every screen process and replaces the stack,
+  # so telling native it was not navigation leaves SwiftUI diffing the incoming
+  # tree into the outgoing screen's view identities — a `TextField` at the same
+  # position inherits the old screen's text and focus, and scroll offsets
+  # survive a stack that no longer exists.
   defp validate_transition!(transition) when transition in @valid_transitions, do: transition
 
   defp validate_transition!(other) do

--- a/lib/mob/socket.ex
+++ b/lib/mob/socket.ex
@@ -13,6 +13,7 @@ defmodule Mob.Socket do
   """
 
   @type platform :: :android | :ios
+  @type transition :: :push | :pop | :reset | :none
 
   @type t :: %__MODULE__{
           assigns: map(),
@@ -175,10 +176,27 @@ defmodule Mob.Socket do
   Replace the entire navigation stack with a single new screen.
 
   Used for auth transitions (post-login → home with no back button to login).
+  Pass `transition: :push` or `transition: :pop` when the reset still represents
+  directional movement, such as switching between custom tabs.
   """
-  @spec reset_to(t(), atom() | module(), map()) :: t()
-  def reset_to(socket, dest, params \\ %{}) do
-    put_mob(socket, :nav_action, {:reset, dest, params})
+  @spec reset_to(t(), atom() | module(), map(), keyword()) :: t()
+  def reset_to(socket, dest, params \\ %{}, opts \\ []) do
+    transition = validate_transition!(Keyword.get(opts, :transition, :reset))
+    put_mob(socket, :nav_action, {:reset, dest, params, transition})
+  end
+
+  @valid_transitions [:push, :pop, :reset, :none]
+
+  # Checked here rather than left to the native layer. `set_transition/1`
+  # accepts any atom and the platform falls back to no animation for one it
+  # does not recognise, so a typo would silently produce the wrong motion with
+  # nothing to point at. Raising names the caller.
+  defp validate_transition!(transition) when transition in @valid_transitions, do: transition
+
+  defp validate_transition!(other) do
+    raise ArgumentError,
+          "Mob.Socket.reset_to/4: invalid transition #{inspect(other)}. " <>
+            "Expected one of #{inspect(@valid_transitions)}."
   end
 
   @doc """

--- a/lib/mob/test.ex
+++ b/lib/mob/test.ex
@@ -337,9 +337,17 @@ defmodule Mob.Test do
   Replace the entire navigation stack with a new root screen. Synchronous.
 
   Use this to simulate auth transitions (e.g. login → home with no back button).
+
+  Pass `transition: :push` or `transition: :pop` to drive a directional reset,
+  matching `Mob.Socket.reset_to/4`.
   """
-  @spec reset_to(node(), module() | atom(), map()) :: :ok
-  def reset_to(node, dest, params \\ %{}), do: nav(node, {:reset, dest, params})
+  @spec reset_to(node(), module() | atom(), map(), [{:transition, atom()}]) :: :ok
+  def reset_to(node, dest, params \\ %{}, opts \\ []) do
+    case Keyword.get(opts, :transition) do
+      nil -> nav(node, {:reset, dest, params})
+      transition -> nav(node, {:reset, dest, params, transition})
+    end
+  end
 
   # ── Lists ─────────────────────────────────────────────────────────────────────
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mob.MixProject do
   def project do
     [
       app: :mob,
-      version: "0.7.33",
+      version: "0.7.34",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -12,6 +12,8 @@ defmodule Mob.Nav.ResetTransitionTest do
   """
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   defmodule HomeScreen do
     use Mob.Screen
 
@@ -81,7 +83,22 @@ defmodule Mob.Nav.ResetTransitionTest do
 
     # The render path reconciles components, which needs the registry's table.
     {:ok, components} = Mob.ComponentRegistry.start_link()
-    on_exit(fn -> stop_safely(components) end)
+
+    # Stop everything this file caused to start, not just what it started
+    # directly. Mob.Router brings up the Sender and Listener under their global
+    # names; leaving them behind is what produces cross-file ordering flakes.
+    on_exit(fn ->
+      stop_safely(components)
+
+      for name <- [Mob.Sender, Mob.Listener], pid = Process.whereis(name) do
+        stop_safely(pid)
+      end
+
+      case Process.whereis(RecordingNif) do
+        nil -> :ok
+        pid -> Agent.stop(pid)
+      end
+    end)
 
     case Process.whereis(RecordingNif) do
       nil -> RecordingNif.start()
@@ -119,6 +136,25 @@ defmodule Mob.Nav.ResetTransitionTest do
 
       assert Mob.Router.get_current_module(router) == OtherScreen
       assert Mob.Router.get_nav_history(router) == []
+    end
+  end
+
+  describe "an action shape the router does not know" do
+    test "is ignored rather than killing navigation and every screen", %{router: router} do
+      # Reachable during a hot code push: module loading is not atomic, so a
+      # screen already on new code can hand an action to a router still on old
+      # code. Unmatched, that is a FunctionClauseError in the owner.
+      screen = Mob.Router.get_screen_pid(router)
+
+      log =
+        capture_log(fn ->
+          :ok = GenServer.call(router, {:navigate, {:reset, OtherScreen, %{}, :push, :extra}})
+        end)
+
+      assert log =~ "unrecognised navigation action"
+      assert Process.alive?(router)
+      assert Process.alive?(screen)
+      assert Mob.Router.get_current_module(router) == HomeScreen
     end
   end
 

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -1,0 +1,135 @@
+defmodule Mob.Nav.ResetTransitionTest do
+  @moduledoc """
+  `reset_to/4`'s `:transition` option, end to end.
+
+  The socket-level tests assert the nav action's shape; these assert the thing
+  the option exists for — that the chosen animation actually reaches
+  `set_transition/1` on the native boundary. A reset that recorded `:push` in
+  its action and still painted `:reset` would pass a shape test and be useless.
+
+  Runs in `:render` with an injected NIF, since `do_paint` short-circuits under
+  `:no_render` and the transition would never be observable.
+  """
+  use ExUnit.Case, async: false
+
+  defmodule HomeScreen do
+    use Mob.Screen
+
+    @other Mob.Nav.ResetTransitionTest.OtherScreen
+
+    def mount(_params, _session, socket), do: {:ok, socket}
+    def render(_assigns), do: %{type: :text, props: %{text: "home"}, children: []}
+
+    def handle_event("reset_default", _, socket),
+      do: {:noreply, Mob.Socket.reset_to(socket, @other)}
+
+    def handle_event("reset_push", _, socket),
+      do: {:noreply, Mob.Socket.reset_to(socket, @other, %{}, transition: :push)}
+
+    def handle_event("reset_pop", _, socket),
+      do: {:noreply, Mob.Socket.reset_to(socket, @other, %{}, transition: :pop)}
+  end
+
+  defmodule OtherScreen do
+    use Mob.Screen
+    def mount(_params, _session, socket), do: {:ok, socket}
+    def render(_assigns), do: %{type: :text, props: %{text: "other"}, children: []}
+  end
+
+  defmodule DemoApp do
+    @behaviour Mob.App
+    import Mob.App
+    @home Mob.Nav.ResetTransitionTest.HomeScreen
+    def navigation(_), do: stack(:home, root: @home)
+  end
+
+  defmodule RecordingNif do
+    def start, do: Agent.start(fn -> [] end, name: __MODULE__)
+    def transitions, do: __MODULE__ |> Agent.get(& &1) |> Enum.reverse()
+    def reset, do: Agent.update(__MODULE__, fn _ -> [] end)
+
+    def platform, do: :android
+    def safe_area, do: {0.0, 0.0, 0.0, 0.0}
+    def take_launch_notification, do: :none
+    def clear_taps, do: :ok
+    def register_tap(_), do: 0
+    def set_root(_json), do: :ok
+
+    def set_transition(t) do
+      Agent.update(__MODULE__, &[t | &1])
+      :ok
+    end
+  end
+
+  defp stop_safely(pid) do
+    GenServer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  # The transition for the frame the reset painted, ignoring the initial mount.
+  defp last_transition do
+    Mob.Sender.sync(:infinity)
+    List.last(RecordingNif.transitions())
+  end
+
+  setup do
+    for name <- [Mob.Nav.Registry, Mob.Sender, Mob.Listener, Mob.ComponentRegistry],
+        pid = Process.whereis(name) do
+      stop_safely(pid)
+    end
+
+    # The render path reconciles components, which needs the registry's table.
+    {:ok, components} = Mob.ComponentRegistry.start_link()
+    on_exit(fn -> stop_safely(components) end)
+
+    case Process.whereis(RecordingNif) do
+      nil -> RecordingNif.start()
+      pid -> Agent.stop(pid) && RecordingNif.start()
+    end
+
+    {:ok, registry} = Mob.Nav.Registry.start_link(DemoApp)
+    on_exit(fn -> stop_safely(registry) end)
+
+    {:ok, router} = Mob.Router.start_root(HomeScreen, %{}, nif: RecordingNif)
+    on_exit(fn -> stop_safely(router) end)
+
+    RecordingNif.reset()
+    %{router: router}
+  end
+
+  describe "the chosen transition reaches the native boundary" do
+    test "a plain reset still cross-fades", %{router: router} do
+      Mob.Router.dispatch(router, "reset_default", %{})
+      assert last_transition() == :reset
+    end
+
+    test "transition: :push paints a push", %{router: router} do
+      Mob.Router.dispatch(router, "reset_push", %{})
+      assert last_transition() == :push
+    end
+
+    test "transition: :pop paints a pop", %{router: router} do
+      Mob.Router.dispatch(router, "reset_pop", %{})
+      assert last_transition() == :pop
+    end
+
+    test "the stack is still replaced, whatever the animation", %{router: router} do
+      Mob.Router.dispatch(router, "reset_push", %{})
+
+      assert Mob.Router.get_current_module(router) == OtherScreen
+      assert Mob.Router.get_nav_history(router) == []
+    end
+  end
+
+  describe "the legacy three-element action" do
+    test "still resets, and still cross-fades", %{router: router} do
+      # Arrives from Mob.Test.reset_to/3 and from any socket built before a hot
+      # code push. Dropping it would break navigation across an upgrade.
+      :ok = GenServer.call(router, {:navigate, {:reset, OtherScreen, %{}}})
+
+      assert last_transition() == :reset
+      assert Mob.Router.get_current_module(router) == OtherScreen
+    end
+  end
+end

--- a/test/mob/screen_case_test.exs
+++ b/test/mob/screen_case_test.exs
@@ -175,9 +175,15 @@ defmodule Mob.ScreenCaseTest do
       assert navigated_to(view) == CounterScreen
     end
 
-    test "records a reset as the destination module" do
+    test "records a legacy three-element reset as the destination module" do
+      # Mob.Socket only emits the four-element form now, so this shape reaches
+      # navigated_to/1 only from a socket built before a hot code push. Built by
+      # hand because nothing in-repo produces it any more — without that the
+      # clause is dead code that a green suite would not notice.
       view = NavScreen |> mount_screen() |> render_event("reset")
-      assert navigated_to(view) == CounterScreen
+      legacy = Mob.Socket.put_mob(view.socket, :nav_action, {:reset, CounterScreen, %{}})
+
+      assert navigated_to(%{view | socket: legacy}) == CounterScreen
     end
 
     test "records a reset carrying a transition as the destination module" do

--- a/test/mob/screen_case_test.exs
+++ b/test/mob/screen_case_test.exs
@@ -54,6 +54,14 @@ defmodule Mob.ScreenCaseTest do
       {:noreply, Mob.Socket.push_screen(socket, CounterScreen)}
     end
 
+    def handle_event("reset", _params, socket) do
+      {:noreply, Mob.Socket.reset_to(socket, CounterScreen)}
+    end
+
+    def handle_event("reset_push", _params, socket) do
+      {:noreply, Mob.Socket.reset_to(socket, CounterScreen, %{}, transition: :push)}
+    end
+
     def handle_info({:tap, :go}, socket) do
       {:noreply, Mob.Socket.push_screen(socket, CounterScreen)}
     end
@@ -164,6 +172,20 @@ defmodule Mob.ScreenCaseTest do
 
     test "records a push from a tap (handle_info) as the destination module" do
       view = NavScreen |> mount_screen() |> render_info({:tap, :go})
+      assert navigated_to(view) == CounterScreen
+    end
+
+    test "records a reset as the destination module" do
+      view = NavScreen |> mount_screen() |> render_event("reset")
+      assert navigated_to(view) == CounterScreen
+    end
+
+    test "records a reset carrying a transition as the destination module" do
+      # reset_to/4 grew a fourth element for the transition. Matching only the
+      # three-element shape here silently returned the raw action tuple, so
+      # `assert navigated_to(view) == SomeScreen` failed for every caller who
+      # passed a transition — in a helper whose whole job is that assertion.
+      view = NavScreen |> mount_screen() |> render_event("reset_push")
       assert navigated_to(view) == CounterScreen
     end
   end

--- a/test/mob/socket_test.exs
+++ b/test/mob/socket_test.exs
@@ -128,4 +128,38 @@ defmodule Mob.SocketTest do
       assert socket.__mob__.root_view == :some_ref
     end
   end
+
+  describe "reset_to/4" do
+    test "keeps the reset transition by default" do
+      socket = Socket.new(MyScreen) |> Socket.reset_to(OtherScreen, %{source: :login})
+
+      assert socket.__mob__.nav_action ==
+               {:reset, OtherScreen, %{source: :login}, :reset}
+    end
+
+    test "accepts a directional transition without changing the reset action" do
+      socket =
+        Socket.new(MyScreen)
+        |> Socket.reset_to(OtherScreen, %{tab: :portfolio}, transition: :push)
+
+      assert socket.__mob__.nav_action ==
+               {:reset, OtherScreen, %{tab: :portfolio}, :push}
+    end
+
+    test "rejects a transition the platform cannot render" do
+      # set_transition/1 accepts any atom and the platform falls back to no
+      # animation for one it does not recognise, so an unchecked typo would
+      # silently produce the wrong motion with nothing to point at.
+      assert_raise ArgumentError, ~r/invalid transition :puhs/, fn ->
+        Socket.new(MyScreen) |> Socket.reset_to(OtherScreen, %{}, transition: :puhs)
+      end
+    end
+
+    test "accepts every transition the renderer understands" do
+      for t <- [:push, :pop, :reset, :none] do
+        socket = Socket.new(MyScreen) |> Socket.reset_to(OtherScreen, %{}, transition: t)
+        assert {:reset, OtherScreen, %{}, ^t} = socket.__mob__.nav_action
+      end
+    end
+  end
 end

--- a/test/mob/socket_test.exs
+++ b/test/mob/socket_test.exs
@@ -155,10 +155,20 @@ defmodule Mob.SocketTest do
       end
     end
 
-    test "accepts every transition the renderer understands" do
-      for t <- [:push, :pop, :reset, :none] do
+    test "accepts the directional transitions and the default" do
+      for t <- [:push, :pop, :reset] do
         socket = Socket.new(MyScreen) |> Socket.reset_to(OtherScreen, %{}, transition: t)
         assert {:reset, OtherScreen, %{}, ^t} = socket.__mob__.nav_action
+      end
+    end
+
+    test "rejects :none, which would replace the stack without telling the platform" do
+      # :none suppresses the navigation-version bump, so SwiftUI diffs the
+      # incoming tree into the outgoing screen's view identities — a TextField
+      # at the same position keeps the old screen's text and focus across a
+      # stack that no longer exists.
+      assert_raise ArgumentError, ~r/invalid transition :none/, fn ->
+        Socket.new(MyScreen) |> Socket.reset_to(OtherScreen, %{}, transition: :none)
       end
     end
   end


### PR DESCRIPTION
## Summary

- add an optional navigation transition to `Mob.Socket.reset_to/4`
- preserve stack-reset semantics while allowing directional `:push` and `:pop` animations
- retain compatibility with legacy three-element reset actions
- document the custom-tab use case and cover the socket contract

## Why

Custom tab bars sometimes replace the active navigation stack while still
needing direction-aware motion. Previously `reset_to/3` always selected the
reset animation, so consumers could not express that distinction without
changing the stack operation.

## Verification

- `mix test` — 1,235 passed, 38 excluded
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `git diff --check`
