### PR TITLE
fix(ios): honor fixed-height boxes

### DIFF
--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -767,6 +767,10 @@ private struct MobBox: View {
                     height: node.fixedHeight > 0 ? CGFloat(node.fixedHeight) : nil,
                     alignment: alignment
                 )
+            } else if node.fixedHeight > 0 {
+                stack
+                    .frame(height: CGFloat(node.fixedHeight), alignment: alignment)
+                    .frame(maxWidth: .infinity, alignment: alignment)
             } else if node.fillHeight {
                 // fill_height: true is what lets a wrapping box stretch to the
                 // viewport so center alignment lands on the visible midpoint

--- a/test/mob/native_box_layout_test.exs
+++ b/test/mob/native_box_layout_test.exs
@@ -1,0 +1,19 @@
+# These source-contract tests guard native SwiftUI behavior that Elixir cannot execute.
+# credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+defmodule Mob.NativeBoxLayoutTest do
+  use ExUnit.Case, async: true
+
+  @root Path.expand("../..", __DIR__)
+
+  test "iOS box applies a fixed height without a fixed width" do
+    source = File.read!(Path.join(@root, "ios/MobRootView.swift"))
+
+    assert source =~
+             "            } else if node.fixedHeight > 0 {\n" <>
+               "                stack\n" <>
+               "                    .frame(height: CGFloat(node.fixedHeight), " <>
+               "alignment: alignment)\n" <>
+               "                    .frame(maxWidth: .infinity, alignment: alignment)\n" <>
+               "            } else if node.fillHeight {\n"
+  end
+end


### PR DESCRIPTION
## Summary

- apply `fixedHeight` when a MobBox has no fixed width
- preserve the existing full-width behavior for width-less boxes
- add a focused native source-contract regression

## Verification

- `mix format`
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix test` (1,259 passed, 38 excluded)
- native iOS simulator build/install on pool-ios-3
- `Mob.Test.frame/2`: height-120 box `{0.0, 62.0, 402.0, 120.0}`; following height-40 reference `{0.0, 182.0, 402.0, 40.0}`