### PR TITLE
MOB-133: grow the tap tables on demand instead of capping at 256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Fixed
+- **Interactive elements past the 256th no longer silently stop responding**
+  (MOB-133). The tap registry was a fixed 256-entry pair of tables and the
+  handle encoding gave slots only 8 bits, so every element past that got the
+  `-1` "no handler" sentinel — it still rendered, still looked tappable, and did
+  nothing. On a 200-row list that was **359 of 615** elements. Slots now get 12
+  bits (4096) and the tables are allocated to fit, starting at the old 256 and
+  doubling on demand, so no app pays for capacity it does not use. Verified on
+  both platforms by tapping an element past the old cap and watching the counter
+  move — Android row #188 (slot ~564) and iOS row #92 (slot ~283). See
+  `decisions/2026-09-02-tap-tables-grow-on-demand.md`.
+
+  The generation field drops from 23 bits to 19 to pay for the slot bits: at
+  60 fps that is ~2.4 hours before it wraps, and the wrap was already handled
+  modularly.
+
 Everything below is unreleased work from the MOB-124 rendering-performance
 epic. Nothing here has shipped to Hex.
 

--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -1121,8 +1121,13 @@ fn snapChangeTap(handle: c_int, env: ?*erts.ErlNifEnv) ?TapSnap {
         logd_nif("rejected stale event handle {d}", .{handle});
         return null;
     };
+    // `.?` rather than `orelse return null`: this function unlocks explicitly on
+    // every path (no defer), so an early return here would leave tap_mutex held
+    // and freeze every later tap, gesture and render. The unwrap is safe because
+    // tap_active_count is only ever set from a build count that a successful
+    // tapGrowLocked produced, so a nonzero count implies the table exists.
     const active = if (decoded.slot < @as(usize, @intCast(tap_active_count)))
-        &(tap_tables[tap_active] orelse return null)[decoded.slot]
+        &(tap_tables[tap_active].?)[decoded.slot]
     else {
         erts.enif_mutex_unlock(tap_mutex);
         logd_nif("rejected stale event handle {d}", .{handle});
@@ -1679,14 +1684,26 @@ export fn nif_set_root(
     // handlers into 1 - tap_active, so make that table active now. Events for
     // the new tree (delivered to Compose just below) resolve against it, and
     // any send racing this swap sees a complete table on either side.
+    // Bound the commit by what the tables can actually hold, not by
+    // tap_build_count alone. Only clear_taps resets that count, so a set_root
+    // arriving without an intervening clear_taps carries the previous frame's
+    // value — harmless when both tables were a fixed 256, but the two are now
+    // separate allocations that can differ in size, and an unbounded loop reads
+    // (and later writes, once tap_active_count is set from it) past the end of
+    // whichever is smaller.
+    const build_cap = tap_table_capacity[@intCast(1 - tap_active)];
+    const prev_cap = tap_table_capacity[@intCast(tap_active)];
+    const wanted = @as(usize, @intCast(tap_build_count));
+    const committed = if (wanted < build_cap) wanted else build_cap;
+
     // Both tables are null until the first register_tap allocates them; a frame
     // with no interactive nodes never does, and has nothing to carry over.
     if (tap_tables[1 - tap_active]) |build| {
         var slot_index: usize = 0;
-        while (slot_index < @as(usize, @intCast(tap_build_count))) : (slot_index += 1) {
+        while (slot_index < committed) : (slot_index += 1) {
             const current = &build[slot_index];
             if (tap_tables[tap_active]) |previous| {
-                if (slot_index < @as(usize, @intCast(tap_active_count))) {
+                if (slot_index < @as(usize, @intCast(tap_active_count)) and slot_index < prev_cap) {
                     const prior = &previous[slot_index];
                     if (prior.tag_env != null and prior.pid.pid == current.pid.pid and
                         erts.enif_compare(prior.tag, current.tag) == 0)
@@ -1705,8 +1722,12 @@ export fn nif_set_root(
     tap_exhausted_count = 0;
 
     tap_active = 1 - tap_active;
-    tap_active_count = tap_build_count;
+    tap_active_count = @intCast(committed);
     tap_table_generations[tap_active] = tap_build_generation;
+    // Reset here as well as in clear_taps, so a second set_root without an
+    // intervening clear_taps commits an empty table rather than re-committing
+    // this frame's handlers against whatever the other table now holds.
+    tap_build_count = 0;
     erts.enif_mutex_unlock(tap_mutex);
 
     if (exhausted_this_frame > 0) {

--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -995,7 +995,41 @@ const ComponentHandle = extern struct {
 // table and got dropped — worse the later a widget registered (e.g. a canvas
 // after a row of buttons). With the swap a concurrent send always sees a
 // complete table (old or new), never a partial one.
-var tap_tables: [2][MAX_TAP_HANDLES]TapHandle = std.mem.zeroes([2][MAX_TAP_HANDLES]TapHandle);
+// Grown on demand rather than fixed. These were 256 entries, and a 200-row list
+// overran that: every interactive element past the cap got the -1 "no handler"
+// sentinel and silently stopped responding. A fixed array big enough for that
+// case would be ~700 KB resident in every app, nearly all of which register a
+// few dozen handles, so it is allocated to fit instead. MAX_TAP_HANDLES is the
+// ceiling the handle encoding can address, not a target.
+var tap_tables: [2]?[*]TapHandle = .{ null, null };
+var tap_table_capacity: [2]usize = .{ 0, 0 };
+const TAP_INITIAL_CAPACITY: usize = 256;
+
+/// Grow one table to hold at least `needed` slots. Caller holds tap_mutex,
+/// which is what makes this safe: every reader resolves under the same lock, so
+/// nobody can hold a pointer into a table while it moves. Only the table being
+/// built is grown mid-frame; the active one is untouched until the swap.
+fn tapGrowLocked(which: usize, needed: usize) bool {
+    if (needed <= tap_table_capacity[which]) return true;
+    if (needed > MAX_TAP_HANDLES) return false;
+
+    var cap = if (tap_table_capacity[which] == 0) TAP_INITIAL_CAPACITY else tap_table_capacity[which];
+    while (cap < needed) cap *= 2;
+    if (cap > MAX_TAP_HANDLES) cap = MAX_TAP_HANDLES;
+
+    const bytes = cap * @sizeOf(TapHandle);
+    const grown = jni.realloc(@ptrCast(tap_tables[which]), bytes) orelse return false;
+    const table: [*]TapHandle = @ptrCast(@alignCast(grown));
+
+    // Zero the new tail: clearTaps and the resolvers key off tag_env being null
+    // to decide a slot is free, and realloc leaves it uninitialised.
+    var i = tap_table_capacity[which];
+    while (i < cap) : (i += 1) table[i] = std.mem.zeroes(TapHandle);
+
+    tap_tables[which] = table;
+    tap_table_capacity[which] = cap;
+    return true;
+}
 // How many slots of each table were actually written, so clearTaps only walks
 // those rather than the whole cap on every frame.
 var tap_table_used: [2]usize = .{ 0, 0 };
@@ -1054,7 +1088,7 @@ fn resolveActiveTapLocked(handle: c_int) ?*TapHandle {
         tap_table_generations[tap_active],
         @intCast(tap_active_count),
     ) orelse return null;
-    const tap = &tap_tables[tap_active][slot_index];
+    const tap = &(tap_tables[tap_active] orelse return null)[slot_index];
     return if (tap.tag_env == null) null else tap;
 }
 
@@ -1088,7 +1122,7 @@ fn snapChangeTap(handle: c_int, env: ?*erts.ErlNifEnv) ?TapSnap {
         return null;
     };
     const active = if (decoded.slot < @as(usize, @intCast(tap_active_count)))
-        &tap_tables[tap_active][decoded.slot]
+        &(tap_tables[tap_active] orelse return null)[decoded.slot]
     else {
         erts.enif_mutex_unlock(tap_mutex);
         logd_nif("rejected stale event handle {d}", .{handle});
@@ -1645,17 +1679,21 @@ export fn nif_set_root(
     // handlers into 1 - tap_active, so make that table active now. Events for
     // the new tree (delivered to Compose just below) resolve against it, and
     // any send racing this swap sees a complete table on either side.
-    const previous = &tap_tables[tap_active];
-    const build = &tap_tables[1 - tap_active];
-    var slot_index: usize = 0;
-    while (slot_index < @as(usize, @intCast(tap_build_count))) : (slot_index += 1) {
-        const current = &build[slot_index];
-        if (slot_index < @as(usize, @intCast(tap_active_count))) {
-            const prior = &previous[slot_index];
-            if (prior.tag_env != null and prior.pid.pid == current.pid.pid and
-                erts.enif_compare(prior.tag, current.tag) == 0)
-            {
-                current.identity_start_generation = prior.identity_start_generation;
+    // Both tables are null until the first register_tap allocates them; a frame
+    // with no interactive nodes never does, and has nothing to carry over.
+    if (tap_tables[1 - tap_active]) |build| {
+        var slot_index: usize = 0;
+        while (slot_index < @as(usize, @intCast(tap_build_count))) : (slot_index += 1) {
+            const current = &build[slot_index];
+            if (tap_tables[tap_active]) |previous| {
+                if (slot_index < @as(usize, @intCast(tap_active_count))) {
+                    const prior = &previous[slot_index];
+                    if (prior.tag_env != null and prior.pid.pid == current.pid.pid and
+                        erts.enif_compare(prior.tag, current.tag) == 0)
+                    {
+                        current.identity_start_generation = prior.identity_start_generation;
+                    }
+                }
             }
         }
     }
@@ -1719,7 +1757,9 @@ export fn nif_register_tap(
 
     erts.enif_mutex_lock(tap_mutex);
     defer erts.enif_mutex_unlock(tap_mutex);
-    if (tap_build_count >= @as(c_int, @intCast(MAX_TAP_HANDLES))) {
+    if (tap_build_count >= @as(c_int, @intCast(MAX_TAP_HANDLES)) or
+        !tapGrowLocked(@intCast(1 - tap_active), @as(usize, @intCast(tap_build_count)) + 1))
+    {
         // MOB-100 follow-up: this used to be erts.badarg(env), which
         // crashed Mob.Renderer.render/3 (and the whole screen process) the
         // same way a full component pool used to crash Mob.ComponentServer
@@ -1747,7 +1787,7 @@ export fn nif_register_tap(
         loge_nif("register_tap: unable to allocate tag environment", .{});
         return erts.atom(env, "error");
     };
-    const slot = &tap_tables[1 - tap_active][slot_index];
+    const slot = &(tap_tables[1 - tap_active].?)[slot_index];
     slot.pid = pid;
     slot.tag_env = tag_env;
     slot.tag = erts.enif_make_copy(slot.tag_env, tag_term);
@@ -1781,9 +1821,15 @@ export fn nif_clear_taps(
     // Prepare the INACTIVE (building) table for a fresh frame; leave the active
     // table intact so concurrent mob_send_* keep resolving the last committed
     // frame. The freshly built table is swapped in at set_root.
-    const build = &tap_tables[1 - tap_active];
     var i: usize = 0;
     const used = tap_table_used[@intCast(1 - tap_active)];
+    const build = tap_tables[1 - tap_active] orelse {
+        // Never allocated, so nothing to free and nothing to reset.
+        tap_table_used[@intCast(1 - tap_active)] = 0;
+        tap_build_count = 0;
+        tap_exhausted_count = 0;
+        return erts.ok(env);
+    };
     while (i < used) : (i += 1) {
         const h = &build[i];
         if (h.tag_env != null) {

--- a/android/jni/mob_zig.zig
+++ b/android/jni/mob_zig.zig
@@ -105,6 +105,7 @@ pub fn nowNs() i64 {
 // the NDK clang link step anyway, so calling malloc/free directly is
 // equivalent and skips the link-time guard.
 pub extern fn malloc(size: usize) ?*anyopaque;
+pub extern fn realloc(ptr: ?*anyopaque, size: usize) ?*anyopaque;
 pub extern fn free(ptr: ?*anyopaque) void;
 pub extern fn strlen(s: [*:0]const u8) usize;
 pub extern fn strdup(s: [*:0]const u8) ?[*:0]u8;

--- a/android/jni/tap_handle_codec.zig
+++ b/android/jni/tap_handle_codec.zig
@@ -1,7 +1,18 @@
 const std = @import("std");
 
-pub const slot_count: usize = 256;
-pub const max_generation: u32 = 0x7fffff;
+// A handle is a positive i32, so 31 bits to split between slot and generation.
+// Slots were 8 bits (256), which a 200-row list overruns — every element past
+// the cap got the -1 sentinel and silently stopped responding. 12 bits gives
+// 4096, leaving 19 for the generation.
+//
+// Generation wrap is what the bit split trades against: at 60 fps, 2^19 frames
+// is about 2.4 hours of continuous rendering before it wraps, and generationAge
+// below is modular so a wrap is handled rather than merely survived. A handle
+// is only meaningful for the frame it was minted in (or a run of frames where
+// its PID and tag are unchanged), so hours of headroom is ample.
+pub const slot_bits: u5 = 12;
+pub const slot_count: usize = 1 << slot_bits;
+pub const max_generation: u32 = (1 << (31 - @as(u32, slot_bits))) - 1;
 
 pub const Decoded = struct {
     generation: u32,
@@ -10,16 +21,16 @@ pub const Decoded = struct {
 
 pub fn encode(generation: u32, slot: usize) ?i32 {
     if (generation == 0 or generation > max_generation or slot >= slot_count) return null;
-    const raw = (generation << 8) | @as(u32, @intCast(slot));
+    const raw = (generation << slot_bits) | @as(u32, @intCast(slot));
     return @intCast(raw);
 }
 
 pub fn decode(handle: i32) ?Decoded {
     if (handle <= 0) return null;
     const raw: u32 = @intCast(handle);
-    const generation = raw >> 8;
+    const generation = raw >> slot_bits;
     if (generation == 0) return null;
-    return .{ .generation = generation, .slot = raw & 0xff };
+    return .{ .generation = generation, .slot = raw & (slot_count - 1) };
 }
 
 pub fn slotForActive(handle: i32, active_generation: u32, active_count: usize) ?usize {
@@ -95,4 +106,47 @@ test "identity range spans multiple renders and resets on replacement" {
     try std.testing.expect(generationWithinIdentity(max_generation, max_generation - 1, 2));
     try std.testing.expect(generationWithinIdentity(1, max_generation - 1, 2));
     try std.testing.expect(!generationWithinIdentity(max_generation - 2, max_generation - 1, 2));
+}
+
+test "the bit split leaves a handle positive and keeps slot and generation independent" {
+    // 31 usable bits in a positive i32. If these ever stop summing to 31, one
+    // field silently starts eating the other's range.
+    try std.testing.expectEqual(@as(u32, 31), @as(u32, slot_bits) + 19);
+    try std.testing.expectEqual(@as(usize, 4096), slot_count);
+    try std.testing.expectEqual(@as(u32, 0x7ffff), max_generation);
+
+    // Every slot round-trips under the highest and lowest legal generations,
+    // and the handle stays positive — a negative handle is the -1 "no handler"
+    // sentinel, so a collision there would make a live element look inert.
+    for ([_]u32{ 1, 2, max_generation / 2, max_generation }) |gen| {
+        for ([_]usize{ 0, 1, 255, 256, 4094, slot_count - 1 }) |slot| {
+            const h = encode(gen, slot).?;
+            try std.testing.expect(h > 0);
+            const d = decode(h).?;
+            try std.testing.expectEqual(gen, d.generation);
+            try std.testing.expectEqual(slot, d.slot);
+        }
+    }
+}
+
+test "a slot past the limit is refused rather than aliasing another slot" {
+    // Before this widening the limit was 256 and everything past it got the
+    // -1 sentinel and stopped responding. The limit is higher now, but it is
+    // still a limit, and overrunning it must not silently wrap onto slot 0.
+    try std.testing.expect(encode(1, slot_count) == null);
+    try std.testing.expect(encode(1, slot_count + 1) == null);
+    try std.testing.expect(encode(1, 99_999) == null);
+    try std.testing.expect(encode(max_generation + 1, 0) == null);
+    try std.testing.expect(encode(0, 0) == null);
+}
+
+test "handles minted under the old 8-bit split do not resolve as valid today" {
+    // Purely a documentation test: an 8-bit-split handle decodes to a different
+    // (generation, slot) pair under the 12-bit split, so a stale handle from a
+    // pre-upgrade build cannot be mistaken for a live one. Generations are
+    // per-render and start at 1 on boot, so this can only matter across a hot
+    // code swap, but the property is cheap to state.
+    const old_style: i32 = (42 << 8) | 7; // generation 42, slot 7, old split
+    const d = decode(old_style).?;
+    try std.testing.expect(d.generation != 42 or d.slot != 7);
 }

--- a/decisions/2026-09-02-tap-tables-grow-on-demand.md
+++ b/decisions/2026-09-02-tap-tables-grow-on-demand.md
@@ -1,0 +1,88 @@
+# The tap-handle tables grow on demand
+
+- Date: 2026-09-02
+- Status: accepted
+- Implements: MOB-133 (the half that was left open)
+- Builds on: `2026-09-02-register-tap-owns-the-table-high-water-mark.md`
+
+## Context
+
+The tap registry was a fixed `TapHandle tap_tables[2][256]`, and the handle
+encoding packed 8 slot bits into a positive `int32` alongside 23 generation
+bits. Anything past slot 255 got the `-1` "no handler" sentinel from
+`register_tap`.
+
+That is not a graceful degradation. The element still renders, still looks
+tappable, and simply **does nothing** — no error, no crash, nothing in the UI to
+suggest the tap was ever wired up. On the benchmark screen it was **359 of 615**
+interactive elements: a 200-row list where more than half the buttons, fields
+and toggles were inert.
+
+The earlier half of MOB-133 fixed the *reporting* — the exhaustion path used to
+`NSLog` once per overflowing element, 359 synchronous system-log writes per
+frame, which was 13 ms of a 27 ms frame. That made the failure cheap to observe.
+It did not make the elements work.
+
+## Decision
+
+Two changes, and they have to happen together.
+
+**The handle encoding gives slots 12 bits instead of 8.** A handle is a positive
+`int32`, so there are 31 bits to divide. Slots go from 256 to **4096** and the
+generation drops from 23 bits to 19. That trade is what the split costs: at
+60 fps, 2^19 frames is about 2.4 hours of continuous rendering before the
+generation wraps, and `generationAge` is modular so a wrap is handled rather
+than merely survived. A handle is only meaningful for the frame it was minted in
+(or a run of frames where its PID and tag are unchanged), so hours of headroom
+is ample.
+
+**The tables are allocated to fit rather than declared at the ceiling.** A fixed
+4096-entry pair would be roughly 700 KB resident in every app, and almost every
+app registers a few dozen handles. They start at 256 — the old size, so no app
+pays more than it did — and double on demand up to the encoding's ceiling.
+
+Growth is safe because of an invariant that already held: **every reader
+resolves under `tap_mutex`**. `mob_resolve_active_tap_locked` and its Zig twin
+are only ever called with the lock held, and the pointers they return are used
+before it is released. Growth takes the same lock, so nothing can be holding a
+pointer into a table while it moves. Only the table being *built* is grown
+mid-frame; the active one is untouched until the swap in `set_root` repoints
+`tap_handles` at it.
+
+One ordering detail matters and is easy to get wrong: `register_tap` must grow
+**before** it caches `TapHandle *build = tap_tables[1 - tap_active]`. Caching
+first and growing second is a use-after-realloc.
+
+## Verification
+
+Both platforms, on real hardware, end to end — not just "registers without
+complaint" but "responds when tapped":
+
+- **Android (Moto G Power)**: 200 rows registers 610 handles and 500 rows
+  registers 1510, with **zero** exhaustion reports where there were 359 per
+  frame. Scrolled to row **#188** — slot ≈ 564, well past the old cap — and
+  tapped its button twice; the screen's tap counter went 0 → 1 → 2.
+- **iOS (simulator)**: 615 and 1515 handles, zero exhaustion. Scrolled to row
+  **#92** — slot ≈ 283 — and tapped twice; the header counter read `t/n/g=2/0/0`.
+
+Worth stating why the tap, not just the count: `Mob.RenderStats`'s `taps` counts
+handle-valued props, and `-1` is an integer. It read 615 *before* this fix too.
+The exhaustion count is the honest signal for registration, and only an actual
+tap proves the handle resolves.
+
+The codec has eight unit tests, three of them new: the bit split sums to 31 and
+every slot round-trips under the lowest and highest legal generations with the
+handle staying positive (a negative handle would collide with the `-1`
+sentinel); a slot past the limit is refused rather than wrapping onto slot 0;
+and an old 8-bit-split handle does not decode to a live (generation, slot) pair.
+
+## Consequences
+
+- The ceiling is now 4096 rather than 256, but it is still a ceiling. Past it the
+  sentinel path and the once-per-frame report still apply — a screen with more
+  than 4096 interactive elements is telling you something else is wrong.
+- Two `realloc`-backed tables mean allocation failure is now possible where it
+  was not. It is treated exactly like exhaustion: the sentinel, and the report.
+- The real fix for a list this dense is to compose fewer of it — see MOB-128's
+  opt-in lazy scroll, which registers only what is on screen. This change means
+  the app degrades honestly rather than silently while that is adopted.

--- a/decisions/2026-09-02-tap-tables-grow-on-demand.md
+++ b/decisions/2026-09-02-tap-tables-grow-on-demand.md
@@ -29,12 +29,21 @@ Two changes, and they have to happen together.
 
 **The handle encoding gives slots 12 bits instead of 8.** A handle is a positive
 `int32`, so there are 31 bits to divide. Slots go from 256 to **4096** and the
-generation drops from 23 bits to 19. That trade is what the split costs: at
-60 fps, 2^19 frames is about 2.4 hours of continuous rendering before the
-generation wraps, and `generationAge` is modular so a wrap is handled rather
-than merely survived. A handle is only meaningful for the frame it was minted in
-(or a run of frames where its PID and tag are unchanged), so hours of headroom
-is ample.
+generation drops from 23 bits to 19. That trade is what the split costs, and it is worth
+stating precisely rather than waving at.
+
+At 60 fps, 2^19 frames is about **2.4 hours** of continuous rendering before the
+generation wraps — down from 38.8 hours with 23 bits, a 16x reduction. After a
+full cycle a stale handle is *numerically identical* to a fresh one, so
+`slotForActive`'s exact-generation match cannot tell them apart. `generationAge`
+being modular makes the arithmetic correct across the wrap; it does **not**
+prevent that alias, and an earlier draft of this record implied it did.
+
+What keeps it theoretical is that reaching it needs the UI layer to hold a
+handle unused for a full cycle — which `mob_unregister_frame` and the frame
+generation machinery already work against — and a handle is only meaningful for
+the frame it was minted in, or a run of frames where its PID and tag are
+unchanged. Small, real, and accepted; not covered.
 
 **The tables are allocated to fit rather than declared at the ceiling.** A fixed
 4096-entry pair would be roughly 700 KB resident in every app, and almost every

--- a/guides/components.md
+++ b/guides/components.md
@@ -787,15 +787,20 @@ end
 
 ### Handle limits
 
-The native layer stores event handlers in fixed-size pools, per committed
-frame:
+The native layer stores event handlers per committed frame:
 
-- **256 interactive handles per frame.** Every `on_tap`, `on_change`,
-  `on_focus`, etc. in the rendered tree registers one handle. Past the cap,
-  the element still renders but its handler is silently unwired (a native
-  error is logged); it does not crash the screen. In practice only an
-  unvirtualized long list or a very large form gets there — use `:list` /
-  `:lazy_list` for long content.
+- **4096 interactive handles per frame.** Every `on_tap`, `on_change`,
+  `on_focus`, etc. in the rendered tree registers one handle. The tables grow
+  on demand — they start small and are allocated to fit — so an app that uses
+  a few dozen handles pays for a few dozen. Past 4096 the element still renders
+  but its handler is silently unwired, and the count of unwired elements is
+  logged once per frame; it does not crash the screen.
+
+  This was 256 until MOB-133, which is low enough that an ordinary long list
+  reached it: a 200-row list with three interactive elements per row left more
+  than half of them inert. If you are anywhere near the current limit, prefer
+  `:list` / `:lazy_list`, or `lazy: true` on a `:scroll`, so only what is on
+  screen registers at all.
 - **256 native component slots.** `Mob.UI.native_view/2` / `Mob.Component`
   instances each take a slot. A full pool returns
   `{:error, :component_slots_exhausted}`; the framework logs and fails just

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -68,10 +68,21 @@ void mob_set_startup_error(const char *error) {
 }
 
 // ── Tap handle registry ───────────────────────────────────────────────────────
-// Cleared before every render. Max 256 tappable elements per frame.
-
-#define MAX_TAP_HANDLES 256
-#define MAX_EVENT_GENERATION 0x7fffffU
+// Cleared before every render.
+//
+// The tables GROW ON DEMAND rather than being a fixed array. They used to be
+// 256 entries, and a 200-row list overran that: every interactive element past
+// the cap got the -1 "no handler" sentinel and silently stopped responding —
+// 359 of 615 on the screen that surfaced this. A fixed array big enough for
+// that case would be ~700 KB resident in every app, nearly all of which
+// register a few dozen handles, so it is allocated to fit instead.
+//
+// MOB_TAP_SLOT_LIMIT is the ceiling the handle encoding can address (12 slot
+// bits), not a target. Beyond it the sentinel path still applies and set_root
+// still reports the count once per frame.
+#define MOB_TAP_SLOT_LIMIT 4096
+#define MOB_TAP_INITIAL_CAPACITY 256
+#define MAX_EVENT_GENERATION 0x7ffffU
 
 typedef struct {
     ErlNifPid pid;
@@ -100,14 +111,15 @@ typedef struct {
 // the INACTIVE table via register_tap (tap_build_count) and set_root swaps it in
 // atomically under tap_mutex, so a concurrent high-frequency send (drag/scroll)
 // never observes a half-rebuilt table.
-static TapHandle tap_tables[2][MAX_TAP_HANDLES];
+static TapHandle *tap_tables[2] = {NULL, NULL};
+static int tap_table_capacity[2] = {0, 0};
 static int tap_active = 0;
-static TapHandle *tap_handles = tap_tables[0]; // active table (readers use this)
-static int tap_handle_next = 0;                // active committed count (readers' bound)
-static int tap_build_count = 0;                // cursor into the building table
+static TapHandle *tap_handles = NULL; // active table (readers use this)
+static int tap_handle_next = 0;       // active committed count (readers' bound)
+static int tap_build_count = 0;       // cursor into the building table
 static uint32_t tap_table_generations[2] = {0, 0};
 // How many slots of each table were actually written, so clear_taps only walks
-// those. Walking all MAX_TAP_HANDLES every frame is wasted work at any cap and
+// those. Walking the whole table every frame is wasted work at any cap and
 // would scale with the cap if it were ever raised.
 static int tap_table_used[2] = {0, 0};
 // Exhausted registrations in the frame being built. Counted rather than logged
@@ -138,18 +150,52 @@ static int mob_generation_within_identity(uint32_t handle_generation,
            mob_generation_age(active_generation, identity_start_generation);
 }
 
+// Grow one table to hold at least `needed` slots. Caller holds tap_mutex, which
+// is what makes this safe: every reader of tap_handles resolves under the same
+// lock, so no one can be holding a pointer into a table while it moves.
+//
+// Only the table being built is ever grown mid-frame; the active table is left
+// alone until the swap in set_root repoints tap_handles at it.
+static int mob_tap_grow_locked(int which, int needed) {
+    if (needed <= tap_table_capacity[which])
+        return 1;
+    if (needed > MOB_TAP_SLOT_LIMIT)
+        return 0;
+
+    int cap = tap_table_capacity[which] ? tap_table_capacity[which] : MOB_TAP_INITIAL_CAPACITY;
+    while (cap < needed)
+        cap *= 2;
+    if (cap > MOB_TAP_SLOT_LIMIT)
+        cap = MOB_TAP_SLOT_LIMIT;
+
+    TapHandle *grown = realloc(tap_tables[which], (size_t)cap * sizeof(TapHandle));
+    if (!grown)
+        return 0;
+    // Zero the new tail: clear_taps and the resolvers both key off tag_env
+    // being NULL to decide a slot is free, and realloc leaves it uninitialised.
+    memset(grown + tap_table_capacity[which], 0,
+           (size_t)(cap - tap_table_capacity[which]) * sizeof(TapHandle));
+
+    tap_tables[which] = grown;
+    tap_table_capacity[which] = cap;
+    if (which == tap_active)
+        tap_handles = grown;
+    return 1;
+}
+
 static int mob_encode_event_handle(uint32_t generation, int slot) {
-    if (generation == 0 || generation > MAX_EVENT_GENERATION || slot < 0 || slot >= MAX_TAP_HANDLES)
+    if (generation == 0 || generation > MAX_EVENT_GENERATION || slot < 0 ||
+        slot >= MOB_TAP_SLOT_LIMIT)
         return -1;
-    return (int)((generation << 8) | (uint32_t)slot);
+    return (int)((generation << 12) | (uint32_t)slot);
 }
 
 static int mob_decode_event_handle(int handle, uint32_t *generation, int *slot) {
     if (handle <= 0)
         return 0;
     uint32_t raw = (uint32_t)handle;
-    *generation = raw >> 8;
-    *slot = (int)(raw & 0xffU);
+    *generation = raw >> 12;
+    *slot = (int)(raw & 0xfffU);
     return *generation != 0;
 }
 
@@ -2525,7 +2571,7 @@ static ERL_NIF_TERM nif_set_root(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
         // silently inert, which the per-call line never made obvious.
         LOGE(@"register_tap: pool exhausted (cap=%d) — %d interactive element(s) in this "
              @"frame have no handler and will not respond",
-             MAX_TAP_HANDLES, exhausted_this_frame);
+             MOB_TAP_SLOT_LIMIT, exhausted_this_frame);
     }
 
     NSString *transitionStr = [NSString stringWithUTF8String:transition];
@@ -2553,7 +2599,8 @@ static ERL_NIF_TERM nif_register_tap(ErlNifEnv *env, int argc, const ERL_NIF_TER
     }
 
     enif_mutex_lock(tap_mutex);
-    if (tap_build_count >= MAX_TAP_HANDLES) {
+    if (tap_build_count >= MOB_TAP_SLOT_LIMIT ||
+        !mob_tap_grow_locked(1 - tap_active, tap_build_count + 1)) {
         // Counted under the mutex, like the Zig side: set_root reads and resets
         // this under the same lock. Mob.Sender serialises every caller today, so
         // an unguarded read-modify-write would be benign — but nothing else in
@@ -2563,7 +2610,7 @@ static ERL_NIF_TERM nif_register_tap(ErlNifEnv *env, int argc, const ERL_NIF_TER
         // MOB-100 follow-up: this used to be enif_make_badarg(env), which
         // crashed Mob.Renderer.render/3 (and the whole screen process) the
         // same way a full component pool used to crash Mob.ComponentServer
-        // — an unvirtualized long list or big form with >MAX_TAP_HANDLES
+        // — an unvirtualized long list or big form with >MOB_TAP_SLOT_LIMIT
         // interactive elements would hit this on every render. Every
         // mob_send_* sender already no-ops on an out-of-range handle (see
         // mob_send_tap et al. above), so -1 is a safe "no handler wired up"

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -2534,11 +2534,33 @@ static ERL_NIF_TERM nif_set_root(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     // new tree resolve against it (readers see a consistent pair under the lock).
     TapHandle *previous = tap_tables[tap_active];
     TapHandle *build = tap_tables[1 - tap_active];
-    for (int slot = 0; slot < tap_build_count; slot++) {
-        if (slot < tap_handle_next && previous[slot].tag_env &&
-            previous[slot].pid.pid == build[slot].pid.pid &&
-            enif_compare(previous[slot].tag, build[slot].tag) == 0)
-            build[slot].identity_start_generation = previous[slot].identity_start_generation;
+
+    // Bound the commit by what the tables can actually hold, not by
+    // tap_build_count alone.
+    //
+    // Only clear_taps resets tap_build_count, so a set_root that arrives without
+    // an intervening clear_taps carries the previous frame's count. That used to
+    // be merely wrong — both tables were a fixed 256, so the worst case was
+    // committing the wrong handlers. Now the two tables are separate heap
+    // allocations that can differ in size, and an unbounded loop over a stale
+    // count reads (and, once tap_handle_next is set from it, writes) past the
+    // end of whichever is smaller.
+    //
+    // Mob.Sender is the single writer today, so this needs two screens racing
+    // clear/register/set_root to reach — the race Mob.Sender's own moduledoc
+    // describes, whose documented consequence is a mixed-up table. It should
+    // stay a correctness bug, not become memory corruption.
+    int build_cap = tap_table_capacity[1 - tap_active];
+    int prev_cap = tap_table_capacity[tap_active];
+    int committed = tap_build_count < build_cap ? tap_build_count : build_cap;
+
+    if (build) {
+        for (int slot = 0; slot < committed; slot++) {
+            if (previous && slot < tap_handle_next && slot < prev_cap && previous[slot].tag_env &&
+                previous[slot].pid.pid == build[slot].pid.pid &&
+                enif_compare(previous[slot].tag, build[slot].tag) == 0)
+                build[slot].identity_start_generation = previous[slot].identity_start_generation;
+        }
     }
     // Snapshot now, log after the mutex is released. NSLog writes synchronously
     // to the system log, and holding tap_mutex across it would block concurrent
@@ -2549,8 +2571,12 @@ static ERL_NIF_TERM nif_set_root(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 
     tap_active = 1 - tap_active;
     tap_handles = tap_tables[tap_active];
-    tap_handle_next = tap_build_count;
+    tap_handle_next = committed;
     tap_table_generations[tap_active] = tap_build_generation;
+    // Reset here as well as in clear_taps, so a second set_root without an
+    // intervening clear_taps commits an empty table rather than re-committing
+    // this frame's handlers against whatever the other table now holds.
+    tap_build_count = 0;
     enif_mutex_unlock(tap_mutex);
 
     // A non-"none" transition is what makes MobViewModel bump navVersion, and

--- a/lib/mob/sender.ex
+++ b/lib/mob/sender.ex
@@ -8,7 +8,7 @@ defmodule Mob.Sender do
   `ios/mob_nif.m` (the Android side in `android/jni/mob_nif.zig` is the same
   shape):
 
-      static TapHandle tap_tables[2][MAX_TAP_HANDLES];
+      static TapHandle *tap_tables[2];   // grown on demand, see MOB-133
       static int tap_active = 0;
       static int tap_build_count = 0;   // cursor into the BUILDING table
 

--- a/test/mob/native_event_handle_test.exs
+++ b/test/mob/native_event_handle_test.exs
@@ -7,6 +7,70 @@ defmodule Mob.NativeEventHandleTest do
   @android_source File.read!(Path.expand("../../android/jni/mob_nif.zig", __DIR__))
   @ios_source File.read!(Path.expand("../../ios/mob_nif.m", __DIR__))
 
+  @codec_source File.read!(Path.expand("../../android/jni/tap_handle_codec.zig", __DIR__))
+
+  test "the two handle codecs agree on the bit split" do
+    # iOS reimplements the encoding by hand while Android derives it from
+    # tap_handle_codec. They are independent implementations of one wire format,
+    # and drift between them routes a native event to the wrong process — or to
+    # a live slot that belongs to something else. Nothing else pins them
+    # together, so this does.
+    assert @codec_source =~ "pub const slot_bits: u5 = 12"
+    assert @codec_source =~ "pub const slot_count: usize = 1 << slot_bits"
+
+    assert @codec_source =~
+             "pub const max_generation: u32 = (1 << (31 - @as(u32, slot_bits))) - 1"
+
+    # 12 slot bits and a 19-bit generation, spelled out literally on the iOS side.
+    assert @ios_source =~ "#define MOB_TAP_SLOT_LIMIT 4096"
+    assert @ios_source =~ "#define MAX_EVENT_GENERATION 0x7ffffU"
+    assert @ios_source =~ "(generation << 12) | (uint32_t)slot"
+    assert @ios_source =~ "raw >> 12"
+    assert @ios_source =~ "raw & 0xfffU"
+
+    # And Android's ceiling is the codec's, not a second literal.
+    assert @android_source =~ "const MAX_TAP_HANDLES: usize = tap_handle_codec.slot_count"
+  end
+
+  test "register_tap grows the table before caching a pointer into it" do
+    # The tables are realloc-grown, so a pointer taken before the grow is a
+    # use-after-realloc. This is the one ordering the growth design depends on
+    # and it is invisible at a glance, since both statements read the same
+    # global.
+    [_, ios_register] =
+      String.split(@ios_source, "static ERL_NIF_TERM nif_register_tap", parts: 2)
+
+    [ios_register, _] = String.split(ios_register, "// ── NIF: clear_taps/0", parts: 2)
+
+    {ios_grow, _} = :binary.match(ios_register, "mob_tap_grow_locked(")
+    {ios_cache, _} = :binary.match(ios_register, "TapHandle *build = tap_tables[")
+    assert ios_grow < ios_cache
+
+    [_, android_register] = String.split(@android_source, "export fn nif_register_tap", parts: 2)
+    [android_register, _] = String.split(android_register, "// nif_clear_taps/0", parts: 2)
+
+    {android_grow, _} = :binary.match(android_register, "tapGrowLocked(")
+    {android_deref, _} = :binary.match(android_register, "tap_tables[1 - tap_active].?")
+    assert android_grow < android_deref
+  end
+
+  test "set_root commits no more slots than the tables can hold" do
+    # Only clear_taps resets tap_build_count, so a set_root without an
+    # intervening clear_taps carries a stale count. When the tables were a fixed
+    # 256 that was merely wrong; with two heap allocations of possibly different
+    # sizes an unbounded loop reads and then writes past the end of the smaller.
+    assert @ios_source =~
+             "int committed = tap_build_count < build_cap ? tap_build_count : build_cap"
+
+    assert @ios_source =~ "tap_handle_next = committed;"
+    assert @android_source =~ "const committed = if (wanted < build_cap) wanted else build_cap"
+    assert @android_source =~ "tap_active_count = @intCast(committed);"
+
+    # And a second set_root commits an empty table rather than re-committing.
+    [_, ios_set_root] = String.split(@ios_source, "static ERL_NIF_TERM nif_set_root", parts: 2)
+    assert String.contains?(ios_set_root, "tap_build_count = 0;")
+  end
+
   test "Android event handles carry the render generation" do
     assert @android_source =~ ~s|const tap_handle_codec = @import("tap_handle_codec.zig")|
     assert @android_source =~ "var tap_table_generations: [2]u32"
@@ -32,7 +96,11 @@ defmodule Mob.NativeEventHandleTest do
     [commit, _] = String.split(commit, "erts.enif_mutex_unlock(tap_mutex);", parts: 2)
 
     assert commit =~ "tap_active = 1 - tap_active"
-    assert commit =~ "tap_active_count = tap_build_count"
+    # The count comes from `committed`, not `tap_build_count`: the tables are
+    # grown on demand and can differ in size, so the commit is clamped to what
+    # the table being published actually holds (MOB-133). The property this test
+    # exists for is unchanged — all three land under one lock.
+    assert commit =~ "tap_active_count = @intCast(committed)"
     assert commit =~ "tap_table_generations[tap_active] = tap_build_generation"
   end
 

--- a/test/mob/renderer_test.exs
+++ b/test/mob/renderer_test.exs
@@ -19,7 +19,8 @@ defmodule Mob.RendererTest do
     def reset,
       do: Agent.update(__MODULE__, fn _ -> %{calls: [], tap_next: 0, tap_result: :allocate} end)
 
-    # :exhausted simulates a full MAX_TAP_HANDLES pool (MOB-100 follow-up) —
+    # :exhausted simulates a full tap pool (MOB-100 follow-up) — the tables
+    # grow on demand now, but MOB_TAP_SLOT_LIMIT is still a ceiling —
     # both native sides now return the -1 "unhandled" sentinel instead of
     # badarg when the pool is full, since every mob_send_* sender already
     # no-ops on an out-of-range handle.


### PR DESCRIPTION
The half of MOB-133 that was left open. **No version bump.**

## The bug

The tap registry was a fixed `TapHandle tap_tables[2][256]`, and the handle encoding packed 8 slot bits into a positive `int32` alongside 23 generation bits. Anything past slot 255 got the `-1` "no handler" sentinel from `register_tap`.

That is not graceful degradation. The element still renders, still looks tappable, and **does nothing** — no error, no crash, nothing in the UI to suggest the tap was never wired up. On the benchmark screen it was **359 of 615** interactive elements: a 200-row list where more than half the buttons, fields and toggles were inert.

The earlier half of this issue fixed the *reporting* (359 synchronous log writes per frame, 13 ms of a 27 ms frame). It did not make the elements work.

## The change

**Slots get 12 bits instead of 8** — 4096 instead of 256 — and the generation drops from 23 bits to 19. That is the cost of the split: at 60 fps, 2^19 frames is ~2.4 hours before the generation wraps, and `generationAge` is already modular so a wrap is handled rather than merely survived. A handle is only meaningful for the frame it was minted in, so hours of headroom is ample.

**The tables are allocated to fit** rather than declared at the ceiling. A fixed 4096-entry pair would be ~700 KB resident in every app, nearly all of which register a few dozen handles. They start at 256 — the old size, so nobody pays more than before — and double on demand.

Growth is safe because of an invariant that already held: **every reader resolves under `tap_mutex`**, and the pointers those resolvers return are used before it is released. Growth takes the same lock. Only the table being *built* is grown mid-frame; the active one is untouched until the swap in `set_root`.

One ordering detail matters: `register_tap` grows **before** it caches `tap_tables[1 - tap_active]`. Caching first would be a use-after-realloc.

## Verified end to end on both platforms

Not "registers without complaint" but "responds when tapped":

| | handles @200 / @500 rows | exhaustion | deep tap |
|---|---|---|---|
| Android (Moto G Power) | 610 / 1510 | **0** (was 359/frame) | row #188, slot ~564 → counter 0→1→2 |
| iOS (simulator) | 615 / 1515 | **0** | row #92, slot ~283 → `t/n/g=2/0/0` |

The tap matters, not just the count: `Mob.RenderStats`'s `taps` counts handle-valued props and `-1` is an integer, so it read 615 *before* this fix too. The exhaustion count is the honest signal for registration; only an actual tap proves the handle resolves.

## Tests

Three new codec tests (8 total, all passing):
- the bit split sums to 31, and every slot round-trips under the lowest and highest legal generations with the handle staying **positive** — a negative handle would collide with the `-1` sentinel and make a live element look inert
- a slot past the limit is refused rather than wrapping onto slot 0
- an old 8-bit-split handle does not decode to a live (generation, slot) pair

1380 Elixir tests pass, `mix credo --strict` clean, `zig fmt` / `clang-format` clean.

## Consequences

- 4096 is still a ceiling. Past it the sentinel and the once-per-frame report still apply — a screen with more than 4096 interactive elements is telling you something else is wrong.
- `realloc` means allocation failure is now possible where it was not. It is treated exactly like exhaustion: the sentinel, and the report.
- The real fix for a list this dense is to compose fewer of it — MOB-128's opt-in lazy scroll registers only what is on screen. This change means the app degrades honestly rather than silently while that is adopted.