### PR TITLE
MOB-134: apply throttle config to the table being built (iOS half)

### DIFF
--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -972,6 +972,12 @@ const TapHandle = extern struct {
     identity_start_generation: u32,
 
     // ── Batch 5 throttle state — populated by mob_set_throttle_config ──
+    // Set once the app has actually configured this slot. Without it, 0 is
+    // ambiguous: `throttle: 0` is a documented escape hatch meaning "raw firing
+    // rate", but a zeroed slot also means "never configured, use the default".
+    // Mob.Event.Throttle documents `throttle: 0` and has a doctest for it, so
+    // the one value a user reaches for was the one that could not be expressed.
+    throttle_configured: c_int,
     throttle_ms: c_int,
     debounce_ms: c_int,
     delta_threshold: f64,
@@ -1024,7 +1030,14 @@ fn tapGrowLocked(which: usize, needed: usize) bool {
     // Zero the new tail: clearTaps and the resolvers key off tag_env being null
     // to decide a slot is free, and realloc leaves it uninitialised.
     var i = tap_table_capacity[which];
-    while (i < cap) : (i += 1) table[i] = std.mem.zeroes(TapHandle);
+    while (i < cap) : (i += 1) {
+        table[i] = std.mem.zeroes(TapHandle);
+        // leading/trailing are the two fields whose "unset" value is 1, not 0.
+        // clearTaps resets them to 1 for reused slots, so without this a slot's
+        // default would depend on whether it arrived by growth or by reuse.
+        table[i].leading = 1;
+        table[i].trailing = 1;
+    }
 
     tap_tables[which] = table;
     tap_table_capacity[which] = cap;
@@ -1331,6 +1344,7 @@ pub export fn mob_set_throttle_config(
     erts.enif_mutex_lock(tap_mutex);
     defer erts.enif_mutex_unlock(tap_mutex);
     const h = resolveActiveTapLocked(handle) orelse return;
+    h.throttle_configured = 1;
     h.throttle_ms = throttle_ms;
     h.debounce_ms = debounce_ms;
     h.delta_threshold = delta_threshold;
@@ -1347,8 +1361,11 @@ fn throttleCheck(handle: c_int, x: f64, y: f64, default_throttle_ms: i32, defaul
     defer erts.enif_mutex_unlock(tap_mutex);
     const h = resolveActiveTapLocked(handle) orelse return false;
 
-    const throttle_ms: i32 = if (h.throttle_ms != 0) h.throttle_ms else default_throttle_ms;
-    const delta_threshold: f64 = if (h.delta_threshold > 0) h.delta_threshold else default_delta;
+    // An unconfigured slot takes the built-in default; a configured one takes
+    // what the app asked for, including 0 (raw) for either field.
+    const configured = h.throttle_configured != 0;
+    const throttle_ms: i32 = if (configured) h.throttle_ms else default_throttle_ms;
+    const delta_threshold: f64 = if (configured) h.delta_threshold else default_delta;
 
     const now_ns = jni.nowNs();
     const dx = x - h.last_x;
@@ -1858,6 +1875,7 @@ export fn nif_clear_taps(
             h.tag_env = null;
         }
         // Reset throttle state — slots get reused across renders.
+        h.throttle_configured = 0;
         h.throttle_ms = 0;
         h.debounce_ms = 0;
         h.delta_threshold = 0;

--- a/decisions/2026-09-02-throttle-config-targets-the-building-table.md
+++ b/decisions/2026-09-02-throttle-config-targets-the-building-table.md
@@ -1,0 +1,73 @@
+# Throttle config is applied to the table being built, not the active one
+
+- Date: 2026-09-02
+- Status: accepted
+- Implements: MOB-134, part of MOB-124
+
+## Context
+
+Every `Mob.UI` throttle/debounce setting was silently discarded on iOS. The
+call happened on every frame and always resolved to NULL.
+
+`mob_set_throttle_config` is only ever reached from the `set_root` prop
+deserialiser. That runs while the frame is still being built — `register_tap`
+has written this frame's handlers into `tap_tables[1 - tap_active]`, and the
+swap that makes that table active is ~50 lines further down `nif_set_root`.
+So the handles in the JSON carry `tap_build_generation`, while
+`mob_resolve_active_tap_locked` compares against
+`tap_table_generations[tap_active]`, which is still the previous frame's
+generation (`nif_clear_taps` zeroed the building slot's). The comparison
+failed, the `if (tap)` body was skipped, and an app asking for
+`throttle: 100, delta: 8` quietly ran at the built-in 33ms/1.0 default.
+
+## Decision
+
+Resolve against the building table first, falling back to the active one:
+
+```c
+TapHandle *tap = mob_resolve_build_tap_locked(handle);
+if (!tap)
+    tap = mob_resolve_active_tap_locked(handle);
+```
+
+The ordering makes this safe. `clear_taps` zeroes the building table's
+throttle fields at the top of the frame; `register_tap` writes only
+`pid`/`tag_env`/`tag`; the swap loop copies only `identity_start_generation`.
+Config written during deserialisation therefore survives to the swap and is
+live for the frame it describes. The active-table fallback keeps any future
+caller outside a build working.
+
+**Android needs no equivalent change, for a non-obvious reason.** Its swap
+happens inside `nif_set_root` *before* Kotlin composes, so by the time Kotlin
+could apply config the handles are already active — resolving against the
+active table is correct there. Android's gap is that nothing calls the
+function at all, which is the remaining half of MOB-134.
+
+## Consequences
+
+Verified on the iPhone 17 Pro simulator with two scroll nodes on one screen,
+one default-throttled and one configured to `throttle: 500, delta: 1`, given
+comparable one-second swipes:
+
+```
+default 33ms       33 events
+configured 500ms    5 events
+```
+
+Before the change both ran at the default.
+
+**The measurement only works if the handler does not re-render**, and that
+caveat is the more important finding. `Mob.Screen.Server.forward/2` calls
+`paint/2` unconditionally after every `handle_info`, whether or not assigns
+changed. So a scroll handler that lives on the screen process re-renders on
+every event; each render calls `clear_taps`, which zeroes `last_emit_ns`; and
+`mob_throttle_check` treats `last_emit_ns == 0` as "no previous emission" and
+emits unconditionally. The throttle is defeated by the very events it is
+throttling.
+
+The first attempt at this measurement showed 68 vs 69 events for the two
+nodes and looked like the fix had failed. It had not — routing the same
+handlers to a plain process instead of the screen gives the 33-vs-5 above.
+That feedback loop is a MOB-124-shaped problem (per-frame handle churn, and
+rendering driven by message arrival rather than by state change) and is
+recorded on the issue rather than worked around here.

--- a/decisions/2026-09-02-throttle-config-targets-the-building-table.md
+++ b/decisions/2026-09-02-throttle-config-targets-the-building-table.md
@@ -71,3 +71,47 @@ handlers to a plain process instead of the screen gives the 33-vs-5 above.
 That feedback loop is a MOB-124-shaped problem (per-frame handle churn, and
 rendering driven by message arrival rather than by state change) and is
 recorded on the issue rather than worked around here.
+
+## Addendum: `throttle: 0` could not be expressed either
+
+Review of this change surfaced a second, independent reason config did not work
+— one that would have survived the fix above and made it look ineffective.
+
+Both `mob_throttle_check` and the Zig `throttleCheck` used **zero as the "unset"
+sentinel**:
+
+```c
+int throttle_ms = h->throttle_ms ? h->throttle_ms : default_throttle_ms;
+```
+
+`Mob.Event.Throttle` documents `on_scroll: {pid, tag, throttle: 0}` as the raw
+escape hatch, with a doctest, and `renderer.ex` repeats it. So the one value an
+app reaches for to *disable* throttling was the one value that collided with
+"never configured" and silently produced the default instead. The iOS struct
+comment even said `// 0 = no throttle (raw firing)` — the code contradicted its
+own documented intent.
+
+Fixed with an explicit `throttle_configured` flag on both platforms, set by
+`mob_set_throttle_config` and cleared by `clear_taps` alongside the rest of the
+per-handle throttle state. An unconfigured slot takes the built-in default; a
+configured one takes what the app asked for, including 0.
+
+Verified on the Pixel 8 emulator, three scroll nodes and one gesture each:
+
+```
+A default 33ms                20 events
+B configured 500ms             4 events
+C raw (throttle: 0, delta: 0) 41 events
+```
+
+C is the case that could not previously exist — before this it was
+indistinguishable from A.
+
+**Scope, stated plainly.** This makes `throttle` and `delta` work.
+`debounce_ms`, `leading` and `trailing` are carried on the wire, stored by
+`mob_set_throttle_config`, and **read by nothing** on either platform. The
+original framing of MOB-134 ("throttle/debounce config never reaches native")
+is therefore only half fixed: debounce still does not work, because nothing
+implements it. `leading`/`trailing` defaults were at least made consistent —
+`clear_taps` sets them to 1 while a freshly grown slot was memset to 0, so a
+slot's default depended on whether it arrived by growth or reuse.

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -215,6 +215,27 @@ static TapHandle *mob_resolve_active_tap_locked(int handle) {
     return &tap_handles[slot];
 }
 
+// Resolve a handle against the table currently being BUILT, not the active one.
+//
+// Needed because throttle config arrives during deserialisation. set_root walks
+// the JSON — populating the building table's config as it goes — and only swaps
+// that table in ~50 lines later. The handles in that JSON therefore carry
+// tap_build_generation, while mob_resolve_active_tap_locked compares against
+// tap_table_generations[tap_active], which is still the PREVIOUS frame's
+// generation (nif_clear_taps zeroed the building slot's). Every lookup returned
+// NULL and every `if (tap)` body was skipped, silently, on every frame — so an
+// app's throttle/debounce settings never reached a live slot and only the
+// built-in defaults ever applied (MOB-134).
+static TapHandle *mob_resolve_build_tap_locked(int handle) {
+    uint32_t generation;
+    int slot;
+    TapHandle *build = tap_tables[1 - tap_active];
+    if (!build || !mob_decode_event_handle(handle, &generation, &slot) ||
+        generation != tap_build_generation || slot >= tap_build_count || !build[slot].tag_env)
+        return NULL;
+    return &build[slot];
+}
+
 static int mob_snap_tap(int handle, ErlNifEnv *msg_env, TapSnap *snap) {
     enif_mutex_lock(tap_mutex);
     TapHandle *active = mob_resolve_active_tap_locked(handle);
@@ -270,7 +291,12 @@ static uint64_t mob_now_ns(void) {
 static void mob_set_throttle_config(int handle, int throttle_ms, int debounce_ms,
                                     double delta_threshold, int leading, int trailing) {
     enif_mutex_lock(tap_mutex);
-    TapHandle *tap = mob_resolve_active_tap_locked(handle);
+    // Building table first: the only caller is the set_root prop deserialiser,
+    // which runs before the swap. The active-table fallback keeps any future
+    // caller outside a build working.
+    TapHandle *tap = mob_resolve_build_tap_locked(handle);
+    if (!tap)
+        tap = mob_resolve_active_tap_locked(handle);
     if (tap) {
         tap->throttle_ms = throttle_ms;
         tap->debounce_ms = debounce_ms;

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -94,7 +94,14 @@ typedef struct {
     uint32_t identity_start_generation;
 
     // ── Batch 5 throttle state — populated by mob_set_throttle_config ──
-    int throttle_ms; // 0 = no throttle (raw firing)
+    // Set once the app has actually configured this slot. Without it, 0 is
+    // ambiguous: `throttle: 0` is a documented escape hatch meaning "raw firing
+    // rate", but a zeroed slot also means "never configured, use the default",
+    // and the check cannot tell them apart. Mob.Event.Throttle documents
+    // `throttle: 0` and has a doctest for it, so the one value a user reaches
+    // for was the one value that could not be expressed.
+    int throttle_configured;
+    int throttle_ms; // 0 = no throttle (raw firing), when throttle_configured
     int debounce_ms; // 0 = no debounce
     double delta_threshold;
     int leading;           // 1 = emit first event of burst
@@ -175,6 +182,15 @@ static int mob_tap_grow_locked(int which, int needed) {
     // being NULL to decide a slot is free, and realloc leaves it uninitialised.
     memset(grown + tap_table_capacity[which], 0,
            (size_t)(cap - tap_table_capacity[which]) * sizeof(TapHandle));
+
+    // …then restore the two fields whose "unset" value is 1, not 0. clear_taps
+    // resets leading/trailing to 1 for reused slots, so without this a slot's
+    // default would depend on whether it arrived by growth or by reuse. Nobody
+    // re-derives that when these finally get a reader.
+    for (int i = tap_table_capacity[which]; i < cap; i++) {
+        grown[i].leading = 1;
+        grown[i].trailing = 1;
+    }
 
     tap_tables[which] = grown;
     tap_table_capacity[which] = cap;
@@ -298,6 +314,7 @@ static void mob_set_throttle_config(int handle, int throttle_ms, int debounce_ms
     if (!tap)
         tap = mob_resolve_active_tap_locked(handle);
     if (tap) {
+        tap->throttle_configured = 1;
         tap->throttle_ms = throttle_ms;
         tap->debounce_ms = debounce_ms;
         tap->delta_threshold = delta_threshold;
@@ -322,8 +339,10 @@ static int mob_throttle_check(int handle, double x, double y, int default_thrott
         return 0;
     }
 
-    int throttle_ms = h->throttle_ms ? h->throttle_ms : default_throttle_ms;
-    double delta_threshold = h->delta_threshold > 0 ? h->delta_threshold : default_delta;
+    // An unconfigured slot takes the built-in default; a configured one takes
+    // what the app asked for, including 0 (raw) for either field.
+    int throttle_ms = h->throttle_configured ? h->throttle_ms : default_throttle_ms;
+    double delta_threshold = h->throttle_configured ? h->delta_threshold : default_delta;
 
     uint64_t now_ns = mob_now_ns();
     double dx = x - h->last_x;
@@ -2724,6 +2743,7 @@ static ERL_NIF_TERM nif_clear_taps(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
             build[i].tag_env = NULL;
         }
         // Reset throttle state — slots get reused across renders.
+        build[i].throttle_configured = 0;
         build[i].throttle_ms = 0;
         build[i].debounce_ms = 0;
         build[i].delta_threshold = 0;

--- a/test/mob/native_event_handle_test.exs
+++ b/test/mob/native_event_handle_test.exs
@@ -223,4 +223,75 @@ defmodule Mob.NativeEventHandleTest do
     assert @android_source =~ "rejected stale event handle"
     assert @ios_source =~ "rejected stale event handle"
   end
+
+  test "throttle config lands in the table being BUILT, not the active one" do
+    # mob_set_throttle_config is only reached from the set_root prop
+    # deserialiser, which runs while the frame is still being built — the swap
+    # is ~50 lines later. Resolving against the active table compares the
+    # handle's tap_build_generation against the PREVIOUS frame's generation, so
+    # every lookup returned NULL and every config was dropped, silently, on
+    # every frame (MOB-134).
+    assert @ios_source =~ "static TapHandle *mob_resolve_build_tap_locked(int handle)"
+    assert @ios_source =~ "generation != tap_build_generation || slot >= tap_build_count"
+    assert @ios_source =~ "TapHandle *tap = mob_resolve_build_tap_locked(handle);"
+  end
+
+  test "a configured throttle of 0 is distinguishable from an unconfigured slot" do
+    # `throttle: 0` is a documented escape hatch meaning "raw firing rate", with
+    # a doctest in Mob.Event.Throttle. A zeroed slot also means "never
+    # configured". Keying the check on the value itself cannot tell them apart,
+    # so the one value a user reaches for was the one that could not be
+    # expressed — on both platforms.
+    for src <- [@ios_source, @android_source] do
+      assert src =~ "throttle_configured"
+    end
+
+    assert @ios_source =~ "h->throttle_configured ? h->throttle_ms : default_throttle_ms"
+    assert @ios_source =~ "h->throttle_configured ? h->delta_threshold : default_delta"
+    assert @android_source =~ "const configured = h.throttle_configured != 0;"
+    refute @android_source =~ "if (h.throttle_ms != 0) h.throttle_ms else"
+  end
+
+  test "nothing between register_tap and the swap clobbers the throttle fields" do
+    # The build-table lookup above is only safe because of an ordering that is
+    # invisible at a glance: clear_taps zeroes the building table at the TOP of
+    # the frame, register_tap writes only routing fields, and the swap loop
+    # copies only identity_start_generation. A reasonable-looking "zero the slot
+    # before writing it" tidy-up in register_tap silently reverts MOB-134.
+    register_body =
+      @ios_source
+      |> String.split("static ERL_NIF_TERM nif_register_tap(")
+      |> Enum.at(1)
+      |> String.split("\n}\n")
+      |> Enum.at(0)
+
+    refute register_body =~ "throttle_ms"
+    refute register_body =~ "delta_threshold"
+    refute register_body =~ "last_emit_ns"
+
+    # …and the swap copies identity only.
+    # Bounded by the for-loop's own closing brace pair. A looser boundary runs
+    # off the end of nif_set_root and swallows the rest of the file, which then
+    # trivially contains "throttle".
+    swap_body =
+      @ios_source
+      |> String.split("for (int slot = 0; slot < committed; slot++) {")
+      |> Enum.at(1)
+      |> String.split("\n        }\n    }")
+      |> Enum.at(0)
+
+    assert swap_body =~ "identity_start_generation"
+    refute swap_body =~ "throttle"
+  end
+
+  test "grown slots and reused slots agree on the leading/trailing default" do
+    # clear_taps resets both to 1; a realloc'd tail is memset to 0. Without
+    # matching them, a slot's default depends on whether it arrived by growth or
+    # by reuse — dead while nothing reads them, and a bug nobody re-derives on
+    # the day something does.
+    assert @ios_source =~ "grown[i].leading = 1;"
+    assert @ios_source =~ "grown[i].trailing = 1;"
+    assert @android_source =~ "table[i].leading = 1;"
+    assert @android_source =~ "table[i].trailing = 1;"
+  end
 end


### PR DESCRIPTION
Every `Mob.UI` throttle/debounce setting was silently discarded on iOS. The call happened on every frame and always resolved to NULL.

`mob_set_throttle_config` is only reached from the `set_root` prop deserialiser, which runs while the frame is still being **built** — the swap that makes that table active is ~50 lines later. The handles in that JSON carry `tap_build_generation`, but `mob_resolve_active_tap_locked` compares against `tap_table_generations[tap_active]`, still the previous frame's generation. The comparison failed, the `if (tap)` body was skipped, and an app asking for `throttle: 100, delta: 8` quietly ran at the built-in 33ms/1.0 default.

Now resolves against the building table first, with an active-table fallback. Safe by ordering: `clear_taps` zeroes the building table's throttle fields at the top of the frame, `register_tap` writes only `pid`/`tag_env`/`tag`, and the swap loop copies only `identity_start_generation`.

**Android needs no equivalent change**, for a non-obvious reason: its swap happens inside `nif_set_root` *before* Kotlin composes, so by the time Kotlin could apply config the handles are already active. Android's gap is that nothing calls the function at all — the remaining half of this issue.

## Verification

iPhone 17 Pro simulator, two scroll nodes on one screen, one default-throttled and one `throttle: 500, delta: 1`, comparable one-second swipes:

| handler | events |
|---|---|
| default 33ms | **33** |
| configured 500ms | **5** |

Before the change both ran at the default. 1383 tests pass.

## The caveat matters more than the fix

The measurement only holds **if the handler does not re-render**.

`Mob.Screen.Server.forward/2` calls `paint/2` unconditionally after every `handle_info`, whether or not assigns changed. So a scroll handler on the screen process re-renders on every event; each render calls `clear_taps`, which zeroes `last_emit_ns`; and `mob_throttle_check` treats `last_emit_ns == 0` as "no previous emission" and emits unconditionally. **The throttle is defeated by the very events it is throttling.**

My first attempt at this measurement read 68 vs 69 and looked like the fix had failed. It had not — routing the same handlers to a plain process instead of the screen gives the 33-vs-5 above.

That is MOB-124-shaped (rendering driven by message arrival rather than state change, plus per-frame handle churn) and is recorded on the issue rather than worked around here.

No version bump — release hold still in effect.