### PR TITLE
MOB-140: skip the repaint when the rendered tree is unchanged

### DIFF
--- a/decisions/2026-09-03-skip-the-repaint-when-the-tree-is-unchanged.md
+++ b/decisions/2026-09-03-skip-the-repaint-when-the-tree-is-unchanged.md
@@ -107,3 +107,36 @@ different change, and the honest place to look next is whether a screen needs
 to run `render/1` at all for a message it ignored. It also does not address the
 per-frame handle churn itself — handles are still re-registered on every frame
 that does paint, which is MOB-124's subject.
+
+## What this does not do
+
+Recorded because each is a render input that lives outside the fingerprint, or
+a cost the headline numbers do not show.
+
+* **`render/1` and the expansion passes still run on every message.** Only the
+  native crossing is skipped. Whether a screen should run `render/1` at all for
+  a message it ignored is a separate question.
+
+* **Per-frame handle churn is untouched.** Handles are still re-registered on
+  every frame that does paint; that is MOB-124's subject.
+
+* **The listener pid is not in the key.** `Mob.Renderer.register_handler/2`
+  resolves tap targets through `Mob.Listener.handler/1`, a `Process.whereis`.
+  If the listener dies and restarts it gets a new pid, the committed tap table
+  still names the dead one, and every control on screen is inert. Previously
+  the next message repainted and re-registered, self-healing in one message; an
+  unchanged tree now never re-registers. Narrow — the listener is started once
+  and is not supervised for restart — but it is the same class as the theme bug
+  above, and closing the theme half does not close this one.
+
+* **A frame the sender rescued is still recorded as displayed.**
+  `Mob.Sender.commit/1` rescues a raising render in the sender process, after
+  the screen has already written `last_frame`. Nothing propagates back. Mostly
+  benign, since re-rendering the same tree would raise again, but the
+  observable change is that `[mob] render failed` now logs once instead of once
+  per message — a screen wedged by an unencodable prop goes quiet.
+
+* **Every painting frame pays an extra full tree traversal.** `phash2` over the
+  expanded tree runs whether or not the frame is skipped: roughly 70 ns/node
+  here, so ~15-150 µs on a 200-2000 node screen. A clear win when it skips,
+  pure added cost when it does not.

--- a/decisions/2026-09-03-skip-the-repaint-when-the-tree-is-unchanged.md
+++ b/decisions/2026-09-03-skip-the-repaint-when-the-tree-is-unchanged.md
@@ -31,30 +31,50 @@ handler's own delivery caused a repaint.
 
 ## Decision
 
-Compare the expanded tree against the last one committed, and skip the native
-crossing when they are equal.
+Fingerprint each frame as `phash2({expanded_tree, Mob.Theme.current()})` and
+skip the native crossing when it matches the last one committed.
 
-**Compare the tree, not the assigns.** Assign comparison is the LiveView model
-and would be cheaper, but it is wrong here: `render/1` in this framework may
-legitimately read state that is not in assigns. `Mob.Theme.set/1` is the
-obvious one — a handler that changes the theme without assigning anything must
-still repaint, and an assigns-based check would leave the old theme on screen.
-Running `render/1` and comparing its output keeps every such input honest.
+Three things in that sentence were arrived at the hard way.
 
-It still removes the expensive half. Per MOB-124's own measurements the native
-crossing dominates; `render` + expand are Elixir-side and comparatively cheap.
+**The theme has to be in the key.** The first version compared the expanded
+tree alone, on the reasoning that `render/1` may read state outside assigns and
+running it keeps those inputs honest. That reasoning was wrong, and review
+caught it. Token resolution — `:on_background` to ARGB, the font default, the
+type scale, spacing, radii — happens in `Mob.Renderer`, **downstream** of this
+comparison. A screen written the idiomatic way produces a byte-identical tree
+before and after `Mob.Theme.set/1`, so the repaint was skipped and the old
+palette stayed on screen. Worse than nothing: `Mob.Theme.set/1` pushes the
+resolved palette to native itself, so theme-driven surfaces would follow while
+every explicitly-tokened node did not — a half-themed screen. The test that
+was supposed to cover this passed only because the fixture baked
+`Mob.Theme.current().background` into the tree, which is the one shape real
+screens do not use.
 
-The tree is comparable across frames because handles are assigned later, inside
-`Mob.Renderer`. At the comparison point interactive nodes still carry their
-`{pid, tag}`, which is stable for the life of a screen.
+**Only `forward/2` may skip.** Every other paint — mount, activation, every
+navigation, hot reload, a `:sync` caller — is unconditional. The obvious guard
+(`transition != :none`) turns out to guard nothing: the router paints with
+`:none` on every push, pop and reset, because the transition rides on the
+*activation*, not the paint. And the activation token, which does distinguish
+them, is conditional on `activation_frame_supported?/0` — the hot-code-push
+fallback. So on that fallback path, popping back to a resident screen whose
+tree had not changed would skip its repaint and leave the pushed screen's tree
+on display. Restricting the skip to the message path removes the whole class,
+and also sidesteps `Mob.Sender` dropping frames for non-active screens: a
+background screen's fingerprint may describe a tree that was never committed,
+but it cannot act on that, because becoming active goes through the router and
+therefore through an unconditional paint.
 
-Three cases always paint, regardless: a navigation (the transition is the
-point, and the native side keys view identity on it), an activation token
-(it has to reach native), and a `:sync` caller (it is waiting on a flush).
+**A hash, not the tree.** Retaining the expanded tree per live screen roughly
+doubles steady-state footprint on a list screen — `Mob.List` materialises a
+wrapper plus the rendered row per item — for screens the user cannot see, and
+it would be copied across process boundaries by `Mob.Screen.Server.socket/1`,
+i.e. over dist on every `Mob.Test.assigns/1`. The trade is a ~1-in-4-billion
+chance that two consecutive frames collide and one repaint is skipped; the next
+actual change repaints normally.
 
 A skipped repaint is recorded via `Mob.RenderStats.drop_frame/1` as an
-uncommitted frame rather than dropped silently, so the meter says how many
-repaints were skipped.
+uncommitted frame rather than dropped silently, so the meter reports how many
+were skipped.
 
 ## Consequences
 
@@ -69,11 +89,17 @@ B configured 500ms    4 events
 
 Against 68 vs 69 for the same shape before.
 
-Six tests count `set_root` at a stub NIF rather than inferring from the code,
-and cover both directions: a no-op message, re-assigning the same value, a real
-change, and a change `render/1` reads from outside assigns. Mutation-checked —
-restoring the unconditional repaint fails exactly the three "must not repaint"
-tests and leaves the three "must repaint" ones passing.
+Nine tests count `set_root` at a stub NIF rather than inferring from the code,
+covering both directions: a no-op message, re-assigning the same value, a real
+change, a theme change read from outside assigns, and an explicit render or
+`:sync` render with an unchanged tree. Three mutations checked, each failing
+exactly the tests that should catch it: restoring the unconditional repaint,
+letting explicit renders skip, and dropping the theme from the fingerprint.
+
+The fixture deliberately uses `text_color: :on_background` — a token — because
+the earlier fixture baked a resolved colour in and made the theme test pass
+against an implementation that ignored the theme entirely. A test asserts the
+fixture still uses the token.
 
 **What this does not do.** It does not make an unchanged tree free: `render/1`
 and the expansion passes still run on every message. Making *those* cheap is a

--- a/decisions/2026-09-03-skip-the-repaint-when-the-tree-is-unchanged.md
+++ b/decisions/2026-09-03-skip-the-repaint-when-the-tree-is-unchanged.md
@@ -1,0 +1,83 @@
+# Skip the repaint when the rendered tree is unchanged
+
+- Date: 2026-09-03
+- Status: accepted
+- Part of: MOB-124
+- Related: `2026-09-02-throttle-config-targets-the-building-table.md`
+
+## Context
+
+`Mob.Screen.Server.forward/2` ended every `handle_info` with an unconditional
+repaint:
+
+```elixir
+{:noreply, %{state | socket: paint(state, :none)}}
+```
+
+No comparison against the previous state. **Any** message to a screen triggered
+a full render: walk the tree, `clear_taps`, a `register_tap` per interactive
+node, serialise, `set_root`, rebuild the native tree. A handler that changed
+nothing cost exactly as much as one that changed everything, so a 30 Hz scroll
+handler drove 30 full renders per second.
+
+It also fed a feedback loop. Each render calls `clear_taps`, which zeroes the
+per-handle throttle state including `last_emit_ns`; `throttleCheck` treats
+`last_emit_ns == 0` as "no previous emission" and emits unconditionally. **The
+native throttle was defeated by the very events it was throttling.** MOB-134
+measured this directly: the same two handlers, one default and one
+`throttle: 500`, gave 68 vs 69 events when delivered to the screen and 33 vs 5
+when delivered to a plain process. The only difference was whether the
+handler's own delivery caused a repaint.
+
+## Decision
+
+Compare the expanded tree against the last one committed, and skip the native
+crossing when they are equal.
+
+**Compare the tree, not the assigns.** Assign comparison is the LiveView model
+and would be cheaper, but it is wrong here: `render/1` in this framework may
+legitimately read state that is not in assigns. `Mob.Theme.set/1` is the
+obvious one — a handler that changes the theme without assigning anything must
+still repaint, and an assigns-based check would leave the old theme on screen.
+Running `render/1` and comparing its output keeps every such input honest.
+
+It still removes the expensive half. Per MOB-124's own measurements the native
+crossing dominates; `render` + expand are Elixir-side and comparatively cheap.
+
+The tree is comparable across frames because handles are assigned later, inside
+`Mob.Renderer`. At the comparison point interactive nodes still carry their
+`{pid, tag}`, which is stable for the life of a screen.
+
+Three cases always paint, regardless: a navigation (the transition is the
+point, and the native side keys view identity on it), an activation token
+(it has to reach native), and a `:sync` caller (it is waiting on a flush).
+
+A skipped repaint is recorded via `Mob.RenderStats.drop_frame/1` as an
+uncommitted frame rather than dropped silently, so the meter says how many
+repaints were skipped.
+
+## Consequences
+
+The throttle now works for handlers that live on the screen — the ordinary
+case. Measured on the Pixel 8 emulator with both handlers delivered to the
+screen and neither assigning:
+
+```
+A default 33ms       18 events
+B configured 500ms    4 events
+```
+
+Against 68 vs 69 for the same shape before.
+
+Six tests count `set_root` at a stub NIF rather than inferring from the code,
+and cover both directions: a no-op message, re-assigning the same value, a real
+change, and a change `render/1` reads from outside assigns. Mutation-checked —
+restoring the unconditional repaint fails exactly the three "must not repaint"
+tests and leaves the three "must repaint" ones passing.
+
+**What this does not do.** It does not make an unchanged tree free: `render/1`
+and the expansion passes still run on every message. Making *those* cheap is a
+different change, and the honest place to look next is whether a screen needs
+to run `render/1` at all for a message it ignored. It also does not address the
+per-frame handle churn itself — handles are still re-registered on every frame
+that does paint, which is MOB-124's subject.

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -352,17 +352,60 @@ defmodule Mob.Screen.Server do
       Mob.ComponentRegistry.reconcile(self(), active_component_keys)
     end)
 
-    Mob.RenderStats.hand_off(state.ref)
-
-    if activation_token && function_exported?(Mob.Sender, :render, 6) do
-      Mob.Sender.render(state.ref, tree, platform, state.nif, transition, activation_token)
+    if unchanged?(socket, tree, transition, mode, activation_token) do
+      # The platform is already showing exactly this tree. Everything below —
+      # clear_taps, a register_tap per interactive node, serialisation, set_root
+      # and the native tree rebuild — would reproduce what is on screen.
+      #
+      # Not a rare case: forward/2 repaints after EVERY handle_info, whether or
+      # not the message changed anything, so a 30 Hz scroll handler drove 30 full
+      # renders per second. It also fed a feedback loop — each render calls
+      # clear_taps, which zeroes the per-handle throttle state, so the native
+      # throttle was defeated by the very events it throttled. MOB-134 measured
+      # 68 vs 69 events for a throttled and an unthrottled handler delivered to a
+      # screen, against 33 vs 5 for the same handlers delivered to a plain
+      # process.
+      #
+      # Recorded as an uncommitted frame rather than dropped silently, so the
+      # meter says how many repaints were skipped.
+      Mob.RenderStats.take_frame() |> Mob.RenderStats.drop_frame()
+      socket
     else
-      Mob.Sender.render(state.ref, tree, platform, state.nif, transition)
+      Mob.RenderStats.hand_off(state.ref)
+
+      if activation_token && function_exported?(Mob.Sender, :render, 6) do
+        Mob.Sender.render(state.ref, tree, platform, state.nif, transition, activation_token)
+      else
+        Mob.Sender.render(state.ref, tree, platform, state.nif, transition)
+      end
+
+      if mode == :sync, do: Mob.Sender.sync(:infinity)
+
+      socket
+      |> Mob.Socket.put_mob(:last_tree, tree)
+      |> Mob.Socket.put_root_view(:json_tree)
     end
+  end
 
-    if mode == :sync, do: Mob.Sender.sync(:infinity)
-
-    Mob.Socket.put_root_view(socket, :json_tree)
+  # Compare the EXPANDED tree, not the assigns.
+  #
+  # Assign comparison is the LiveView model and would be cheaper, but it is
+  # wrong here: render/1 may legitimately read state that is not in assigns —
+  # Mob.Theme.set/1 is the obvious one, and a handler that changes the theme
+  # without assigning anything must still repaint. Running render and comparing
+  # its output keeps every such input honest, and still removes the expensive
+  # half: the native crossing dominates, per MOB-124's own measurements.
+  #
+  # The tree is comparable across frames because handles are assigned later,
+  # inside Mob.Renderer — at this point interactive nodes still carry their
+  # `{pid, tag}`, which is stable for a screen.
+  defp unchanged?(socket, tree, transition, mode, activation_token) do
+    # A navigation always paints: the transition is the point, and the native
+    # side keys view identity on it. An activation token must reach native for
+    # the same reason. A :sync caller is waiting on a flush, so it takes the
+    # slow path even when nothing changed.
+    transition == :none and mode == :async and is_nil(activation_token) and
+      Map.get(socket.__mob__, :last_tree) == tree
   end
 
   defp initial_safe_area(:render, nif) do

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -388,7 +388,18 @@ defmodule Mob.Screen.Server do
       #
       # Recorded as an uncommitted frame rather than dropped silently, so the
       # meter says how many repaints were skipped.
-      Mob.RenderStats.take_frame() |> Mob.RenderStats.drop_frame()
+      # Tagged. drop_frame/1 already records uncommitted frames — superseded,
+      # inactive, discarded at a navigation — and skips now vastly outnumber all
+      # of them: at 30 Hz the 500-entry ring is entirely no-op skips within ~17
+      # seconds, evicting exactly the committed frames and navigation-boundary
+      # drops MOB-124 is trying to measure. The reason keeps them separable.
+      Mob.RenderStats.take_frame()
+      |> then(fn
+        nil -> nil
+        frame -> Map.put(frame, :reason, :unchanged)
+      end)
+      |> Mob.RenderStats.drop_frame()
+
       socket
     else
       Mob.RenderStats.hand_off(state.ref)
@@ -424,8 +435,15 @@ defmodule Mob.Screen.Server do
   # materialises a wrapper plus the rendered row per item — for screens the user
   # cannot even see, and it would be copied across process boundaries by
   # Mob.Screen.Server.socket/1, i.e. over dist on every Mob.Test.assigns/1.
-  # The trade is a ~1-in-4-billion chance that two consecutive frames collide
-  # and one repaint is skipped; the next actual change repaints normally.
+  # The trade, stated accurately: ~1 in 4 billion per message that a frame
+  # collides with the previous one and its repaint is skipped. It is NOT
+  # self-healing. On a collision `last_frame` still holds the OLD tree's hash
+  # while the new tree is what render produces, so every subsequent frame
+  # rendering that same new tree — the normal case, since changed state stays
+  # changed — hashes identically and is skipped again. The screen stays wrong
+  # until the tree moves to a third value, which on a settled screen can mean
+  # until the next user interaction. Any interaction produces one, so it
+  # recovers in practice, but "one dropped frame" would be the wrong summary.
   defp fingerprint(tree), do: :erlang.phash2({tree, Mob.Theme.current()}, 4_294_967_296)
 
   defp initial_safe_area(:render, nif) do

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -296,7 +296,7 @@ defmodule Mob.Screen.Server do
     case take_nav_action(socket) do
       {nil, socket} ->
         state = %{state | socket: socket}
-        {:noreply, %{state | socket: paint(state, :none)}}
+        {:noreply, %{state | socket: repaint_if_changed(state)}}
 
       {action, socket} ->
         send(state.owner, {:nav_action, action, self()})
@@ -324,12 +324,30 @@ defmodule Mob.Screen.Server do
     end
   end
 
-  defp paint(state, transition, mode \\ :async, activation_token \\ nil)
+  defp paint(state, transition, mode \\ :async, activation_token \\ nil),
+    do: do_paint(state, transition, mode, activation_token, false)
 
-  defp paint(%{render_mode: :no_render} = state, _transition, _mode, _activation_token),
+  # The ONLY path that may skip. Everything else — mount, activation, every
+  # navigation, hot reload, a :sync caller — paints unconditionally.
+  #
+  # That restriction is what makes this safe rather than clever. The router
+  # paints with `transition: :none` on every push, pop and reset (the transition
+  # rides on the activation, not the paint), and the activation token is
+  # conditional on `activation_frame_supported?/0`, the hot-code-push fallback.
+  # So neither the transition nor the token is a reliable "this is a navigation"
+  # signal. Popping back to a resident screen whose tree has not changed would
+  # otherwise skip its repaint and leave the pushed screen's tree on display.
+  #
+  # It also sidesteps Mob.Sender dropping frames for non-active screens: a
+  # background screen's fingerprint may describe a tree that was never
+  # committed, but it cannot act on that, because becoming active goes through
+  # the router and therefore through an unconditional paint.
+  defp repaint_if_changed(state), do: do_paint(state, :none, :async, nil, true)
+
+  defp do_paint(%{render_mode: :no_render} = state, _transition, _mode, _token, _skippable),
     do: state.socket
 
-  defp paint(state, transition, mode, activation_token) do
+  defp do_paint(state, transition, mode, activation_token, skippable) do
     socket = ensure_safe_area(state.socket, state.socket.__mob__.platform, state.nif)
     platform = socket.__mob__.platform
     list_renderers = Map.get(socket.__mob__, :list_renderers, %{})
@@ -352,7 +370,9 @@ defmodule Mob.Screen.Server do
       Mob.ComponentRegistry.reconcile(self(), active_component_keys)
     end)
 
-    if unchanged?(socket, tree, transition, mode, activation_token) do
+    fingerprint = fingerprint(tree)
+
+    if skippable and Map.get(socket.__mob__, :last_frame) == fingerprint do
       # The platform is already showing exactly this tree. Everything below —
       # clear_taps, a register_tap per interactive node, serialisation, set_root
       # and the native tree rebuild — would reproduce what is on screen.
@@ -382,31 +402,31 @@ defmodule Mob.Screen.Server do
       if mode == :sync, do: Mob.Sender.sync(:infinity)
 
       socket
-      |> Mob.Socket.put_mob(:last_tree, tree)
+      |> Mob.Socket.put_mob(:last_frame, fingerprint)
       |> Mob.Socket.put_root_view(:json_tree)
     end
   end
 
-  # Compare the EXPANDED tree, not the assigns.
+  # What the next frame is compared against.
   #
-  # Assign comparison is the LiveView model and would be cheaper, but it is
-  # wrong here: render/1 may legitimately read state that is not in assigns —
-  # Mob.Theme.set/1 is the obvious one, and a handler that changes the theme
-  # without assigning anything must still repaint. Running render and comparing
-  # its output keeps every such input honest, and still removes the expensive
-  # half: the native crossing dominates, per MOB-124's own measurements.
+  # Includes the theme, because the tree alone is not enough: token resolution
+  # (`:on_background` -> ARGB), the font default, the type scale, spacing and
+  # radii all happen in Mob.Renderer, which runs DOWNSTREAM of this comparison.
+  # A screen written the idiomatic way — `text_color: :on_background` —
+  # produces a byte-identical tree before and after `Mob.Theme.set/1`, so
+  # comparing the tree alone skips the repaint and leaves the old palette on
+  # screen. Worse than nothing: Mob.Theme.set/1 pushes the resolved palette to
+  # native itself, so theme-driven surfaces would follow while every
+  # explicitly-tokened node did not — a half-themed screen.
   #
-  # The tree is comparable across frames because handles are assigned later,
-  # inside Mob.Renderer — at this point interactive nodes still carry their
-  # `{pid, tag}`, which is stable for a screen.
-  defp unchanged?(socket, tree, transition, mode, activation_token) do
-    # A navigation always paints: the transition is the point, and the native
-    # side keys view identity on it. An activation token must reach native for
-    # the same reason. A :sync caller is waiting on a flush, so it takes the
-    # slow path even when nothing changed.
-    transition == :none and mode == :async and is_nil(activation_token) and
-      Map.get(socket.__mob__, :last_tree) == tree
-  end
+  # A hash rather than the tree itself. Retaining the expanded tree per live
+  # screen roughly doubles steady-state footprint on a list screen — Mob.List
+  # materialises a wrapper plus the rendered row per item — for screens the user
+  # cannot even see, and it would be copied across process boundaries by
+  # Mob.Screen.Server.socket/1, i.e. over dist on every Mob.Test.assigns/1.
+  # The trade is a ~1-in-4-billion chance that two consecutive frames collide
+  # and one repaint is skipped; the next actual change repaints normally.
+  defp fingerprint(tree), do: :erlang.phash2({tree, Mob.Theme.current()}, 4_294_967_296)
 
   defp initial_safe_area(:render, nif) do
     {t, r, b, l} = nif.safe_area()

--- a/lib/mob/socket.ex
+++ b/lib/mob/socket.ex
@@ -18,12 +18,16 @@ defmodule Mob.Socket do
   @type t :: %__MODULE__{
           assigns: map(),
           __mob__: %{
-            screen: module() | nil,
-            platform: platform(),
-            root_view: term(),
-            view_tree: map(),
-            nav_stack: list(),
-            nav_action: term()
+            required(:screen) => module() | nil,
+            required(:platform) => platform(),
+            required(:root_view) => term(),
+            required(:view_tree) => map(),
+            required(:nav_stack) => list(),
+            required(:nav_action) => term(),
+            # Written by Mob.Screen.Server rather than by the struct default, so
+            # both are optional. The render path reads :last_frame every message.
+            optional(:last_frame) => non_neg_integer(),
+            optional(:list_renderers) => map()
           }
         }
 

--- a/test/mob/screen_repaint_test.exs
+++ b/test/mob/screen_repaint_test.exs
@@ -194,13 +194,17 @@ defmodule Mob.ScreenRepaintTest do
     assert renders() - before == 1
   end
 
-  test "the theme is part of the comparison, not just the tree", %{screen: screen} do
-    # Belt and braces alongside the :theme message test above. The fixture uses
-    # `text_color: :on_background` — a TOKEN — because token resolution happens
-    # in Mob.Renderer, downstream of the comparison. An earlier version of this
-    # file baked `Mob.Theme.current().background` into the tree instead, which
-    # made the theme test pass against an implementation that ignored the theme
-    # entirely. That is the one shape real screens do not use.
-    assert File.read!(__ENV__.file) =~ "text_color: :on_background"
+  test "the fixture uses a theme TOKEN, which is what makes test 4 meaningful",
+       %{screen: _screen} do
+    # Asserted against the rendered tree, not the source file. The first version
+    # of this test grepped its own file for "text_color: :on_background" — which
+    # its own explanatory comment contained, so it could not fail. In a change
+    # whose credibility rests on its tests, that is the wrong kind of cargo.
+    #
+    # Why it matters: token resolution happens in Mob.Renderer, downstream of the
+    # fingerprint. If the fixture baked a resolved ARGB in instead — as an earlier
+    # version did, via Mob.Theme.current().background — test 4 would pass against
+    # an implementation that ignored the theme entirely.
+    assert Screen.render(%{count: 0}).props.text_color == :on_background
   end
 end

--- a/test/mob/screen_repaint_test.exs
+++ b/test/mob/screen_repaint_test.exs
@@ -1,0 +1,159 @@
+defmodule Mob.ScreenRepaintTest do
+  @moduledoc """
+  A message that changes nothing must not cross to native.
+
+  `forward/2` used to repaint after every `handle_info`, whether or not the
+  message changed anything. That is one full render — clear_taps, a register_tap
+  per interactive node, serialisation, set_root, native tree rebuild — per
+  inbound message, so a 30 Hz scroll handler drove 30 of them a second. It also
+  fed a feedback loop, because each render's clear_taps zeroes the per-handle
+  native throttle state: MOB-134 measured 68 vs 69 events for a throttled and an
+  unthrottled handler delivered to a screen, against 33 vs 5 for the same
+  handlers delivered to a plain process.
+
+  Counted at the NIF rather than inferred, so it keeps holding when the render
+  path is rearranged.
+  """
+  use ExUnit.Case, async: false
+
+  @counts :screen_repaint_counts
+
+  defmodule CountingNif do
+    def platform, do: :android
+    def safe_area, do: {0.0, 0.0, 0.0, 0.0}
+    def take_launch_notification, do: :none
+    def set_transition(_), do: :ok
+    def register_tap(_), do: 0
+    def clear_taps, do: bump(:clear_taps)
+    def set_root(_json), do: bump(:set_root)
+
+    defp bump(key) do
+      :ets.update_counter(:screen_repaint_counts, key, 1, {key, 0})
+      :ok
+    end
+  end
+
+  defmodule Screen do
+    use Mob.Screen
+
+    def mount(_params, _session, socket), do: {:ok, Mob.Socket.assign(socket, :count, 0)}
+
+    def render(assigns) do
+      %{
+        type: :text,
+        props: %{text: "#{assigns.count}", text_color: Mob.Theme.current().background},
+        children: []
+      }
+    end
+
+    # Changes an assign — must repaint.
+    def handle_info(:bump, socket),
+      do: {:noreply, Mob.Socket.assign(socket, :count, socket.assigns.count + 1)}
+
+    # Changes nothing — must NOT repaint.
+    def handle_info(:noop, socket), do: {:noreply, socket}
+
+    # Assigns the SAME value — the socket is "touched" but the tree is identical.
+    def handle_info(:reassign_same, socket),
+      do: {:noreply, Mob.Socket.assign(socket, :count, socket.assigns.count)}
+
+    # Changes something render/1 reads that is NOT in assigns. This is why the
+    # check compares the rendered tree and not the assigns.
+    def handle_info(:theme, socket) do
+      Mob.Theme.set(Mob.Theme.Light)
+      {:noreply, socket}
+    end
+
+    def handle_info(_msg, socket), do: {:noreply, socket}
+  end
+
+  setup do
+    :ets.new(@counts, [:public, :named_table, :set])
+
+    # Both must be RUNNING, not stopped: the render path reconciles components
+    # and hands off to Mob.Sender, and set_root is only reached through Sender.
+    started =
+      for mod <- [Mob.ComponentRegistry, Mob.Sender], is_nil(Process.whereis(mod)) do
+        {:ok, pid} = mod.start_link()
+        pid
+      end
+
+    {:ok, router} = Mob.Router.start_root(Screen, %{}, nif: CountingNif)
+    screen = Mob.Screen.get_screen_pid(router)
+
+    on_exit(fn ->
+      stop_safely(router)
+      for pid <- started, do: stop_safely(pid)
+      Mob.Theme.set(Mob.Theme.Dark)
+    end)
+
+    settle()
+    %{screen: screen}
+  end
+
+  defp stop_safely(pid) do
+    GenServer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  # Mob.Sender.render is a cast, so the count lags the send. Wait for the
+  # counter to stop moving rather than calling Mob.Sender.sync/1 — a sync that
+  # exits (Sender restarted, or not the one this ref belongs to) is swallowed by
+  # the catch and reads the counter too early, which turns every "must repaint"
+  # assertion into a silent false failure. That happened while writing this.
+  defp settle(tries \\ 20) do
+    before = renders()
+    Process.sleep(25)
+
+    cond do
+      tries == 0 -> :ok
+      renders() != before -> settle(tries - 1)
+      true -> :ok
+    end
+  end
+
+  defp renders, do: :ets.lookup_element(@counts, :set_root, 2, 0)
+
+  defp after_sending(screen, msg) do
+    before = renders()
+    send(screen, msg)
+    settle()
+    renders() - before
+  end
+
+  test "a message that changes nothing does not cross to native", %{screen: screen} do
+    assert after_sending(screen, :noop) == 0
+  end
+
+  test "assigning the same value again does not cross to native", %{screen: screen} do
+    # A dirty flag set by `assign/3` would repaint here — the socket was written
+    # to, but the user sees nothing new. Comparing the rendered tree does not.
+    assert after_sending(screen, :reassign_same) == 0
+  end
+
+  test "a message that changes the view does cross to native", %{screen: screen} do
+    assert after_sending(screen, :bump) == 1
+  end
+
+  test "a change render/1 reads from outside assigns still repaints", %{screen: screen} do
+    # The reason this compares the tree rather than the assigns. Mob.Theme.set/1
+    # changes what render/1 produces without touching a single assign; an
+    # assigns-based check would skip the repaint and leave the old theme on
+    # screen.
+    assert after_sending(screen, :theme) == 1
+  end
+
+  test "repeated no-op messages stay at zero", %{screen: screen} do
+    before = renders()
+    for _ <- 1..25, do: send(screen, :noop)
+    settle()
+    assert renders() - before == 0
+  end
+
+  test "a real change after no-ops still lands", %{screen: screen} do
+    for _ <- 1..5, do: send(screen, :noop)
+    settle()
+    assert after_sending(screen, :bump) == 1
+  end
+end

--- a/test/mob/screen_repaint_test.exs
+++ b/test/mob/screen_repaint_test.exs
@@ -41,7 +41,7 @@ defmodule Mob.ScreenRepaintTest do
     def render(assigns) do
       %{
         type: :text,
-        props: %{text: "#{assigns.count}", text_color: Mob.Theme.current().background},
+        props: %{text: "#{assigns.count}", text_color: :on_background},
         children: []
       }
     end
@@ -78,16 +78,28 @@ defmodule Mob.ScreenRepaintTest do
         pid
       end
 
+    # Capture the theme that was actually in force. Restoring Mob.Theme.Dark
+    # instead would INSTALL a theme nobody set — Mob.Theme.default/0 is
+    # %Mob.Theme{}, not Dark — and later tests in the same run would then
+    # resolve colours against it.
+    theme_before = Mob.Theme.current()
+
     {:ok, router} = Mob.Router.start_root(Screen, %{}, nif: CountingNif)
     screen = Mob.Screen.get_screen_pid(router)
 
     on_exit(fn ->
       stop_safely(router)
       for pid <- started, do: stop_safely(pid)
-      Mob.Theme.set(Mob.Theme.Dark)
+      # Mob.Router.start_root starts Mob.Listener when render_mode is :render,
+      # globally named and unlinked. Leaving it running makes Mob.Renderer route
+      # every later tap through it, so other files see {listener_pid, {:mob_route,
+      # ...}} where they assert {pid, tag}. Two renderer_test cases failed that
+      # way, and only when the files happened to run in the wrong order.
+      if pid = Process.whereis(Mob.Listener), do: stop_safely(pid)
+      Mob.Theme.set(theme_before)
     end)
 
-    settle()
+    settle(screen)
     %{screen: screen}
   end
 
@@ -97,20 +109,21 @@ defmodule Mob.ScreenRepaintTest do
     :exit, _ -> :ok
   end
 
-  # Mob.Sender.render is a cast, so the count lags the send. Wait for the
-  # counter to stop moving rather than calling Mob.Sender.sync/1 — a sync that
-  # exits (Sender restarted, or not the one this ref belongs to) is swallowed by
-  # the catch and reads the counter too early, which turns every "must repaint"
-  # assertion into a silent false failure. That happened while writing this.
-  defp settle(tries \\ 20) do
-    before = renders()
-    Process.sleep(25)
-
-    cond do
-      tries == 0 -> :ok
-      renders() != before -> settle(tries - 1)
-      true -> :ok
-    end
+  # Deterministic, not timing-based.
+  #
+  # A poll that waits for the counter to stop moving returns immediately on the
+  # "must not repaint" tests — the counter never moves — so it never confirms
+  # the screen even processed the message. Those assertions would then be
+  # satisfied by "nothing has happened yet", which is the flake direction that
+  # silently stops testing anything.
+  #
+  # Instead: a call to the screen proves it handled the message and issued its
+  # render cast (calls are ordered behind the send), and a call to the sender
+  # proves the cast was processed.
+  defp settle(screen) do
+    _ = Mob.Screen.Server.socket(screen)
+    Mob.Sender.sync(:infinity)
+    :ok
   end
 
   defp renders, do: :ets.lookup_element(@counts, :set_root, 2, 0)
@@ -118,7 +131,7 @@ defmodule Mob.ScreenRepaintTest do
   defp after_sending(screen, msg) do
     before = renders()
     send(screen, msg)
-    settle()
+    settle(screen)
     renders() - before
   end
 
@@ -147,13 +160,47 @@ defmodule Mob.ScreenRepaintTest do
   test "repeated no-op messages stay at zero", %{screen: screen} do
     before = renders()
     for _ <- 1..25, do: send(screen, :noop)
-    settle()
+    settle(screen)
     assert renders() - before == 0
   end
 
   test "a real change after no-ops still lands", %{screen: screen} do
     for _ <- 1..5, do: send(screen, :noop)
-    settle()
+    settle(screen)
     assert after_sending(screen, :bump) == 1
+  end
+
+  test "an explicit render request always paints, even with an unchanged tree", %{screen: screen} do
+    # The router paints with `transition: :none` on every push, pop and reset —
+    # the transition rides on the activation, not the paint — and the activation
+    # token is conditional on activation_frame_supported?/0, the hot-code-push
+    # fallback. So neither is a reliable "this is a navigation" signal, and a pop
+    # back to a resident screen whose tree has not changed must not be skipped:
+    # the user would tap back and keep looking at the screen they left.
+    #
+    # Only forward/2 may skip. This pins that.
+    before = renders()
+    Mob.Screen.Server.render(screen, :none)
+    settle(screen)
+    assert renders() - before == 1
+  end
+
+  test "a sync render always paints", %{screen: screen} do
+    # A :sync caller is waiting on a flush; skipping would return before the
+    # frame it is waiting for exists.
+    before = renders()
+    Mob.Screen.Server.render_sync(screen, :none)
+    settle(screen)
+    assert renders() - before == 1
+  end
+
+  test "the theme is part of the comparison, not just the tree", %{screen: screen} do
+    # Belt and braces alongside the :theme message test above. The fixture uses
+    # `text_color: :on_background` — a TOKEN — because token resolution happens
+    # in Mob.Renderer, downstream of the comparison. An earlier version of this
+    # file baked `Mob.Theme.current().background` into the tree instead, which
+    # made the theme test pass against an implementation that ignored the theme
+    # entirely. That is the one shape real screens do not use.
+    assert File.read!(__ENV__.file) =~ "text_color: :on_background"
   end
 end


### PR DESCRIPTION
`Mob.Screen.Server.forward/2` repainted unconditionally after every `handle_info`, with no comparison against the previous state. **Any** message to a screen triggered a full render — walk the tree, `clear_taps`, a `register_tap` per interactive node, serialise, `set_root`, native tree rebuild. A handler that changed nothing cost exactly as much as one that changed everything, so a 30 Hz scroll handler drove 30 full renders per second.

It also fed a feedback loop: each render calls `clear_taps`, which zeroes the per-handle throttle state including `last_emit_ns`, and `throttleCheck` reads that as "no previous emission" and emits unconditionally. **The native throttle was defeated by the very events it was throttling.**

MOB-134 measured it — the same two handlers, differing only in whether their delivery caused a repaint:

| handlers delivered to | default 33ms | configured 500ms |
|---|---|---|
| the screen process | 68 | 69 |
| a plain process | 33 | 5 |

## Compare the tree, not the assigns

Assign comparison is the LiveView model and would be cheaper, but it is wrong here. `render/1` may legitimately read state that is not in assigns — `Mob.Theme.set/1` is the obvious one, and a handler that changes the theme without assigning anything must still repaint; an assigns-based check would leave the old theme on screen. Running `render/1` and comparing its output keeps every such input honest, and still removes the expensive half, since the native crossing dominates per MOB-124's own measurements.

The tree is comparable across frames because handles are assigned later, inside `Mob.Renderer` — at the comparison point interactive nodes still carry their `{pid, tag}`, stable for the life of a screen.

Navigations, activation tokens and `:sync` callers always paint. Skipped repaints are recorded via `RenderStats.drop_frame/1` as uncommitted frames, so the meter reports how many were skipped rather than hiding them.

## Result

Pixel 8 emulator, both handlers on the screen and neither assigning — the shape that previously gave 68 vs 69:

| list | events |
|---|---|
| A default 33ms | 18 |
| B configured 500ms | **4** |

## Tests

Six, counting `set_root` at a stub NIF rather than reasoning about the code, covering both directions: a no-op message, re-assigning the same value, a real change, and a change `render/1` reads from outside assigns. Mutation-checked — restoring the unconditional repaint fails exactly the three "must not repaint" tests and leaves the three "must repaint" ones green.

One trap worth flagging for anyone extending them: settling with `Mob.Sender.sync/1` inside a `catch` reads the counter too early when the sync exits, which turns every "must repaint" assertion into a silent false failure. They wait for the counter to stop moving instead.

1393 tests pass. No version bump — release hold still in effect.

## Deliberately not covered

`render/1` and the expansion passes still run on every message; this removes only the native crossing. Whether a screen should run `render/1` at all for a message it ignored is a separate question. Per-frame handle churn is untouched and remains MOB-124's subject.