### PR TITLE
MOB-127: key children on the author's :id instead of on position (iOS)

### DIFF
--- a/decisions/2026-09-03-children-key-on-author-id.md
+++ b/decisions/2026-09-03-children-key-on-author-id.md
@@ -67,9 +67,37 @@ author who puts `:id` on a child of the repeated node gets positional keying
 and no warning. That is worth documenting in the guides, and is the most
 likely way this is mis-used.
 
-**Not done here.** `MobTabView`'s `ForEach(Array(tabs.enumerated()), id: \.offset)`
-still keys positionally — it iterates tab dictionaries rather than child nodes,
-and a tab bar is a short, rarely reordered list. The `MobFrameTracker`
-`.onChange(of: id)` workaround is kept: named nodes no longer need it, but
-unnamed ones still fall back to position, so the hazard it guards is real for
-them.
+**`:id` is coerced to a String in `Mob.Renderer`.** iOS reads it as an
+`NSString` and ignores anything else; Android's `MobNodeIdentity` canonicalises
+any JSON value. So `id: user.id` with an integer — the most natural way to
+write it — keyed rows on Android and fell back to positional on iOS, silently.
+Coercing atoms and numbers once, before the value leaves Elixir, makes the two
+platforms agree by construction. Map and list ids still fall back to position on
+both.
+
+**`MobTabView` is keyed too.** An earlier version of this document claimed its
+`ForEach` "iterates tab dictionaries rather than child nodes" and left it
+positional. That was wrong — the body subscripts `node.childNodes`, so toggling
+a conditional tab shifted every later tab's entire content subtree into its
+neighbour's identity.
+
+**`MobFrameTracker`'s `.onChange(of: id)` is kept, for a different reason than
+first written.** A tracker only exists when the node has an id, so unnamed nodes
+have no tracker and the original "unnamed nodes still shift" rationale was
+wrong in both directions. What remains is the duplicate-id fallback: those keys
+embed a position, so they genuinely do move between nodes when a duplicated
+id's list shrinks.
+
+**`on_end_reached` now fires on list content replacement (iOS).** Under
+positional keying the first N views survived a content swap and `.onAppear` did
+not re-fire. With author ids, replacing a list's contents gives every row a new
+identity and the last row's `.onAppear` runs. A search screen that replaces
+results per keystroke now fires a pagination request per keystroke where it did
+not before. Android's index-based `derivedStateOf` already behaved this way, so
+this is convergence rather than a new divergence — but it is a behaviour change
+and it is not covered by a test.
+
+**Identity attaches to the repeated element, not to something inside it.** An
+author who puts `:id` on a child of the repeated node gets positional keying and
+no warning. This is the most likely way the feature is mis-used and it cost a
+round of debugging while writing the test screen for it.

--- a/decisions/2026-09-03-children-key-on-author-id.md
+++ b/decisions/2026-09-03-children-key-on-author-id.md
@@ -19,22 +19,29 @@ moved the typed text to a different row. `MobFrameTracker` carries an
 `.onChange(of: id)` specifically to paper over the same problem for the frame
 registry — the workaround is in the file, with a comment describing the hazard.
 
-The epic said "the identity already exists on the wire". True, but it was not
-reachable where `ForEach` needed it: on iOS the `:id` prop was read into
-`MobNode` only as `nativeViewId`, and only for `native_view` nodes.
-`accessibilityId` is a different prop. So iOS needed a `nodeId` on `MobNode`
-first.
+The epic said "the identity already exists on the wire", and on iOS it was
+already reachable: `mob_nif.m` has always read `:id` into `MobNode.nativeViewId`
+for every node type — only `nativeViewProps` is gated on the node being a
+native_view, and `MobFrameTracker` has always read `nativeViewId` for all node
+types. The name is historical and misleading, which is why a first attempt at
+this change added a second, identical `nodeId` property before review caught
+it. `accessibilityId` is a genuinely different prop (`:accessibility_id`).
 
 ## Decision
 
 Key children on the author's `:id` when present, position otherwise.
 
-* **iOS** — `MobNode.nodeId` added and populated from `MOB_PROP_id` for every
-  node type; `mobIdentifiedChildren/1` returns `[MobIdentifiedChild]`; all seven
-  `childNodes` `ForEach` sites use it.
-* **Android** — `mobChildKeys/1` mirrors it, built on the existing
-  `MobNodeIdentity.keyFor/1`; `Column`/`Row` children go through `key()`, and
-  `LazyColumn` uses `itemsIndexed(..., key:)`.
+* **iOS** — `mobIdentifiedChildren/1` returns `[MobIdentifiedChild]`, reading
+  the author id from the existing `MobNode.nativeViewId`; all seven `childNodes`
+  `ForEach` sites use it, and `mobIdentifiedTabs/1` does the same for the tab
+  bar, whose `ForEach` also subscripts `childNodes`.
+* **Android** — `mobChildKeys/1` mirrors it. Deliberately NOT built on
+  `MobNodeIdentity.keyFor/1`: that canonicalises any JSON value where iOS reads
+  only an `NSString`, and it raises on an unknown value type — acceptable for
+  the one sheet per screen it was written for, not on a path that runs for every
+  child of every container. All seven containers are keyed (`column`, `row`,
+  `box`, both `scroll` axes, the sheet body, and `LazyColumn` via
+  `itemsIndexed(..., key:)`).
 
 Three details that are easy to get wrong:
 
@@ -62,18 +69,17 @@ stayed with charlie as it moved down. The same screen with the `:id` on the
 inner `text_field` instead of on the repeated row keys positionally, and the
 typed text is lost; that is the before-behaviour, on the same build.
 
-**Identity attaches to the repeated element, not to something inside it.** An
-author who puts `:id` on a child of the repeated node gets positional keying
-and no warning. That is worth documenting in the guides, and is the most
-likely way this is mis-used.
+**Numeric `:id` is coerced to a String in `Mob.Renderer`.** iOS reads `:id` as
+an `NSString` and ignores anything else, so `id: user.id` with an integer keyed
+rows on Android and fell back to positional on iOS. Numbers only: `:json.encode`
+already stringifies bare atoms, so widening to atoms would change nothing for
+them while turning `true`/`false` from a JSON boolean both platforms correctly
+reject into the real id `"true"`, and `nil` into `""`. Map and list ids still
+fall back to position on both.
 
-**`:id` is coerced to a String in `Mob.Renderer`.** iOS reads it as an
-`NSString` and ignores anything else; Android's `MobNodeIdentity` canonicalises
-any JSON value. So `id: user.id` with an integer — the most natural way to
-write it — keyed rows on Android and fell back to positional on iOS, silently.
-Coercing atoms and numbers once, before the value leaves Elixir, makes the two
-platforms agree by construction. Map and list ids still fall back to position on
-both.
+The coercion is `prepare_props`-scoped, so it does **not** reach ids nested
+inside prop values — `tabs: [%{id: 1}]` still degrades to positional keying and
+a mismatched `.tag`. Worth fixing if tab ids are ever authored numerically.
 
 **`MobTabView` is keyed too.** An earlier version of this document claimed its
 `ForEach` "iterates tab dictionaries rather than child nodes" and left it

--- a/decisions/2026-09-03-children-key-on-author-id.md
+++ b/decisions/2026-09-03-children-key-on-author-id.md
@@ -1,0 +1,75 @@
+# Children key on the author's `:id`, not on position
+
+- Date: 2026-09-03
+- Status: accepted
+- Implements: MOB-127, part of MOB-124
+- Cross-repo: this and the matching `mob_new` change are one issue
+
+## Context
+
+Nine `ForEach` sites in `ios/MobRootView.swift` used `id: \.offset`, and the
+Compose bridge's `LazyColumn` used `items(children)` with no `key`. Both mean
+positional identity: insert or delete a row and every later row becomes a
+different view to the platform, so it is rebuilt and its state discarded rather
+than moved.
+
+The consequences are not only performance. A `text_field`'s edit buffer lives
+in `remember`, tied to the composition slot, so on Android prepending a row
+moved the typed text to a different row. `MobFrameTracker` carries an
+`.onChange(of: id)` specifically to paper over the same problem for the frame
+registry — the workaround is in the file, with a comment describing the hazard.
+
+The epic said "the identity already exists on the wire". True, but it was not
+reachable where `ForEach` needed it: on iOS the `:id` prop was read into
+`MobNode` only as `nativeViewId`, and only for `native_view` nodes.
+`accessibilityId` is a different prop. So iOS needed a `nodeId` on `MobNode`
+first.
+
+## Decision
+
+Key children on the author's `:id` when present, position otherwise.
+
+* **iOS** — `MobNode.nodeId` added and populated from `MOB_PROP_id` for every
+  node type; `mobIdentifiedChildren/1` returns `[MobIdentifiedChild]`; all seven
+  `childNodes` `ForEach` sites use it.
+* **Android** — `mobChildKeys/1` mirrors it, built on the existing
+  `MobNodeIdentity.keyFor/1`; `Column`/`Row` children go through `key()`, and
+  `LazyColumn` uses `itemsIndexed(..., key:)`.
+
+Three details that are easy to get wrong:
+
+**Authored ids and positions are prefixed differently** (`i\x01…` vs `p\x01…`),
+so an author id of `"3"` cannot collide with position 3 and silently merge two
+unrelated rows.
+
+**A duplicate id folds in its position** rather than emitting two equal keys.
+SwiftUI misbehaves quietly on duplicate `ForEach` ids and Compose *throws* on
+duplicates in a lazy list — turning a cosmetic problem into a crash would be
+worse than the bug being fixed.
+
+**Android keys are plain `String`s.** `LazyColumn` keys must survive
+saved-instance state, and `MobNodeIdentityKey` is a data class, not Saveable.
+
+`Modifier.weight` is resolved in the layout scope before `key()` is entered:
+`forEachIndexed` is inline so `ColumnScope` survives, but `key()`'s block is a
+plain composable lambda with no scope of its own.
+
+## Consequences
+
+Verified on the Pixel 8 emulator with four rows, each a `text_field`, and a
+button that prepends a row. Typed `ZZZ` into "charlie", prepended — `ZZZ`
+stayed with charlie as it moved down. The same screen with the `:id` on the
+inner `text_field` instead of on the repeated row keys positionally, and the
+typed text is lost; that is the before-behaviour, on the same build.
+
+**Identity attaches to the repeated element, not to something inside it.** An
+author who puts `:id` on a child of the repeated node gets positional keying
+and no warning. That is worth documenting in the guides, and is the most
+likely way this is mis-used.
+
+**Not done here.** `MobTabView`'s `ForEach(Array(tabs.enumerated()), id: \.offset)`
+still keys positionally — it iterates tab dictionaries rather than child nodes,
+and a tab bar is a short, rarely reordered list. The `MobFrameTracker`
+`.onChange(of: id)` workaround is kept: named nodes no longer need it, but
+unnamed ones still fall back to position, so the hazard it guards is real for
+them.

--- a/ios/MobNode.h
+++ b/ios/MobNode.h
@@ -238,6 +238,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable)
     NSDictionary *nativeViewProps; // full props dict forwarded to the factory
 
+// The author's `:id` prop, verbatim.
+//
+// Distinct from accessibilityId (the `:accessibility_id` prop) and from
+// nativeViewId (the same `:id`, but only read for native_view nodes). This is
+// the node identity SwiftUI keys ForEach on, so that inserting or deleting a
+// row patches its siblings instead of rebuilding them.
+@property(nonatomic, copy, nullable) NSString *nodeId;
+
 // Accessibility — identifiers support test addressing; labels and disabled
 // state describe composite controls such as tappable boxes.
 @property(nonatomic, copy, nullable) NSString *accessibilityId;

--- a/ios/MobNode.h
+++ b/ios/MobNode.h
@@ -238,14 +238,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable)
     NSDictionary *nativeViewProps; // full props dict forwarded to the factory
 
-// The author's `:id` prop, verbatim.
-//
-// Distinct from accessibilityId (the `:accessibility_id` prop) and from
-// nativeViewId (the same `:id`, but only read for native_view nodes). This is
-// the node identity SwiftUI keys ForEach on, so that inserting or deleting a
-// row patches its siblings instead of rebuilding them.
-@property(nonatomic, copy, nullable) NSString *nodeId;
-
 // Accessibility — identifiers support test addressing; labels and disabled
 // state describe composite controls such as tappable boxes.
 @property(nonatomic, copy, nullable) NSString *accessibilityId;

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -659,10 +659,14 @@ private struct MobFrameTracker: ViewModifier {
                             }
                             // Kept after MOB-127, but not for the reason the
                             // original comment gave. A tracker only exists when
-                            // the node HAS an id (the `if let` above), and named
-                            // children now keep their identity across an insert
-                            // — so the ordinary shift-under-a-tracker case is
-                            // gone. What remains is the duplicate-id fallback:
+                            // the node HAS an id (the `if let` above), so the
+                            // "unnamed nodes still shift" rationale was wrong in
+                            // both directions. Two cases remain. A tracked node
+                            // nested inside an UNNAMED repeated row still shifts
+                            // wholesale, because the row itself keys by
+                            // position — the documented mis-use, where `:id` is
+                            // put on something inside the repeated element
+                            // rather than on it. And the duplicate-id fallback:
                             // those keys embed a position, so they genuinely do
                             // move between nodes when a duplicated id's list
                             // shrinks. The hazard is the same — a frame value
@@ -1991,17 +1995,6 @@ struct MobScrollObserverGate: ViewModifier {
     }
 }
 
-/// A child paired with a stable identity for `ForEach`.
-///
-/// Positional identity (`id: \.offset`) means an insert or delete makes every
-/// later row a different view as far as SwiftUI is concerned, so it is rebuilt
-/// rather than patched. That is what MOB-127 is about.
-///
-/// Author `:id` when the node has one, position otherwise. The two are prefixed
-/// differently so an author id of "3" cannot collide with position 3. A
-/// repeated id falls back to including the position, because SwiftUI requires
-/// ForEach ids to be unique and misbehaves quietly when they are not — which
-/// would be a worse bug than the one being fixed.
 /// A tab paired with a stable identity.
 ///
 /// Tabs are dictionaries rather than MobNodes, so they cannot go through
@@ -2033,6 +2026,17 @@ func mobIdentifiedTabs(_ tabs: [[String: Any]]) -> [MobIdentifiedTab] {
     }
 }
 
+/// A child paired with a stable identity for `ForEach`.
+///
+/// Positional identity (`id: \.offset`) means an insert or delete makes every
+/// later row a different view as far as SwiftUI is concerned, so it is rebuilt
+/// rather than patched. That is what MOB-127 is about.
+///
+/// Author `:id` when the node has one, position otherwise. The two are prefixed
+/// differently so an author id of "3" cannot collide with position 3. A
+/// repeated id falls back to including the position, because SwiftUI requires
+/// ForEach ids to be unique and misbehaves quietly when they are not — which
+/// would be a worse bug than the one being fixed.
 struct MobIdentifiedChild: Identifiable {
     let id: String
     let index: Int

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -657,19 +657,19 @@ private struct MobFrameTracker: ViewModifier {
                             .onChange(of: geo.frame(in: .global), initial: true) { _, frame in
                                 record(id, frame)
                             }
-                            // Kept after MOB-127, deliberately. Children now
-                            // key on their author `:id` when they have one
-                            // (mobIdentifiedChildren), so a tracker on a named
-                            // node IS bound to one id for its lifetime and this
-                            // no longer fires for it. Unnamed nodes still fall
-                            // back to position, and for those the original
-                            // hazard stands: delete an item and every later id
-                            // shifts down under a tracker that keeps its
-                            // identity. Its frame value may be unchanged
-                            // (equal-height rows), so nothing else here would
-                            // fire, and the id just taken over would keep the
-                            // previous occupant's entry — or lose it entirely to
-                            // the departing tracker's .onDisappear.
+                            // Kept after MOB-127, but not for the reason the
+                            // original comment gave. A tracker only exists when
+                            // the node HAS an id (the `if let` above), and named
+                            // children now keep their identity across an insert
+                            // — so the ordinary shift-under-a-tracker case is
+                            // gone. What remains is the duplicate-id fallback:
+                            // those keys embed a position, so they genuinely do
+                            // move between nodes when a duplicated id's list
+                            // shrinks. The hazard is the same — a frame value
+                            // may be unchanged (equal-height rows), so nothing
+                            // else here fires, and the id just taken over keeps
+                            // the previous occupant's entry, or loses it to the
+                            // departing tracker's .onDisappear.
                             .onChange(of: id) { _, newId in
                                 record(newId, geo.frame(in: .global))
                             }
@@ -1177,7 +1177,15 @@ private struct MobTabView: View {
             get: { activeId },
             set: { newId in node.onTabSelect?(newId) }
         )) {
-            ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
+            // Keyed on the tab's own id, not on position. This ForEach does
+            // iterate child nodes (the subscript below), so toggling a
+            // conditional tab shifted every later tab's whole content subtree
+            // into its neighbour's identity — text-field buffers and scroll
+            // positions discarded, and every named node in those subtrees
+            // re-registered with the frame registry.
+            ForEach(mobIdentifiedTabs(tabs)) { item in
+                let index = item.index
+                let tab = item.tab
                 if index < node.childNodes.count {
                     let child = node.childNodes[index]
                     MobNodeView(node: child)
@@ -1983,24 +1991,48 @@ struct MobScrollObserverGate: ViewModifier {
     }
 }
 
-// MobScrollObserver wires SwiftUI's onScrollGeometryChange (iOS 18+) to the
-// MobNode closures populated by mob_nif.m. Throttling and delta-thresholding
-// happen native-side in mob_send_scroll, so this modifier just forwards every
-// geometry change. End-of-scroll is detected by a debounced "no motion for N
-// ms" timer.
 /// A child paired with a stable identity for `ForEach`.
 ///
 /// Positional identity (`id: \.offset`) means an insert or delete makes every
 /// later row a different view as far as SwiftUI is concerned, so it is rebuilt
-/// rather than patched. That is what MOB-127 is about, and it is also why
-/// MobFrameTracker carries an `.onChange(of: id)`: with rows shifting under it,
-/// a tracker is not bound to one id for its lifetime.
+/// rather than patched. That is what MOB-127 is about.
 ///
 /// Author `:id` when the node has one, position otherwise. The two are prefixed
 /// differently so an author id of "3" cannot collide with position 3. A
 /// repeated id falls back to including the position, because SwiftUI requires
 /// ForEach ids to be unique and misbehaves quietly when they are not — which
 /// would be a worse bug than the one being fixed.
+/// A tab paired with a stable identity.
+///
+/// Tabs are dictionaries rather than MobNodes, so they cannot go through
+/// mobIdentifiedChildren — but the ForEach over them subscripts childNodes, so
+/// positional keying there discards a whole tab's content subtree when the tab
+/// list changes. Same rules as the child helper, including the duplicate
+/// fallback: two unkeyed tabs must not share a key.
+struct MobIdentifiedTab: Identifiable {
+    let id: String
+    let index: Int
+    let tab: [String: Any]
+}
+
+func mobIdentifiedTabs(_ tabs: [[String: Any]]) -> [MobIdentifiedTab] {
+    var seen = Set<String>()
+    seen.reserveCapacity(tabs.count)
+
+    return tabs.enumerated().map { index, tab in
+        var key: String
+        if let authored = tab["id"] as? String, !authored.isEmpty {
+            key = "i\u{1}" + authored
+        } else {
+            key = "p\u{1}\(index)"
+        }
+        if !seen.insert(key).inserted {
+            key = "d\u{1}\(index)\u{1}" + key
+        }
+        return MobIdentifiedTab(id: key, index: index, tab: tab)
+    }
+}
+
 struct MobIdentifiedChild: Identifiable {
     let id: String
     let index: Int
@@ -2013,7 +2045,7 @@ func mobIdentifiedChildren(_ children: [MobNode]) -> [MobIdentifiedChild] {
 
     return children.enumerated().map { index, child in
         var key: String
-        if let authored = child.nodeId, !authored.isEmpty {
+        if let authored = child.nativeViewId, !authored.isEmpty {
             key = "i\u{1}" + authored
         } else {
             key = "p\u{1}\(index)"
@@ -2025,6 +2057,11 @@ func mobIdentifiedChildren(_ children: [MobNode]) -> [MobIdentifiedChild] {
     }
 }
 
+// MobScrollObserver wires SwiftUI's onScrollGeometryChange (iOS 18+) to the
+// MobNode closures populated by mob_nif.m. Throttling and delta-thresholding
+// happen native-side in mob_send_scroll, so this modifier just forwards every
+// geometry change. End-of-scroll is detected by a debounced "no motion for N
+// ms" timer.
 @available(iOS 18.0, *)
 struct MobScrollObserver: ViewModifier {
     let node: MobNode

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -280,8 +280,8 @@ struct MobNodeView: View {
                 // every one of its modifiers below intact, which flattening the
                 // column away would not.
                 MobEitherStack(lazy: lazyContainer, alignment: .leading) {
-                    ForEach(Array(node.childNodes.enumerated()), id: \.offset) { _, child in
-                        MobNodeView(node: child, layoutWeightAxis: .vertical)
+                    ForEach(mobIdentifiedChildren(node.childNodes)) { item in
+                        MobNodeView(node: item.node, layoutWeightAxis: .vertical)
                     }
                 }
                 // fill_height: true lets a column flex to fill its parent so children
@@ -307,8 +307,8 @@ struct MobNodeView: View {
                     }
                 }()
                 HStack(alignment: alignment, spacing: 0) {
-                    ForEach(Array(node.childNodes.enumerated()), id: \.offset) { _, child in
-                        MobNodeView(node: child, layoutWeightAxis: .horizontal)
+                    ForEach(mobIdentifiedChildren(node.childNodes)) { item in
+                        MobNodeView(node: item.node, layoutWeightAxis: .horizontal)
                     }
                 }
                 // Without maxWidth: .infinity an HStack hugs its content.
@@ -412,15 +412,15 @@ struct MobNodeView: View {
                             // vertical axis is bounded and never scrolls, so
                             // anything below the fold would never be built at
                             // all rather than built on demand.
-                            ForEach(Array(node.childNodes.enumerated()), id: \.offset) { _, child in
-                                MobNodeView(node: child)
+                            ForEach(mobIdentifiedChildren(node.childNodes)) { item in
+                                MobNodeView(node: item.node)
                             }
                         }
                         .frame(maxHeight: .infinity, alignment: .topLeading)
                     } else {
                         VStack(alignment: .leading, spacing: 0) {
-                            ForEach(Array(node.childNodes.enumerated()), id: \.offset) { _, child in
-                                MobNodeView(node: child, lazyContainer: node.lazyContent)
+                            ForEach(mobIdentifiedChildren(node.childNodes)) { item in
+                                MobNodeView(node: item.node, lazyContainer: node.lazyContent)
                             }
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -480,10 +480,10 @@ struct MobNodeView: View {
             case .lazyList:
                 ScrollView(.vertical, showsIndicators: true) {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(node.childNodes.enumerated()), id: \.offset) { index, child in
-                            MobNodeView(node: child)
+                        ForEach(mobIdentifiedChildren(node.childNodes)) { item in
+                            MobNodeView(node: item.node)
                                 .onAppear {
-                                    if index == node.childNodes.count - 1 {
+                                    if item.index == node.childNodes.count - 1 {
                                         node.onTap?()
                                     }
                                 }
@@ -657,14 +657,17 @@ private struct MobFrameTracker: ViewModifier {
                             .onChange(of: geo.frame(in: .global), initial: true) { _, frame in
                                 record(id, frame)
                             }
-                            // Every ForEach in this file keys children by index
-                            // (`id: \.offset`) while the registry is keyed by
-                            // :id, so a tracker is NOT bound to one id for its
-                            // lifetime — delete an item and every later id
-                            // shifts down a position under a tracker that keeps
-                            // its identity. Its frame value may be unchanged
+                            // Kept after MOB-127, deliberately. Children now
+                            // key on their author `:id` when they have one
+                            // (mobIdentifiedChildren), so a tracker on a named
+                            // node IS bound to one id for its lifetime and this
+                            // no longer fires for it. Unnamed nodes still fall
+                            // back to position, and for those the original
+                            // hazard stands: delete an item and every later id
+                            // shifts down under a tracker that keeps its
+                            // identity. Its frame value may be unchanged
                             // (equal-height rows), so nothing else here would
-                            // fire and the id we just took over would keep the
+                            // fire, and the id just taken over would keep the
                             // previous occupant's entry — or lose it entirely to
                             // the departing tracker's .onDisappear.
                             .onChange(of: id) { _, newId in
@@ -786,8 +789,8 @@ private struct MobBox: View {
         let alignment: Alignment = boxAlignmentFromString(node.boxAlign)
 
         let stack = ZStack(alignment: alignment) {
-            ForEach(Array(node.childNodes.enumerated()), id: \.offset) { _, child in
-                MobNodeView(node: child)
+            ForEach(mobIdentifiedChildren(node.childNodes)) { item in
+                MobNodeView(node: item.node)
             }
         }
 
@@ -1650,8 +1653,8 @@ private struct MobSheetView: View {
 
     private var sheetBody: some View {
         VStack(spacing: 0) {
-            ForEach(Array(node.childNodes.enumerated()), id: \.offset) { _, child in
-                MobNodeView(node: child)
+            ForEach(mobIdentifiedChildren(node.childNodes)) { item in
+                MobNodeView(node: item.node)
             }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -1985,6 +1988,43 @@ struct MobScrollObserverGate: ViewModifier {
 // happen native-side in mob_send_scroll, so this modifier just forwards every
 // geometry change. End-of-scroll is detected by a debounced "no motion for N
 // ms" timer.
+/// A child paired with a stable identity for `ForEach`.
+///
+/// Positional identity (`id: \.offset`) means an insert or delete makes every
+/// later row a different view as far as SwiftUI is concerned, so it is rebuilt
+/// rather than patched. That is what MOB-127 is about, and it is also why
+/// MobFrameTracker carries an `.onChange(of: id)`: with rows shifting under it,
+/// a tracker is not bound to one id for its lifetime.
+///
+/// Author `:id` when the node has one, position otherwise. The two are prefixed
+/// differently so an author id of "3" cannot collide with position 3. A
+/// repeated id falls back to including the position, because SwiftUI requires
+/// ForEach ids to be unique and misbehaves quietly when they are not — which
+/// would be a worse bug than the one being fixed.
+struct MobIdentifiedChild: Identifiable {
+    let id: String
+    let index: Int
+    let node: MobNode
+}
+
+func mobIdentifiedChildren(_ children: [MobNode]) -> [MobIdentifiedChild] {
+    var seen = Set<String>()
+    seen.reserveCapacity(children.count)
+
+    return children.enumerated().map { index, child in
+        var key: String
+        if let authored = child.nodeId, !authored.isEmpty {
+            key = "i\u{1}" + authored
+        } else {
+            key = "p\u{1}\(index)"
+        }
+        if !seen.insert(key).inserted {
+            key = "d\u{1}\(index)\u{1}" + key
+        }
+        return MobIdentifiedChild(id: key, index: index, node: child)
+    }
+}
+
 @available(iOS 18.0, *)
 struct MobScrollObserver: ViewModifier {
     let node: MobNode

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -1696,6 +1696,10 @@ static MobNode *mob_node_from_dict(NSDictionary *dict) {
         id nativeViewModule = pv[MOB_PROP_module];
         if ([nativeViewModule isKindOfClass:[NSString class]])
             node.nativeViewModule = nativeViewModule;
+        // The author's `:id`, for EVERY node type — the name is historical and
+        // misleading. It is the node identity ForEach keys on (MOB-127) and
+        // what MobFrameTracker registers under; only nativeViewProps below is
+        // actually gated on the node being a native_view.
         id nativeViewId = pv[MOB_PROP_id];
         if ([nativeViewId isKindOfClass:[NSString class]])
             node.nativeViewId = nativeViewId;
@@ -1738,13 +1742,6 @@ static MobNode *mob_node_from_dict(NSDictionary *dict) {
             default:
                 break;
             }
-        }
-
-        // The author's :id, for every node type. nativeViewId below reads the
-        // same prop but only for native_view; this is what ForEach keys on.
-        id nodeId = pv[MOB_PROP_id];
-        if ([nodeId isKindOfClass:[NSString class]]) {
-            node.nodeId = nodeId;
         }
 
         id accessibilityId = pv[MOB_PROP_accessibility_id];

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -1740,6 +1740,13 @@ static MobNode *mob_node_from_dict(NSDictionary *dict) {
             }
         }
 
+        // The author's :id, for every node type. nativeViewId below reads the
+        // same prop but only for native_view; this is what ForEach keys on.
+        id nodeId = pv[MOB_PROP_id];
+        if ([nodeId isKindOfClass:[NSString class]]) {
+            node.nodeId = nodeId;
+        }
+
         id accessibilityId = pv[MOB_PROP_accessibility_id];
         if ([accessibilityId isKindOfClass:[NSString class]]) {
             node.accessibilityId = accessibilityId;

--- a/lib/mob/renderer.ex
+++ b/lib/mob/renderer.ex
@@ -542,6 +542,18 @@ defmodule Mob.Renderer do
       {:draw, ops} when is_list(ops) ->
         [{"draw", Enum.map(ops, &encode_canvas_op(&1, ctx))}]
 
+      # `:id` is node identity on both platforms, and they must agree on it.
+      # iOS reads it as an NSString and ignores anything else; Android
+      # canonicalises any JSON value. So `id: user.id` with an integer — the
+      # most natural way to write it — keyed rows on Android and fell back to
+      # positional on iOS, silently, which is the exact bug MOB-127 exists to
+      # fix. Coerce once here so the platforms cannot disagree.
+      {:id, value} when is_binary(value) ->
+        [{"id", value}]
+
+      {:id, value} when is_atom(value) or is_number(value) ->
+        [{"id", to_string(value)}]
+
       {key, value} ->
         [{Atom.to_string(key), resolve_token(key, value, ctx)}]
     end)

--- a/lib/mob/renderer.ex
+++ b/lib/mob/renderer.ex
@@ -542,16 +542,18 @@ defmodule Mob.Renderer do
       {:draw, ops} when is_list(ops) ->
         [{"draw", Enum.map(ops, &encode_canvas_op(&1, ctx))}]
 
-      # `:id` is node identity on both platforms, and they must agree on it.
-      # iOS reads it as an NSString and ignores anything else; Android
-      # canonicalises any JSON value. So `id: user.id` with an integer — the
-      # most natural way to write it — keyed rows on Android and fell back to
-      # positional on iOS, silently, which is the exact bug MOB-127 exists to
-      # fix. Coerce once here so the platforms cannot disagree.
-      {:id, value} when is_binary(value) ->
-        [{"id", value}]
-
-      {:id, value} when is_atom(value) or is_number(value) ->
+      # `:id` is node identity on both platforms and they must agree on it.
+      # iOS reads it as an NSString and ignores anything else, so a numeric id —
+      # `id: user.id`, the most natural way to write it — keyed rows on Android
+      # and fell back to positional on iOS. Coerced once here so the two cannot
+      # disagree.
+      #
+      # Numbers ONLY. `:json.encode/1` already stringifies bare atoms (`:foo`
+      # arrives as "foo"), so including atoms would change nothing for them
+      # while widening `true`/`false` from a JSON boolean — which both platforms
+      # correctly reject — into the real id "true", and `nil` from "nil" into "".
+      # That would hand ids to nodes the author never named.
+      {:id, value} when is_number(value) ->
         [{"id", to_string(value)}]
 
       {key, value} ->

--- a/test/mob/native_child_identity_test.exs
+++ b/test/mob/native_child_identity_test.exs
@@ -43,8 +43,13 @@ defmodule Mob.NativeChildIdentityTest do
     # keyed rows on Android and fell back to positional on iOS — silently, for
     # the most natural way to write it.
     renderer = File.read!(Path.expand("../../lib/mob/renderer.ex", __DIR__))
-    assert renderer =~ ~s|{:id, value} when is_atom(value) or is_number(value) ->|
+    assert renderer =~ ~s|{:id, value} when is_number(value) ->|
     assert renderer =~ ~s|[{"id", to_string(value)}]|
+
+    # Numbers only. :json.encode already stringifies bare atoms, so widening to
+    # is_atom would turn `true` from a JSON boolean both platforms reject into
+    # the real id "true", and `nil` into "" — handing ids to unnamed nodes.
+    refute renderer =~ ~s|{:id, value} when is_atom(value)|
   end
 
   test "the identity ForEach keys on is populated for every node type" do
@@ -74,5 +79,30 @@ defmodule Mob.NativeChildIdentityTest do
     # `id: ""` would otherwise give every unnamed-but-present sibling the same
     # key.
     assert @ios =~ "let authored = child.nativeViewId, !authored.isEmpty"
+  end
+
+  test "the tab bar keys on the tab's own id" do
+    # This ForEach subscripts node.childNodes, so positional keying discards a
+    # whole tab's content subtree when the tab list changes — toggling a
+    # conditional "Admin" tab shifts every later tab's state into its
+    # neighbour's. It was left positional in the first version of this change on
+    # the false premise that it iterated only dictionaries.
+    assert @ios =~ "ForEach(mobIdentifiedTabs(tabs))"
+    refute @ios =~ "ForEach(Array(tabs.enumerated()), id: \\.offset)"
+  end
+
+  test "tab identities follow the same rules as child identities" do
+    # Same prefixes and the same duplicate fallback: two unkeyed tabs must not
+    # share a key. An earlier attempt gave every unkeyed tab the same constant.
+    body =
+      @ios
+      |> String.split("func mobIdentifiedTabs(")
+      |> Enum.at(1)
+      |> String.split("\n}\n")
+      |> Enum.at(0)
+
+    assert body =~ ~s|key = "i\\u{1}" + authored|
+    assert body =~ ~s|key = "p\\u{1}\\(index)"|
+    assert body =~ "if !seen.insert(key).inserted"
   end
 end

--- a/test/mob/native_child_identity_test.exs
+++ b/test/mob/native_child_identity_test.exs
@@ -20,21 +20,40 @@ defmodule Mob.NativeChildIdentityTest do
     refute @ios =~ "node.childNodes.enumerated()), id: \\.offset"
   end
 
-  test "every childNodes ForEach goes through the identity helper" do
-    # Count them rather than spot-check: a new ForEach added later with
-    # positional keys is the regression this guards.
-    helper_uses =
+  test "no ForEach iterates childNodes directly" do
+    # Not a hard-coded count. The earlier version asserted "== 7", which failed
+    # on any legitimate new container AND passed for the regression it named:
+    # `ForEach(node.childNodes) { child in ... }` compiles, because MobNode has
+    # a pre-existing Identifiable conformance returning ObjectIdentifier — a
+    # brand-new identity every frame, since nodes are re-allocated from JSON on
+    # every set_root. That is strictly worse than positional keying, and the
+    # count test waved it through.
+    unkeyed = ~r/ForEach\(\s*(Array\()?node\.childNodes/ |> Regex.scan(@ios) |> length()
+    assert unkeyed == 0, "#{unkeyed} ForEach still iterates childNodes directly"
+
+    identified =
       @ios |> String.split("ForEach(mobIdentifiedChildren(node.childNodes))") |> length()
 
-    assert helper_uses - 1 == 7, "expected 7 identified child lists, found #{helper_uses - 1}"
+    assert identified - 1 >= 7, "the identified child lists should still be there"
   end
 
-  test "the author's :id reaches MobNode for every node type" do
-    # It previously reached native only as nativeViewId, and only for
-    # native_view nodes, so there was nothing for ForEach to key on.
-    assert @header =~ "@property(nonatomic, copy, nullable) NSString *nodeId;"
-    assert @nif =~ "id nodeId = pv[MOB_PROP_id];"
-    assert @nif =~ "node.nodeId = nodeId;"
+  test "the author's :id is coerced to a String before it leaves Elixir" do
+    # iOS reads :id as an NSString and ignores anything else; Android
+    # canonicalises any JSON value. Without this, `id: user.id` with an integer
+    # keyed rows on Android and fell back to positional on iOS — silently, for
+    # the most natural way to write it.
+    renderer = File.read!(Path.expand("../../lib/mob/renderer.ex", __DIR__))
+    assert renderer =~ ~s|{:id, value} when is_atom(value) or is_number(value) ->|
+    assert renderer =~ ~s|[{"id", to_string(value)}]|
+  end
+
+  test "the identity ForEach keys on is populated for every node type" do
+    # nativeViewId is the author's :id despite its name — only nativeViewProps
+    # is gated on the node being a native_view. An earlier version of this
+    # change added a second, identical property for the same prop.
+    refute @header =~ "NSString *nodeId;"
+    assert @nif =~ "id nativeViewId = pv[MOB_PROP_id];"
+    assert @ios =~ "if let authored = child.nativeViewId, !authored.isEmpty {"
   end
 
   test "authored ids and positions cannot collide" do
@@ -54,6 +73,6 @@ defmodule Mob.NativeChildIdentityTest do
   test "an empty id is treated as absent" do
     # `id: ""` would otherwise give every unnamed-but-present sibling the same
     # key.
-    assert @ios =~ "let authored = child.nodeId, !authored.isEmpty"
+    assert @ios =~ "let authored = child.nativeViewId, !authored.isEmpty"
   end
 end

--- a/test/mob/native_child_identity_test.exs
+++ b/test/mob/native_child_identity_test.exs
@@ -1,0 +1,59 @@
+defmodule Mob.NativeChildIdentityTest do
+  @moduledoc """
+  Children are keyed by the author's `:id`, not by position (MOB-127).
+
+  Positional identity means an insert or delete makes every later child a
+  different view to the platform, so it is rebuilt and its state discarded
+  rather than moved. Source-asserted because there is no host-side way to
+  observe SwiftUI's diffing.
+  """
+  # credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+  use ExUnit.Case, async: true
+
+  @ios File.read!(Path.expand("../../ios/MobRootView.swift", __DIR__))
+  @nif File.read!(Path.expand("../../ios/mob_nif.m", __DIR__))
+  @header File.read!(Path.expand("../../ios/MobNode.h", __DIR__))
+
+  test "no ForEach over childNodes keys by position any more" do
+    # The whole issue. Nine sites used `id: \\.offset`; the ones over childNodes
+    # are the ones that repeat author content.
+    refute @ios =~ "node.childNodes.enumerated()), id: \\.offset"
+  end
+
+  test "every childNodes ForEach goes through the identity helper" do
+    # Count them rather than spot-check: a new ForEach added later with
+    # positional keys is the regression this guards.
+    helper_uses =
+      @ios |> String.split("ForEach(mobIdentifiedChildren(node.childNodes))") |> length()
+
+    assert helper_uses - 1 == 7, "expected 7 identified child lists, found #{helper_uses - 1}"
+  end
+
+  test "the author's :id reaches MobNode for every node type" do
+    # It previously reached native only as nativeViewId, and only for
+    # native_view nodes, so there was nothing for ForEach to key on.
+    assert @header =~ "@property(nonatomic, copy, nullable) NSString *nodeId;"
+    assert @nif =~ "id nodeId = pv[MOB_PROP_id];"
+    assert @nif =~ "node.nodeId = nodeId;"
+  end
+
+  test "authored ids and positions cannot collide" do
+    # Without distinct prefixes an author id of "3" and position 3 are the same
+    # key, which silently merges two unrelated rows.
+    assert @ios =~ ~s|key = "i\\u{1}" + authored|
+    assert @ios =~ ~s|key = "p\\u{1}\\(index)"|
+  end
+
+  test "a duplicate id falls back rather than producing two equal keys" do
+    # SwiftUI requires ForEach ids to be unique and misbehaves quietly when they
+    # are not — a worse bug than the positional one being fixed.
+    assert @ios =~ "if !seen.insert(key).inserted"
+    assert @ios =~ ~s|key = "d\\u{1}\\(index)\\u{1}" + key|
+  end
+
+  test "an empty id is treated as absent" do
+    # `id: ""` would otherwise give every unnamed-but-present sibling the same
+    # key.
+    assert @ios =~ "let authored = child.nodeId, !authored.isEmpty"
+  end
+end

--- a/test/mob/native_layout_weight_test.exs
+++ b/test/mob/native_layout_weight_test.exs
@@ -23,8 +23,12 @@ defmodule Mob.NativeLayoutWeightTest do
   test "iOS expands weighted children on their parent's main axis" do
     source = File.read!(Path.join(@ios, "MobRootView.swift"))
 
-    assert source =~ "MobNodeView(node: child, layoutWeightAxis: .vertical)"
-    assert source =~ "MobNodeView(node: child, layoutWeightAxis: .horizontal)"
+    # `item.node` since MOB-127: children are keyed by author :id through
+    # mobIdentifiedChildren rather than by position, so the ForEach element is
+    # the identified wrapper. The property being pinned is unchanged — a column
+    # passes .vertical, a row .horizontal.
+    assert source =~ "MobNodeView(node: item.node, layoutWeightAxis: .vertical)"
+    assert source =~ "MobNodeView(node: item.node, layoutWeightAxis: .horizontal)"
     assert source =~ ".modifier(MobLayoutWeight(node: node, axis: layoutWeightAxis))"
     assert source =~ "frame(maxHeight: .infinity, alignment: .top)"
     assert source =~ "frame(maxWidth: .infinity, alignment: .leading)"


### PR DESCRIPTION
Nine `ForEach` sites in `MobRootView.swift` used `id: \.offset`. Positional identity means an insert or delete makes every later row a different view to SwiftUI, so it is rebuilt and its state discarded rather than moved.

Paired with mob_new#50 — one issue, two repos.

## The identity was on the wire but not reachable

The epic says "the identity already exists on the wire". True, but not where `ForEach` needed it: the `:id` prop was read into `MobNode` only as `nativeViewId`, and only for `native_view` nodes. `accessibilityId` is a different prop (`:accessibility_id`). So this adds `MobNode.nodeId`, populated from `MOB_PROP_id` for every node type, and `mobIdentifiedChildren/1` which pairs each child with a stable key. All seven `childNodes` sites use it.

## Three details that are easy to get wrong

- **Authored ids and positions are prefixed differently** (`i\x01…` vs `p\x01…`), so an author id of `"3"` cannot collide with position 3 and silently merge two unrelated rows.
- **A duplicate id folds in its position** rather than emitting two equal keys. SwiftUI misbehaves quietly on duplicate `ForEach` ids — and Compose *throws* on duplicates in a lazy list, so on the Android side this would turn a cosmetic problem into a crash.
- **An empty `id: ""` is treated as absent**, or every unnamed-but-present sibling would share a key.

## Verification

Behavioural proof is on the Android side (mob_new#50), since SwiftUI's diffing has no host-side observable: four rows each containing a `text_field`, plus a button that prepends a row. Typed `ZZZ` into "charlie", prepended — `ZZZ` stayed with charlie as it moved down. The same screen with the `:id` on the inner `text_field` instead of the repeated row keys positionally and loses the text, which is the before-behaviour on the same build.

iOS is source-asserted (6 tests) and confirmed to compile and render on the iPhone 17 Pro simulator.

Mutation-checked: reverting one site to positional fails two of the six.

## Deliberately not done

`MobTabView`'s `ForEach(Array(tabs.enumerated()), id: \.offset)` still keys positionally — it iterates tab dictionaries rather than child nodes, and a tab bar is short and rarely reordered.

`MobFrameTracker`'s `.onChange(of: id)` workaround is kept, and its comment corrected. It existed because trackers were not bound to one id for their lifetime; that is now true only for unnamed nodes, which still fall back to position.

**Worth knowing:** identity attaches to the repeated element, not to something inside it. An author who puts `:id` on a child of the repeated node gets positional keying and no warning — recorded in the decision doc as the most likely mis-use.

1402 tests pass. No version bump — release hold still in effect.