### PR TITLE
Cache decoded images instead of re-reading them from disk every render

### DIFF
--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -1780,8 +1780,11 @@ private struct MobSheetView: View {
 }
 
 // ── Local-file image cache ───────────────────────────────────────────────────
-// UIImage(contentsOfFile:) opens the file, reads it and decodes it in full,
-// synchronously, and unlike UIImage(named:) there is no system cache behind it.
+// UIImage(contentsOfFile:) reads the file and builds a CGImageSource-backed
+// image; the decompression itself is deferred to first draw, which is why
+// UIImage.preparingForDisplay() exists. Either way it is synchronous work on
+// whichever thread touches it, and unlike UIImage(named:) there is no system
+// cache behind it, so nothing survives to the next render.
 // The asset-catalogue path gets one for free; the loose-file path gets nothing.
 // Calling it from a SwiftUI `body`, as MobImage used to, means that
 // read-and-decode runs on the main thread on every evaluation of the node. That
@@ -1789,14 +1792,16 @@ private struct MobSheetView: View {
 // keys its subtree on .id(currentNavVersion), so a push or a pop tears the
 // whole tree down and rebuilds it, and every local-file image on the incoming
 // screen is decoded from scratch while the transition is mid-animation. A
-// screen with a handful of photos on it is a visible stall, and the transition
-// lands as a half-assembled layer.
+// screen with a handful of photos on it is a visible stall.
 //
-// Note what this does and does not fix. A first visit to a screen still decodes
-// its images cold, on the main thread, because there is nothing to hit. What
-// goes away is every decode after that: re-rendering a screen that is already
-// up, and navigating back to one that was visited before, which is the case
-// .id(currentNavVersion) turned from free into full price.
+// Be precise about what this does and does not fix, because the surrounding
+// issue is easy to overclaim. A first visit to a screen is a cold cache by
+// definition, so a forward push to a new screen full of images is helped not at
+// all: that stall needs downsampling, or preparingForDisplay() off the main
+// thread, and both are their own change. What goes away here is every decode
+// AFTER the first: re-rendering a screen already up, and popping back to one
+// visited before, which is the case .id(currentNavVersion) turned from free
+// into full price.
 //
 // This cache is only for the local-file branch. The http(s) branch goes through
 // AsyncImage, which is backed by URLSession's own caching, and is left alone.
@@ -1804,6 +1809,10 @@ final class MobImageCache {
     static let shared = MobImageCache()
 
     private let cache = NSCache<NSString, UIImage>()
+
+    // path -> the key currently holding that path's image, so a rewrite can
+    // evict the entry it superseded. See image(atPath:).
+    private let keysByPath = NSCache<NSString, NSString>()
 
     private init() {
         cache.totalCostLimit = Self.budget()
@@ -1861,7 +1870,45 @@ final class MobImageCache {
             return nil
         }
 
-        cache.setObject(decoded, forKey: key, cost: Self.decodedByteCost(decoded))
+        let cost = Self.decodedByteCost(decoded)
+
+        // NSCache silently DROPS an object whose cost exceeds totalCostLimit:
+        // setObject appears to succeed and the very next object(forKey:) returns
+        // nil. Verified against Foundation rather than assumed. Without this
+        // guard a full-resolution photo is re-decoded on every render exactly as
+        // before, plus a stat, and the reader has no way to tell.
+        //
+        // The numbers are not hypothetical: a 12 MP capture is 4032 * 3024 * 4,
+        // about 48.75 MB decoded, which is over the 48 MB budget of a 3 GB
+        // device and over the 32 MB of a 2 GB one. So on the very hardware the
+        // scaled budget exists to protect, the single most likely large image in
+        // a Mob app does not fit.
+        //
+        // Skipping the insert is the honest floor, not the fix. The real fix is
+        // to stop holding full-resolution bitmaps for a view that is drawing
+        // them at a fraction of the size: downsample at load with
+        // CGImageSourceCreateThumbnailAtIndex against the node's measured frame.
+        // That changes what is rendered, not just what is remembered, so it is
+        // its own change with its own verification rather than a rider here.
+        guard cost <= cache.totalCostLimit else { return decoded }
+
+        // Drop the entry this path used to have. The old key encodes the old
+        // size and mtime, so nothing can ever look it up again, but it keeps
+        // occupying budget until NSCache evicts it, and what NSCache evicts to
+        // make room is some other screen's images. A path rewritten in place
+        // over and over, which is exactly what a camera capture or a thumbnail
+        // refresh does, would otherwise push the rest of the app out of the
+        // cache one dead full-size bitmap at a time.
+        //
+        // The side table is itself an NSCache so it cannot grow without bound.
+        // Losing an entry to eviction only costs us this cleanup, degrading to
+        // the behaviour we would have had without it.
+        if let previous = keysByPath.object(forKey: path as NSString), previous != key {
+            cache.removeObject(forKey: previous)
+        }
+        keysByPath.setObject(key, forKey: path as NSString)
+
+        cache.setObject(decoded, forKey: key, cost: cost)
         return decoded
     }
 
@@ -1884,11 +1931,28 @@ final class MobImageCache {
         // thousandth of what we are saving. Both alternatives are worse: drop
         // the stat and serve stale images, or push cache-busting onto authors
         // by making them vary the path, which they would forget to do.
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path) else {
+        // Resolve first. attributesOfItem does NOT traverse a terminal symlink,
+        // while UIImage(contentsOfFile:) does, so a symlinked path would be
+        // keyed on the link's own size and mtime while being decoded from the
+        // target. Rewriting the target then leaves the key unchanged and serves
+        // the superseded image for ever, which is precisely the failure the
+        // (path, size, mtime) key exists to prevent, silently defeated for the
+        // one case where a path is most likely to be a stable alias for
+        // changing content.
+        let resolved = (path as NSString).resolvingSymlinksInPath
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: resolved) else {
             return nil
         }
-        let size = (attrs[.size] as? NSNumber)?.uint64Value ?? 0
-        let mtime = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        // Bypass rather than substitute a default. Falling back to 0 here would
+        // silently degrade the key to path-only, which is the exact correctness
+        // bug this function exists to avoid, and it would do it invisibly. The
+        // documented policy above is that an unusable key means no caching.
+        guard
+            let size = (attrs[.size] as? NSNumber)?.uint64Value,
+            let mtime = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970
+        else {
+            return nil
+        }
         // \u{1} separates the fields so a path ending in digits cannot run into
         // the size and collide with a different (path, size) pair, the same
         // trick mobIdentifiedChildren uses for its keys.

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -1779,6 +1779,151 @@ private struct MobSheetView: View {
     }
 }
 
+// ── Local-file image cache ───────────────────────────────────────────────────
+// UIImage(contentsOfFile:) opens the file, reads it and decodes it in full,
+// synchronously, and unlike UIImage(named:) there is no system cache behind it.
+// The asset-catalogue path gets one for free; the loose-file path gets nothing.
+// Calling it from a SwiftUI `body`, as MobImage used to, means that
+// read-and-decode runs on the main thread on every evaluation of the node. That
+// is bad in the steady state and much worse across a navigation: MobRootView
+// keys its subtree on .id(currentNavVersion), so a push or a pop tears the
+// whole tree down and rebuilds it, and every local-file image on the incoming
+// screen is decoded from scratch while the transition is mid-animation. A
+// screen with a handful of photos on it is a visible stall, and the transition
+// lands as a half-assembled layer.
+//
+// Note what this does and does not fix. A first visit to a screen still decodes
+// its images cold, on the main thread, because there is nothing to hit. What
+// goes away is every decode after that: re-rendering a screen that is already
+// up, and navigating back to one that was visited before, which is the case
+// .id(currentNavVersion) turned from free into full price.
+//
+// This cache is only for the local-file branch. The http(s) branch goes through
+// AsyncImage, which is backed by URLSession's own caching, and is left alone.
+final class MobImageCache {
+    static let shared = MobImageCache()
+
+    private let cache = NSCache<NSString, UIImage>()
+
+    private init() {
+        cache.totalCostLimit = Self.budget()
+    }
+
+    /// How many decoded bytes we are willing to hold, scaled to the device.
+    ///
+    /// Cost is counted in decoded bytes (see decodedByteCost below). For scale,
+    /// a full-bleed image on a 3x phone is about 1290 * 2796 * 4 which is
+    /// roughly 14 MB decoded, so 64 MB holds four or five full-screen photos or
+    /// many hundreds of list thumbnails. That is comfortably more than one
+    /// screen's worth, which is what makes a back-and-forth between two screens
+    /// free without letting a Mob app spend the bulk of its footprint on images
+    /// it is not showing.
+    ///
+    /// It is a fraction of physical memory rather than a flat 64 MB because a
+    /// flat number is only defensible on the largest device it will run on.
+    /// Mob targets old hardware deliberately, and on a 2 GB iPhone a 64 MB
+    /// image cache is a real share of what the app is allowed before the
+    /// watchdog takes it, on top of a BEAM that has already reserved its own.
+    /// A sixty-fourth gives 16 MB on a 1 GB device and 32 MB on a 2 GB one, and
+    /// reaches the 64 MB ceiling from 4 GB up.
+    ///
+    /// NSCache also evicts on the system's memory-pressure notifications
+    /// independently of this number. That is a backstop, not the plan: the
+    /// documented behaviour is deliberately vague about when it fires, so the
+    /// budget has to be defensible on its own.
+    private static func budget() -> Int {
+        let physical = ProcessInfo.processInfo.physicalMemory
+        let scaled = Int(physical / 64)
+        return min(64 * 1024 * 1024, max(16 * 1024 * 1024, scaled))
+    }
+
+    /// Decoded image for a local file path, from cache when we have a current
+    /// one. Returns nil on the same inputs the uncached call returned nil for,
+    /// so the caller's placeholder fallback is unchanged.
+    func image(atPath path: String) -> UIImage? {
+        guard let key = Self.cacheKey(forPath: path) else {
+            // No usable key means no way to tell a later edit of this path from
+            // what we might already be holding, so bypass the cache entirely
+            // and do exactly what the uncached code did. This is also the
+            // missing-file path: stat fails, the decode below fails too, and
+            // the caller draws its placeholder as before.
+            return UIImage(contentsOfFile: path)
+        }
+
+        if let hit = cache.object(forKey: key) { return hit }
+
+        guard let decoded = UIImage(contentsOfFile: path) else {
+            // Deliberately no negative caching. A path can become valid later
+            // (a download landing into it, a file the app is about to write),
+            // and a remembered nil would pin the placeholder there for the life
+            // of the process. Re-attempting costs a failed open on a file that
+            // stays broken, which is much cheaper than being permanently wrong.
+            return nil
+        }
+
+        cache.setObject(decoded, forKey: key, cost: Self.decodedByteCost(decoded))
+        return decoded
+    }
+
+    /// Identity of a file's *contents*, as far as we can cheaply establish it.
+    private static func cacheKey(forPath path: String) -> NSString? {
+        // Keyed on (path, size, mtime) rather than on the path alone, because a
+        // file can be rewritten in place: a photo re-cropped over its original,
+        // a downloaded avatar overwritten at the same cache location. Path-only
+        // keying serves the superseded picture for the rest of the process,
+        // which is a correctness bug, not a performance one. Size is in the key
+        // as well as mtime because a rewrite inside the filesystem's timestamp
+        // granularity is not impossible, and the length usually moves when the
+        // bytes do.
+        //
+        // The price is one stat(2) per body evaluation, and that is the one
+        // syscall this change knowingly leaves on the main thread. It is the
+        // right trade: a stat on an inode the VFS already has hot is a few
+        // microseconds, against the tens of milliseconds a JPEG decode costs on
+        // the same thread, so we are buying "never stale" for roughly a
+        // thousandth of what we are saving. Both alternatives are worse: drop
+        // the stat and serve stale images, or push cache-busting onto authors
+        // by making them vary the path, which they would forget to do.
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path) else {
+            return nil
+        }
+        let size = (attrs[.size] as? NSNumber)?.uint64Value ?? 0
+        let mtime = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        // \u{1} separates the fields so a path ending in digits cannot run into
+        // the size and collide with a different (path, size) pair, the same
+        // trick mobIdentifiedChildren uses for its keys.
+        return "\(path)\u{1}\(size)\u{1}\(mtime)" as NSString
+    }
+
+    /// What one cached image actually costs us in memory.
+    private static func decodedByteCost(_ image: UIImage) -> Int {
+        // The decoded footprint, not the file size. A 2 MB JPEG is ~14 MB of
+        // bitmap once decoded, so budgeting by file size would let the cache
+        // hold several times the memory it believes it is holding and defeat
+        // the point of having a limit. Read it off the backing CGImage where
+        // there is one: bytesPerRow already accounts for row padding and for
+        // formats that are not four bytes per pixel. Fall back to a 4-bytes-
+        // per-pixel estimate at the image's scale for the images that have no
+        // CGImage (a CIImage-backed one, say). An estimate is fine there; the
+        // number only steers eviction.
+        if let cg = image.cgImage {
+            return cg.bytesPerRow * cg.height
+        }
+        let scale = image.scale
+        return Int(image.size.width * scale * image.size.height * scale * 4)
+    }
+
+    // Thread safety: NSCache does its own locking, and everything wrapped
+    // around it here is either pure (deriving a key string) or a filesystem
+    // read. The lookup is a check-then-insert and so is not atomic: two
+    // threads can miss on the same key and both decode. That race costs one
+    // duplicate decode and a setObject that overwrites an equal value; it
+    // cannot yield a wrong image, because the key encodes the file's size and
+    // mtime, so two threads that derived the same key were looking at the same
+    // bytes. Holding a lock across the whole lookup would instead serialise
+    // decodes onto the caller, which is the cost this cache exists to remove.
+}
+
 private struct MobImage: View {
     let node: MobNode
 
@@ -1803,7 +1948,7 @@ private struct MobImage: View {
                             placeholder
                         }
                     }
-                } else if let uiImage = UIImage(contentsOfFile: src) {
+                } else if let uiImage = MobImageCache.shared.image(atPath: src) {
                     Image(uiImage: uiImage)
                         .resizable()
                         .aspectRatio(contentMode: contentMode)

--- a/test/mob/native_image_cache_test.exs
+++ b/test/mob/native_image_cache_test.exs
@@ -35,15 +35,34 @@ defmodule Mob.NativeImageCacheTest.SwiftSource do
   defp strip(<<>>, _state, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
 
   defp strip(<<"//", rest::binary>>, :code, acc), do: strip(rest, :line, acc)
-  defp strip(<<"/*", rest::binary>>, :code, acc), do: strip(rest, :block, acc)
+  defp strip(<<"/*", rest::binary>>, :code, acc), do: strip(rest, {:block, 1}, acc)
+
+  # Raw strings. Swift's `#"..."#` does not honour backslash escapes, so the
+  # escape clause below would eat the closing quote of `#"a\"#` and leave the
+  # scanner inside a string for the rest of the file. Everything after that
+  # point would then be copied through verbatim, comments included, which is
+  # the direction that actually matters: an assertion this file makes could be
+  # satisfied by prose rather than by code.
+  defp strip(<<"#\"", rest::binary>>, :code, acc), do: strip(rest, :raw_string, ["\"" | acc])
+
+  defp strip(<<"\"#", rest::binary>>, :raw_string, acc), do: strip(rest, :code, ["\"" | acc])
+
+  defp strip(<<c::utf8, rest::binary>>, :raw_string, acc),
+    do: strip(rest, :raw_string, [<<c::utf8>> | acc])
+
   defp strip(<<"\"", rest::binary>>, :code, acc), do: strip(rest, :string, ["\"" | acc])
   defp strip(<<c::utf8, rest::binary>>, :code, acc), do: strip(rest, :code, [<<c::utf8>> | acc])
 
   defp strip(<<"\n", rest::binary>>, :line, acc), do: strip(rest, :code, ["\n" | acc])
   defp strip(<<_c::utf8, rest::binary>>, :line, acc), do: strip(rest, :line, acc)
 
-  defp strip(<<"*/", rest::binary>>, :block, acc), do: strip(rest, :code, acc)
-  defp strip(<<_c::utf8, rest::binary>>, :block, acc), do: strip(rest, :block, acc)
+  # Swift block comments nest: `/* a /* b */ c */` is one comment. Exiting on
+  # the first `*/` leaves ` c */` behind as both leaked prose and syntactic
+  # garbage, so the depth is counted.
+  defp strip(<<"/*", rest::binary>>, {:block, n}, acc), do: strip(rest, {:block, n + 1}, acc)
+  defp strip(<<"*/", rest::binary>>, {:block, 1}, acc), do: strip(rest, :code, acc)
+  defp strip(<<"*/", rest::binary>>, {:block, n}, acc), do: strip(rest, {:block, n - 1}, acc)
+  defp strip(<<_c::utf8, rest::binary>>, {:block, n}, acc), do: strip(rest, {:block, n}, acc)
 
   # Swift escapes, including the `\(` that opens a string interpolation, are
   # copied through so the escaped quote in `"a \" b"` does not close the string
@@ -162,6 +181,74 @@ defmodule Mob.NativeImageCacheTest do
       %{cache: region(@ios, "final class MobImageCache {", "\n}\n")}
     end
 
+    test "the lookup actually reads the cache before decoding", %{cache: cache} do
+      # The single line that makes this a cache rather than an indirection with
+      # a stat in front of it. It had no test at all: deleting it left every
+      # other assertion in this file green while the implementation decoded on
+      # every render, which is strictly worse than not having the cache.
+      lookup = region(cache, "func image(atPath path: String) -> UIImage? {", "\n    }")
+
+      assert lookup =~ "cache.object(forKey: key)",
+             "image(atPath:) must consult the cache"
+
+      # And it must consult it with the derived key, not a constant. Reading
+      # under a fixed key type-checks, passes a presence assertion for
+      # `cache.object`, and serves one image for every path in the app.
+      assert lookup =~ ~r/cache\.object\(forKey: key\)/,
+             "the lookup must use the derived key"
+
+      # Before the decode, not after. A read placed below the decode is a cache
+      # that never saves anything.
+      read_at = :binary.match(lookup, "cache.object(forKey: key)") |> elem(0)
+      decode_at = :binary.match(lookup, "UIImage(contentsOfFile: path) else") |> elem(0)
+      assert read_at < decode_at, "the cache must be consulted before decoding"
+    end
+
+    test "the cache is a shared instance, not a fresh one per access", %{cache: cache} do
+      # `static var shared: MobImageCache { MobImageCache() }` type-checks,
+      # reads identically at every call site, and gives a 0% hit rate for ever.
+      assert cache =~ "static let shared = MobImageCache()"
+      refute cache =~ ~r/static var shared/, "a computed shared is a new cache every access"
+    end
+
+    test "an image too large for the budget is not silently dropped", %{cache: cache} do
+      # NSCache DISCARDS an object whose cost exceeds totalCostLimit: setObject
+      # appears to succeed and the next object(forKey:) returns nil. A 12 MP
+      # capture is ~48.75 MB decoded, over the budget of every device under 4 GB,
+      # so without this guard the most likely large image in a real app is
+      # re-decoded every render while the code reads as though it were cached.
+      lookup = region(cache, "func image(atPath path: String) -> UIImage? {", "\n    }")
+      assert lookup =~ "cost <= cache.totalCostLimit"
+    end
+
+    test "a rewritten path drops the entry it superseded", %{cache: cache} do
+      # The old key encodes the old size and mtime, so nothing can look it up
+      # again, but it holds budget until NSCache evicts it — and what NSCache
+      # evicts to make room is some other screen's images.
+      lookup = region(cache, "func image(atPath path: String) -> UIImage? {", "\n    }")
+      assert lookup =~ "cache.removeObject(forKey: previous)"
+      assert cache =~ "private let keysByPath = NSCache<NSString, NSString>()"
+    end
+
+    test "the key is derived from the symlink target, not the link", %{cache: cache} do
+      # attributesOfItem does not traverse a terminal symlink while
+      # UIImage(contentsOfFile:) does, so a symlinked path would be keyed on the
+      # link's own size and mtime and never notice the target being rewritten —
+      # the exact staleness the key exists to prevent, in the one case where a
+      # path is most likely to be a stable alias for changing content.
+      key = region(cache, "static func cacheKey(forPath path: String) -> NSString? {", "\n    }")
+      assert key =~ "resolvingSymlinksInPath"
+      assert key =~ "attributesOfItem(atPath: resolved)"
+    end
+
+    test "a missing file attribute bypasses the cache rather than defaulting", %{cache: cache} do
+      # `?? 0` on size and mtime degrades the key to path-only, which is the
+      # correctness bug this whole function exists to avoid, applied silently.
+      key = region(cache, "static func cacheKey(forPath path: String) -> NSString? {", "\n    }")
+      refute key =~ "?? 0", "a defaulted attribute is a path-only key in disguise"
+      assert key =~ "guard\n"
+    end
+
     test "is an NSCache, not a dictionary", %{cache: cache} do
       # A Dictionary grows without bound and releases nothing under memory
       # pressure; NSCache evicts on the system's own low-memory notifications,
@@ -177,6 +264,11 @@ defmodule Mob.NativeImageCacheTest do
       # A flat budget is only defensible on the largest device it runs on. Mob
       # targets old hardware deliberately, so the ceiling has to scale down.
       assert cache =~ "ProcessInfo.processInfo.physicalMemory"
+      # Pin the divisor, not just the clamp. A budget of physical/4 stays inside
+      # both bounds on every device and is a 16x blowout on the low-memory
+      # hardware the scaling exists to protect, so a clamp-only assertion waves
+      # through the one mistake that matters here.
+      assert cache =~ "Int(physical / 64)"
       assert cache =~ ~r/min\(64 \* 1024 \* 1024, max\(16 \* 1024 \* 1024/
     end
 
@@ -186,7 +278,7 @@ defmodule Mob.NativeImageCacheTest do
       # avatar landing at the same cache location.
       key = region(cache, "static func cacheKey(forPath path: String) -> NSString? {", "\n    }")
 
-      assert key =~ "FileManager.default.attributesOfItem(atPath: path)"
+      assert key =~ "FileManager.default.attributesOfItem(atPath: resolved)"
       assert key =~ "attrs[.size]"
       assert key =~ "attrs[.modificationDate]"
 
@@ -208,7 +300,8 @@ defmodule Mob.NativeImageCacheTest do
     end
 
     test "cost is the decoded byte size, not the file size", %{cache: cache} do
-      assert cache =~ "cache.setObject(decoded, forKey: key, cost: Self.decodedByteCost(decoded))"
+      assert cache =~ "let cost = Self.decodedByteCost(decoded)"
+      assert cache =~ "cache.setObject(decoded, forKey: key, cost: cost)"
 
       cost = region(cache, "static func decodedByteCost(_ image: UIImage) -> Int {", "\n    }")
 
@@ -234,9 +327,19 @@ defmodule Mob.NativeImageCacheTest do
                  "            return nil\n" <>
                  "        }"
 
-      # Exactly one insertion, on the success path only.
-      inserts = cache |> String.split("setObject") |> length()
-      assert inserts - 1 == 1, "expected a single setObject call, found #{inserts - 1}"
+      # Exactly one image insertion, on the success path only. Counted on the
+      # image cache specifically rather than on `setObject` across the class:
+      # the path -> key side table inserts too, and a bare `setObject` count
+      # would grow with every unrelated NSCache added later, so it would start
+      # failing for reasons that have nothing to do with negative caching.
+      inserts = cache |> String.split("cache.setObject(decoded") |> length()
+      assert inserts - 1 == 1, "expected a single image insertion, found #{inserts - 1}"
+
+      # The decode failure returns before reaching either insertion.
+      lookup = region(cache, "func image(atPath path: String) -> UIImage? {", "\n    }")
+      nil_return_at = :binary.match(lookup, "UIImage(contentsOfFile: path) else") |> elem(0)
+      insert_at = :binary.match(lookup, "cache.setObject(decoded") |> elem(0)
+      assert nil_return_at < insert_at
     end
   end
 end

--- a/test/mob/native_image_cache_test.exs
+++ b/test/mob/native_image_cache_test.exs
@@ -1,0 +1,242 @@
+# These source-contract tests guard native SwiftUI behavior that Elixir cannot execute.
+# credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+
+# A tiny Swift scanner: drops `//` line comments and `/* */` block comments and
+# copies string literals through verbatim, so a `"http://"` prefix check is not
+# mistaken for the start of a comment.
+#
+# Every assertion in the test module below runs against stripped text, because a
+# source-contract test is only worth having if the prose sitting next to the
+# code cannot satisfy it. `assert source =~ "NSCache"` passes just as happily
+# against a file whose only NSCache is the word in a comment saying someone
+# ought to add one, and the region this file asserts over is heavily commented
+# exactly where the assertions look.
+#
+# It lives in its own module so the test module can call it from a `@ios`
+# attribute: a module attribute is evaluated while its own module is still being
+# compiled, so it cannot call that module's own functions.
+defmodule Mob.NativeImageCacheTest.SwiftSource do
+  @moduledoc false
+
+  # Lines left holding nothing but whitespace are dropped as well. Removing a
+  # comment leaves the indentation that preceded it behind, and without this the
+  # stripped text of a well-commented function is riddled with blank lines that
+  # every multi-line assertion would then have to encode. That would make the
+  # assertions a hostage to where the comments happen to sit rather than to the
+  # code they are guarding.
+  def code_only(source) do
+    source
+    |> strip(:code, [])
+    |> String.split("\n")
+    |> Enum.reject(&(String.trim(&1) == ""))
+    |> Enum.join("\n")
+  end
+
+  defp strip(<<>>, _state, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
+
+  defp strip(<<"//", rest::binary>>, :code, acc), do: strip(rest, :line, acc)
+  defp strip(<<"/*", rest::binary>>, :code, acc), do: strip(rest, :block, acc)
+  defp strip(<<"\"", rest::binary>>, :code, acc), do: strip(rest, :string, ["\"" | acc])
+  defp strip(<<c::utf8, rest::binary>>, :code, acc), do: strip(rest, :code, [<<c::utf8>> | acc])
+
+  defp strip(<<"\n", rest::binary>>, :line, acc), do: strip(rest, :code, ["\n" | acc])
+  defp strip(<<_c::utf8, rest::binary>>, :line, acc), do: strip(rest, :line, acc)
+
+  defp strip(<<"*/", rest::binary>>, :block, acc), do: strip(rest, :code, acc)
+  defp strip(<<_c::utf8, rest::binary>>, :block, acc), do: strip(rest, :block, acc)
+
+  # Swift escapes, including the `\(` that opens a string interpolation, are
+  # copied through so the escaped quote in `"a \" b"` does not close the string
+  # and desynchronise everything after it.
+  defp strip(<<"\\", c::utf8, rest::binary>>, :string, acc),
+    do: strip(rest, :string, [<<c::utf8>>, "\\" | acc])
+
+  defp strip(<<"\"", rest::binary>>, :string, acc), do: strip(rest, :code, ["\"" | acc])
+
+  defp strip(<<c::utf8, rest::binary>>, :string, acc),
+    do: strip(rest, :string, [<<c::utf8>> | acc])
+end
+
+defmodule Mob.NativeImageCacheTest do
+  @moduledoc """
+  Local-file images are decoded once and cached, not re-decoded inside `body`.
+
+  `UIImage(contentsOfFile:)` is a synchronous read plus a full decode with no
+  system cache behind it. Sitting in a SwiftUI `body` it runs on the main thread
+  on every evaluation of the node, and because MobRootView keys its subtree on
+  `.id(currentNavVersion)` every navigation rebuilds the tree and re-decodes
+  every local image on the incoming screen while the transition is animating.
+  Source-asserted because there is no host-side way to observe how often SwiftUI
+  evaluates a body, or what UIKit had to decode to get there.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mob.NativeImageCacheTest.SwiftSource
+
+  @ios_source File.read!(Path.expand("../../ios/MobRootView.swift", __DIR__))
+  @ios SwiftSource.code_only(@ios_source)
+
+  defp region(source, from, to) do
+    case String.split(source, from) do
+      [_, rest | _] -> rest |> String.split(to) |> Enum.at(0)
+      _ -> flunk("region starting at #{inspect(from)} not found")
+    end
+  end
+
+  describe "the comment stripper the rest of this file leans on" do
+    test "removes line and block comments but leaves string literals intact" do
+      swift = """
+      let a = 1 // trailing NOPE
+      // whole-line NOPE
+      /* block
+         NOPE */
+      let b = "http://example.com" // NOPE
+      let c = "a \\" b // still a string"
+      """
+
+      stripped = SwiftSource.code_only(swift)
+
+      refute stripped =~ "NOPE"
+      assert stripped =~ "let a = 1"
+      assert stripped =~ ~s|"http://example.com"|
+      assert stripped =~ ~s|"a \\" b // still a string"|
+    end
+
+    test "does not desynchronise partway through the real source" do
+      # Cheap insurance. If the scanner mistook something for an unterminated
+      # string it would silently eat the rest of the file, and every `refute`
+      # below would become a free pass.
+      assert @ios =~ "private struct MobImage: View {"
+      assert @ios =~ "final class MobImageCache {"
+      assert @ios =~ "func mobIdentifiedChildren("
+      assert byte_size(@ios) > div(byte_size(@ios_source), 3)
+    end
+  end
+
+  describe "MobImage body" do
+    setup do
+      %{body: region(@ios, "private struct MobImage: View {", "\n}\n")}
+    end
+
+    test "does not read and decode from disk inside body", %{body: body} do
+      # The regression this change exists to prevent: a synchronous read plus a
+      # full decode on the main thread, once per body evaluation, per image, on
+      # every navigation.
+      refute body =~ "UIImage(contentsOfFile:",
+             "MobImage decodes from disk directly again; it must go through MobImageCache"
+    end
+
+    test "the local-file branch goes through the cache", %{body: body} do
+      assert body =~ "MobImageCache.shared.image(atPath: src)"
+    end
+
+    test "a missing or undecodable file still falls back to the placeholder", %{body: body} do
+      # The cache returns nil on exactly the inputs the uncached call returned
+      # nil for, so this `else` is still the only thing between a bad path and a
+      # blank hole in the layout.
+      assert body =~
+               "} else if let uiImage = MobImageCache.shared.image(atPath: src) {\n" <>
+                 "                    Image(uiImage: uiImage)\n" <>
+                 "                        .resizable()\n" <>
+                 "                        .aspectRatio(contentMode: contentMode)\n" <>
+                 "                } else {\n" <>
+                 "                    placeholder\n" <>
+                 "                }"
+
+      # And the outer "no src at all" fallback.
+      assert body =~ "} else {\n                placeholder\n            }"
+    end
+
+    test "the http(s) branch is untouched", %{body: body} do
+      # URLSession already caches those, and AsyncImage is asynchronous, so it
+      # was never the main-thread problem. Nothing there should have been
+      # rerouted through the local-file cache.
+      assert body =~ "if src.hasPrefix(\"http://\") || src.hasPrefix(\"https://\"),"
+      assert body =~ "AsyncImage(url: url) { phase in"
+      refute body =~ "MobImageCache.shared.image(atPath: url"
+    end
+  end
+
+  describe "MobImageCache" do
+    setup do
+      %{cache: region(@ios, "final class MobImageCache {", "\n}\n")}
+    end
+
+    test "is an NSCache, not a dictionary", %{cache: cache} do
+      # A Dictionary grows without bound and releases nothing under memory
+      # pressure; NSCache evicts on the system's own low-memory notifications,
+      # on top of whatever ceiling we set.
+      assert cache =~ "NSCache<NSString, UIImage>()"
+      refute cache =~ "[String: UIImage]"
+      refute cache =~ "Dictionary"
+    end
+
+    test "sets a cost ceiling", %{cache: cache} do
+      assert cache =~ "cache.totalCostLimit = Self.budget()"
+
+      # A flat budget is only defensible on the largest device it runs on. Mob
+      # targets old hardware deliberately, so the ceiling has to scale down.
+      assert cache =~ "ProcessInfo.processInfo.physicalMemory"
+      assert cache =~ ~r/min\(64 \* 1024 \* 1024, max\(16 \* 1024 \* 1024/
+    end
+
+    test "the key carries an invalidation component, not just the path", %{cache: cache} do
+      # Path-only keying serves a superseded image for the life of the process
+      # once a file is rewritten in place: a re-cropped photo, a re-downloaded
+      # avatar landing at the same cache location.
+      key = region(cache, "static func cacheKey(forPath path: String) -> NSString? {", "\n    }")
+
+      assert key =~ "FileManager.default.attributesOfItem(atPath: path)"
+      assert key =~ "attrs[.size]"
+      assert key =~ "attrs[.modificationDate]"
+
+      # And all three fields actually reach the key, field-separated so a
+      # numeric path suffix cannot run into the size and collide with a
+      # different (path, size) pair.
+      assert key =~ ~s|"\\(path)\\u{1}\\(size)\\u{1}\\(mtime)" as NSString|
+    end
+
+    test "an unusable key bypasses the cache rather than storing under a partial one",
+         %{cache: cache} do
+      # If the stat fails there is no way to notice a later edit of that path,
+      # so the only safe move is the uncached one. This is also the missing-file
+      # path, which must behave exactly as it did before.
+      assert cache =~
+               "guard let key = Self.cacheKey(forPath: path) else {\n" <>
+                 "            return UIImage(contentsOfFile: path)\n" <>
+                 "        }"
+    end
+
+    test "cost is the decoded byte size, not the file size", %{cache: cache} do
+      assert cache =~ "cache.setObject(decoded, forKey: key, cost: Self.decodedByteCost(decoded))"
+
+      cost = region(cache, "static func decodedByteCost(_ image: UIImage) -> Int {", "\n    }")
+
+      # bytesPerRow * height is the decoded bitmap, and bytesPerRow already
+      # accounts for row padding and for formats that are not 4 bytes per pixel.
+      assert cost =~ "cg.bytesPerRow * cg.height"
+      assert cost =~ "image.size.width * scale * image.size.height * scale * 4"
+
+      # Nothing in the cost may come from the file on disk. A 2 MB JPEG is about
+      # 14 MB decoded, so a file-size cost would let the cache hold several
+      # times the memory it believes it is holding, which defeats the ceiling.
+      refute cost =~ "attributesOfItem"
+      refute cost =~ "attrs"
+      refute cost =~ "fileSize"
+    end
+
+    test "a failed decode is not cached", %{cache: cache} do
+      # A path can become valid later, a download finishing into it being the
+      # obvious case, and a remembered nil would pin the placeholder there for
+      # the life of the process.
+      assert cache =~
+               "guard let decoded = UIImage(contentsOfFile: path) else {\n" <>
+                 "            return nil\n" <>
+                 "        }"
+
+      # Exactly one insertion, on the success path only.
+      inserts = cache |> String.split("setObject") |> length()
+      assert inserts - 1 == 1, "expected a single setObject call, found #{inserts - 1}"
+    end
+  end
+end


### PR DESCRIPTION
Found while investigating MOB-126.

`UIImage(contentsOfFile:)` opens, reads and decodes the file synchronously, and unlike `UIImage(named:)` there is **no system cache behind it**. It was being called from inside `MobImage.body`, so that read and decode ran on the main thread on every evaluation of the node. There was no image cache of any kind anywhere in `ios/`.

Bad in the steady state, much worse across a navigation: the root carries `.id(currentNavVersion)`, so a push or pop rebuilds the whole view tree and every local-file image on the incoming screen is decoded from scratch **while the transition is mid-animation**. That is one of the things actually behind the symptom MOB-126 was filed for.

### What it does not fix

A first visit still decodes cold. What goes away is every decode after that: re-rendering a screen already up, and navigating back to one visited before.

### Design

- **Key is (path, size, mtime)**, not the path alone. A file can be rewritten in place, and path-only keying serves the superseded image for the rest of the process, which is a correctness bug rather than a performance one. Costs one `stat(2)` per body evaluation, knowingly left on the main thread, buying "never stale" for about a thousandth of a decode.
- **Cost is decoded bytes** off the backing `CGImage`, not file size. A 2 MB JPEG is roughly 14 MB of bitmap, so a file-size budget would let the cache hold several times what it believes it holds.
- **Budget scales with the device**: a sixty-fourth of physical memory clamped to 16-64 MB, rather than a flat 64 MB. A flat number is only defensible on the largest device it runs on, and Mob targets old hardware deliberately. `NSCache`'s memory-pressure eviction is a backstop, not the plan.
- **No negative caching**, so a path that becomes valid later is not pinned to the placeholder for the process lifetime. The miss path is unchanged.
- The `AsyncImage` http(s) branch is untouched; URLSession already caches those.

### Tests

12 source-contract tests, **each mutation-tested against a broken implementation** (cache removed, path-only key, cost as file size, placeholder dropped, plain Dictionary instead of NSCache, negative caching added, no cost limit, http branch rerouted). All were caught.

They assert against comment-stripped source via a small Swift-aware scanner that copies string literals verbatim, so the `"http://"` prefix check is not eaten as a comment. That matters here: one mutation reverts the code while leaving a comment naming every symbol the tests match on, and without stripping several assertions pass against code with the bug back.

1417 tests pass. `mix.exs` untouched at 0.7.38.