### PR TITLE
MOB-126: measure the native half of a frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@ Everything below is unreleased work from the MOB-124 rendering-performance
 epic. Nothing here has shipped to Hex.
 
 ### Added
+- **Native frame timing: `Mob.RenderStats.native_enable/1`, `native_frames/1`
+  and `native_summary/1`** (MOB-126). `Mob.RenderStats` measures seven stages
+  and every one is on the BEAM side of the boundary: `set_root_us` closes when
+  `nif_set_root` returns, and that is the moment the tree is handed to the main
+  thread, not the moment it is on screen. Everything SwiftUI does to build, lay
+  out and display it happened after the measurement closed, so the native half
+  of every frame had never been measured. These read a native ring buffer of
+  main-thread busy time per applied tree, tagged with the transition that
+  produced it so a navigation rebuild can be told apart from a steady-state
+  re-render.
+
+  Off by default; the disabled path is one relaxed atomic load per `set_root`.
+  Read it as an upper bound on a frame's native cost rather than an
+  attribution: anything else queued on the main thread in the same window is
+  inside the number. **iOS only for now** — Android returns
+  `{:error, :unsupported}`, which is accurate rather than silently zero. See
+  `decisions/2026-09-03-measure-the-native-half-of-a-frame.md`.
+
 - **`Mob.RenderStats` — per-frame render instrumentation** (MOB-125). Records
   the user's `render/1`, tree expansion, component reconcile, the renderer's
   prepare walk, `register_tap`, `:json.encode`, and `set_root` as seen from the
@@ -109,6 +127,19 @@ epic. Nothing here has shipped to Hex.
   recorded through `Mob.RenderStats` with `reason: :unchanged` rather than
   vanishing, so a screen that stops updating stays diagnosable. See
   `decisions/2026-09-03-skip-the-repaint-when-the-tree-is-unchanged.md`.
+- **Local-file images are cached instead of re-read on every render**
+  (found via MOB-126). `UIImage(contentsOfFile:)` was called inside SwiftUI's
+  `body`, and unlike `UIImage(named:)` there is no system cache behind it, so
+  every evaluation of an image node re-read the file from disk on the main
+  thread. Worst across a navigation, where the root's identity change rebuilds
+  the whole tree and every image on the incoming screen is loaded again while
+  the transition animates.
+
+  Keyed on (path, size, mtime) so a file rewritten in place is not served
+  stale, with the budget scaled to physical memory (16-64 MB) rather than a
+  flat ceiling that is only defensible on the largest device it runs on. A
+  first visit still loads cold; what goes away is every load after that.
+
 - **Children keep their identity across list edits** (MOB-127). Children of
   every container were keyed on their position, so inserting or removing a row
   made each following row adopt the previous occupant's view state: typed text,

--- a/decisions/2026-09-03-measure-the-native-half-of-a-frame.md
+++ b/decisions/2026-09-03-measure-the-native-half-of-a-frame.md
@@ -1,0 +1,97 @@
+# Measure the native half of a frame
+
+**Date:** 2026-09-03
+**Issue:** MOB-126 (and the evidence gate on MOB-129 / MOB-130)
+
+## Context
+
+`Mob.RenderStats` was built for MOB-125 so the rendering-performance epic would
+stop being a set of guesses. It measures seven stages: the user's `render/1`,
+expansion, reconcile, the prepare walk, `register_tap`, `:json.encode` and
+`set_root`.
+
+All seven are on the BEAM side of the boundary. `set_root_us` closes when
+`nif_set_root` returns, and on iOS `nif_set_root` finishes by calling
+`[[MobViewModel shared] setRoot:transition:]`, which dispatches to the main
+thread and returns immediately. Everything SwiftUI then does to build the view
+tree, lay it out and hand it to Core Animation happens after that measurement
+has closed. Compose on Android is the same shape.
+
+So the native half of every frame has been invisible since the harness was
+written. That did not matter until MOB-126, whose whole argument is about how
+much the native side costs when `.id(currentNavVersion)` discards the view tree
+on navigation. MOB-129 (retain one native tree per live screen) is a large
+change justified entirely by that cost, and MOB-130 says the wire-format
+decision must be made "on evidence only". None of the three can be settled
+against a number nobody has.
+
+## Decision
+
+Record main-thread busy time per applied tree, natively, in a ring buffer that
+the BEAM can read over dist.
+
+**What is measured is main-thread busy time**, from the instant the new tree is
+applied to the view model to the instant the main run loop goes idle again.
+That is deliberately the pessimistic reading: anything else queued on the main
+thread inside that window is counted too. It is also the honest one, because a
+frame is dropped when the main thread is busy, whoever made it busy. A sample
+is an upper bound on that frame's native cost, not an attribution, and the docs
+say so.
+
+**The closing bracket is a `beforeWaiting` run loop observer.**
+`CATransaction.setCompletionBlock` is the obvious alternative and is wrong here:
+SwiftUI's update frequently lands in a later transaction than the one open at
+assignment time, so the completion fires before the work being measured has
+happened and the measurement reads near zero.
+
+**The transition travels with each sample**, and `native_summary/1` groups on
+it rather than pooling. A `"none"` sample is a steady-state re-render into an
+existing view tree; `"push"`, `"pop"` and `"reset"` each rebuild the tree
+because the root takes a new identity. Pooling them gives a p50 that describes
+neither, and the size of that gap is precisely the quantity MOB-126 and MOB-129
+are arguing about.
+
+**Off by default, and the disabled path is one relaxed atomic load.** The flag
+is `_Atomic` rather than lock-guarded so that an app which never measures
+anything does not take, on the main thread, on every `set_root`, a lock that a
+NIF thread also takes. The timestamps and the observer are downstream of that
+check. `Mob.RenderStats` already sets this standard in its own moduledoc, which
+accounts for its cost when disabled down to nanoseconds per call.
+
+**Enabling clears the window**, because enabling is the natural "start
+measuring here" marker and callers read it that way. The payload carries
+`recorded` and `dropped` so a percentile over a 240-sample ring can be read
+honestly: `dropped > 0` says the numbers describe the tail of the run, not all
+of it.
+
+**It is a separate window from `frames/0`.** The native sample completes
+asynchronously, well after the BEAM frame it belongs to has been committed and
+recorded. Correlating the two would mean threading an identifier through the
+wire, for a number that is only ever read by a human deciding whether an
+optimisation is worth building.
+
+## Consequences
+
+`Mob.RenderStats.native_enable/1`, `native_frames/1` and `native_summary/1`
+return `{:error, :unsupported}` rather than raising when the platform's native
+half has not implemented them. That covers the host, where `:mob_nif` does not
+exist at all, and it covers Android until the Compose half lands. A function
+exported from `mob_nif.erl` but absent from the native library keeps its Erlang
+stub and raises `:nif_not_loaded`; degrading is better than taking down
+whatever is reading stats.
+
+**This ships the iOS half only.** The Android equivalent needs the same shape
+around `setRootJson` and a Choreographer or `doOnPreDraw` closing bracket, and
+it touches `MobBridge.kt.eex`, which MOB-142 is editing in the same window.
+Sequencing them avoids a conflict in a template file that has been the site of
+two cross-platform divergences already in this epic. Until it lands, Android
+reports `:unsupported`, which is accurate rather than silently zero.
+
+## What this does not do
+
+It does not attribute cost within the native half. It cannot say how much of an
+apply was SwiftUI body evaluation versus layout versus a synchronous image
+decode on the main thread. If that granularity turns out to be needed, the tool
+for it is `os_signpost` read through Instruments, which is a different exercise
+with a different audience: signposts are for a human with a profiler open, and
+this is for an agent on the end of a dist connection.

--- a/ios/MobDemo-Bridging-Header.h
+++ b/ios/MobDemo-Bridging-Header.h
@@ -58,3 +58,17 @@ void mob_unregister_frame(const char *id, uint64_t seq);
 // font names from the last Mob.Theme.set/1 (nif_set_theme in mob_nif.m
 // stores it). Empty (never nil) when no theme has set font_fallback.
 NSArray<NSString *> *mob_font_fallback(void);
+
+// Native frame timing, read back through the native_stats NIF.
+//
+// mob_native_stats_enabled() is checked on the main thread on every set_root,
+// so the disabled path must stay cheap: it is a single relaxed atomic load and
+// nothing else. MobViewModel only arms its run loop observer when this returns
+// non-zero.
+//
+// mob_record_native_frame() takes main-thread busy time in microseconds for one
+// applied tree, together with the transition that produced it ("push", "pop",
+// "reset" or "none") so navigation frames can be told apart from steady-state
+// re-renders. Implemented in mob_nif.m.
+int mob_native_stats_enabled(void);
+void mob_record_native_frame(double apply_us, const char *transition);

--- a/ios/MobViewModel.swift
+++ b/ios/MobViewModel.swift
@@ -3,6 +3,7 @@
 
 import SwiftUI
 import Combine
+import QuartzCore
 
 @objc public class MobViewModel: NSObject, ObservableObject {
     @objc public static let shared = MobViewModel()
@@ -48,13 +49,55 @@ import Combine
 
     @objc public func setRoot(_ node: MobNode?, transition: String) {
         DispatchQueue.main.async {
+            let measuring = mob_native_stats_enabled() != 0
+            let start = measuring ? CACurrentMediaTime() : 0
+
             self.transition = transition
             self.root = node
             self.rootVersion += 1
             if transition != "none" {
                 self.navVersion += 1
             }
+
+            if measuring {
+                self.measureApply(from: start, transition: transition)
+            }
         }
+    }
+
+    /// Record how long the main thread stays busy applying this tree.
+    ///
+    /// The `@Published` writes above only *schedule* SwiftUI's work. Building
+    /// the view tree, laying it out and handing it to Core Animation all happen
+    /// later in the same run loop pass, which is exactly the half
+    /// `Mob.RenderStats` cannot see: its `set_root_us` closes when `setRoot`
+    /// returns, and `setRoot` returns as soon as it has dispatched.
+    ///
+    /// A `beforeWaiting` observer is the closing bracket because it fires when
+    /// the main run loop has nothing left to do and is about to sleep, which is
+    /// after layout and display. `CATransaction.setCompletionBlock` was the
+    /// obvious alternative and is wrong here: SwiftUI's update frequently lands
+    /// in a later transaction than the one open at assignment time, so the
+    /// completion fires before the work being measured has happened.
+    ///
+    /// The observer is one-shot (`repeats: false`) and removes itself, so a
+    /// burst of `set_root` calls in a single pass arms several observers that
+    /// all fire on the same idle and each records its own start. That
+    /// over-counts overlapping applies rather than losing them, which is the
+    /// safer direction for a measurement whose purpose is to justify work.
+    private func measureApply(from start: CFTimeInterval, transition: String) {
+        var observer: CFRunLoopObserver?
+        observer = CFRunLoopObserverCreateWithHandler(
+            kCFAllocatorDefault,
+            CFRunLoopActivity.beforeWaiting.rawValue,
+            false,
+            0
+        ) { obs, _ in
+            mob_record_native_frame((CACurrentMediaTime() - start) * 1_000_000, transition)
+            CFRunLoopRemoveObserver(CFRunLoopGetMain(), obs, .commonModes)
+        }
+        guard let observer else { return }
+        CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
     }
 
     @objc public func setStartupPhase(_ phase: String) {

--- a/ios/MobViewModel.swift
+++ b/ios/MobViewModel.swift
@@ -80,18 +80,36 @@ import QuartzCore
     /// in a later transaction than the one open at assignment time, so the
     /// completion fires before the work being measured has happened.
     ///
+    /// The order matters as much as the activity, and getting it wrong fails
+    /// silently with a plausible number. `beforeWaiting` observers run in
+    /// ascending `order`, and Core Animation's transaction-commit observer sits
+    /// at 2000000 (UIKit's post-commit handler at 2000001). SwiftUI evaluates
+    /// bodies and lays out inside that commit, so an observer at order 0 fires
+    /// *before* any of the work being measured and reports little more than the
+    /// three property assignments above. `CFIndex.max` puts this last, after
+    /// the commit, which is the only position where the closing bracket means
+    /// what the doc above says it means.
+    ///
     /// The observer is one-shot (`repeats: false`) and removes itself, so a
     /// burst of `set_root` calls in a single pass arms several observers that
     /// all fire on the same idle and each records its own start. That
     /// over-counts overlapping applies rather than losing them, which is the
     /// safer direction for a measurement whose purpose is to justify work.
+    ///
+    /// Two known biases, both upward, both worth knowing before trusting a
+    /// tail figure. `beforeWaiting` fires only when the loop is actually about
+    /// to sleep, so a main thread under continuous load can go many iterations
+    /// without one and the sample absorbs all of it. And the observer is added
+    /// to `.commonModes`, so a run loop excursion into a mode outside that set
+    /// is reported as apply time when a common mode resumes. Read `max` and
+    /// `p95` with that in mind; a single excursion poisons both.
     private func measureApply(from start: CFTimeInterval, transition: String) {
         var observer: CFRunLoopObserver?
         observer = CFRunLoopObserverCreateWithHandler(
             kCFAllocatorDefault,
             CFRunLoopActivity.beforeWaiting.rawValue,
             false,
-            0
+            CFIndex.max
         ) { obs, _ in
             mob_record_native_frame((CACurrentMediaTime() - start) * 1_000_000, transition)
             CFRunLoopRemoveObserver(CFRunLoopGetMain(), obs, .commonModes)

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -6777,8 +6777,7 @@ void mob_record_native_frame(double apply_us, const char *transition) {
         // strncpy rather than strlcpy so this stays portable to the Android
         // build if the same shape is ported; the explicit terminator is what
         // strncpy does not guarantee.
-        strncpy(slot->transition, transition ? transition : "none",
-                sizeof(slot->transition) - 1);
+        strncpy(slot->transition, transition ? transition : "none", sizeof(slot->transition) - 1);
         slot->transition[sizeof(slot->transition) - 1] = '\0';
         g_native_frame_seq++;
     }

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -6697,6 +6697,93 @@ static ERL_NIF_TERM nif_screenshot(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 }
 #endif // !MOB_RELEASE || MOB_ENABLE_SCREENSHOT
 
+// Storage and the two Swift-callable entry points live OUTSIDE the debug-only
+// harness guard below, deliberately. MobViewModel calls both on every set_root
+// with no knowledge of MOB_RELEASE: the release pipeline compiles ios/*.swift
+// without the flag and mob_nif.m with it, so defining these inside the guard
+// links fine in debug and fails every release build with an undefined symbol.
+// This file already states the rule where g_ui_event_seq is declared: "only the
+// harness reads it; the writers stay unconditional". Only the two NIFs that
+// READ the samples are gated, alongside the rest of the harness.
+
+// ── Native frame timing (the half Mob.RenderStats cannot see) ────────────────
+//
+// `Mob.RenderStats` stops at the BEAM boundary. Its `set_root_us` covers the
+// ObjC half of `nif_set_root` only — JSON parse, node construction, the tap
+// table swap — because `[MobViewModel setRoot:transition:]` dispatches to the
+// main thread and returns immediately. Everything SwiftUI then does to build,
+// lay out and display the tree happens after that measurement has closed, so
+// the entire native half of a frame has never been measured on either platform.
+//
+// That is the quantity MOB-126 and MOB-129 are arguing about: whether tearing
+// the view tree down on navigation costs enough to be worth retaining trees per
+// screen. MOB-130 says the wire-format decision must be made on evidence only.
+// None of those can be settled against a number nobody has.
+//
+// What is recorded here is **main-thread busy time**: from the instant the new
+// tree is applied to the view model to the instant the main run loop goes idle
+// again, which is after SwiftUI has built the view tree, laid it out and handed
+// it to Core Animation. That is deliberately the pessimistic reading — anything
+// else queued on the main thread in that window is counted too — because it is
+// also the honest one: a frame is dropped when the main thread is busy, whoever
+// made it busy. Treat a sample as an upper bound on this frame's native cost,
+// not as an attribution.
+//
+// Cost when disabled is one relaxed atomic load per `set_root`. The run loop
+// observer, the timestamps and the lock are all downstream of that check, so an
+// app that never enables this pays for a single integer read per navigation.
+
+#define MOB_NATIVE_FRAME_SAMPLES 240
+
+typedef struct {
+    double apply_us;
+    uint64_t seq;
+    char transition[16];
+} mob_native_frame_t;
+
+// Ring buffer. `g_native_frame_seq` counts every sample ever recorded, so a
+// reader can tell "240 samples, that is all there were" from "240 samples, and
+// 5000 more scrolled past" — the difference decides whether a percentile over
+// this window means anything.
+static mob_native_frame_t g_native_frames[MOB_NATIVE_FRAME_SAMPLES];
+static uint64_t g_native_frame_seq = 0;
+
+// Read on the main thread on every set_root, written from a NIF thread. Atomic
+// rather than lock-guarded so the disabled path costs a load and no more; the
+// relaxed ordering is fine because a sample recorded a frame either side of the
+// flag flipping is not a correctness problem.
+static _Atomic int g_native_stats_enabled = 0;
+
+static NSObject *g_native_stats_lock = nil;
+static dispatch_once_t g_native_stats_once;
+
+static NSObject *mob_native_stats_lock(void) {
+    dispatch_once(&g_native_stats_once, ^{
+      g_native_stats_lock = [NSObject new];
+    });
+    return g_native_stats_lock;
+}
+
+int mob_native_stats_enabled(void) {
+    return atomic_load_explicit(&g_native_stats_enabled, memory_order_relaxed);
+}
+
+void mob_record_native_frame(double apply_us, const char *transition) {
+    NSObject *lock = mob_native_stats_lock();
+    @synchronized(lock) {
+        mob_native_frame_t *slot = &g_native_frames[g_native_frame_seq % MOB_NATIVE_FRAME_SAMPLES];
+        slot->apply_us = apply_us;
+        slot->seq = g_native_frame_seq;
+        // strncpy rather than strlcpy so this stays portable to the Android
+        // build if the same shape is ported; the explicit terminator is what
+        // strncpy does not guarantee.
+        strncpy(slot->transition, transition ? transition : "none",
+                sizeof(slot->transition) - 1);
+        slot->transition[sizeof(slot->transition) - 1] = '\0';
+        g_native_frame_seq++;
+    }
+}
+
 #if !MOB_RELEASE // resume the debug-only harness (sampling + scroll + element frames)
 
 // sample_region(X, Y, W, H) -> {ok, PixelW, PixelH, RGBA} | {error, Reason}
@@ -6857,84 +6944,6 @@ static ERL_NIF_TERM nif_scroll_to(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
     return ok ? enif_make_atom(env, "ok")
               : enif_make_tuple2(env, enif_make_atom(env, "error"),
                                  enif_make_atom(env, "scroll_view_not_found"));
-}
-
-// ── Native frame timing (the half Mob.RenderStats cannot see) ────────────────
-//
-// `Mob.RenderStats` stops at the BEAM boundary. Its `set_root_us` covers the
-// ObjC half of `nif_set_root` only — JSON parse, node construction, the tap
-// table swap — because `[MobViewModel setRoot:transition:]` dispatches to the
-// main thread and returns immediately. Everything SwiftUI then does to build,
-// lay out and display the tree happens after that measurement has closed, so
-// the entire native half of a frame has never been measured on either platform.
-//
-// That is the quantity MOB-126 and MOB-129 are arguing about: whether tearing
-// the view tree down on navigation costs enough to be worth retaining trees per
-// screen. MOB-130 says the wire-format decision must be made on evidence only.
-// None of those can be settled against a number nobody has.
-//
-// What is recorded here is **main-thread busy time**: from the instant the new
-// tree is applied to the view model to the instant the main run loop goes idle
-// again, which is after SwiftUI has built the view tree, laid it out and handed
-// it to Core Animation. That is deliberately the pessimistic reading — anything
-// else queued on the main thread in that window is counted too — because it is
-// also the honest one: a frame is dropped when the main thread is busy, whoever
-// made it busy. Treat a sample as an upper bound on this frame's native cost,
-// not as an attribution.
-//
-// Cost when disabled is one relaxed atomic load per `set_root`. The run loop
-// observer, the timestamps and the lock are all downstream of that check, so an
-// app that never enables this pays for a single integer read per navigation.
-
-#define MOB_NATIVE_FRAME_SAMPLES 240
-
-typedef struct {
-    double apply_us;
-    uint64_t seq;
-    char transition[16];
-} mob_native_frame_t;
-
-// Ring buffer. `g_native_frame_seq` counts every sample ever recorded, so a
-// reader can tell "240 samples, that is all there were" from "240 samples, and
-// 5000 more scrolled past" — the difference decides whether a percentile over
-// this window means anything.
-static mob_native_frame_t g_native_frames[MOB_NATIVE_FRAME_SAMPLES];
-static uint64_t g_native_frame_seq = 0;
-
-// Read on the main thread on every set_root, written from a NIF thread. Atomic
-// rather than lock-guarded so the disabled path costs a load and no more; the
-// relaxed ordering is fine because a sample recorded a frame either side of the
-// flag flipping is not a correctness problem.
-static _Atomic int g_native_stats_enabled = 0;
-
-static NSObject *g_native_stats_lock = nil;
-static dispatch_once_t g_native_stats_once;
-
-static NSObject *mob_native_stats_lock(void) {
-    dispatch_once(&g_native_stats_once, ^{
-      g_native_stats_lock = [NSObject new];
-    });
-    return g_native_stats_lock;
-}
-
-int mob_native_stats_enabled(void) {
-    return atomic_load_explicit(&g_native_stats_enabled, memory_order_relaxed);
-}
-
-void mob_record_native_frame(double apply_us, const char *transition) {
-    NSObject *lock = mob_native_stats_lock();
-    @synchronized(lock) {
-        mob_native_frame_t *slot = &g_native_frames[g_native_frame_seq % MOB_NATIVE_FRAME_SAMPLES];
-        slot->apply_us = apply_us;
-        slot->seq = g_native_frame_seq;
-        // strncpy rather than strlcpy so this stays portable to the Android
-        // build if the same shape is ported; the explicit terminator is what
-        // strncpy does not guarantee.
-        strncpy(slot->transition, transition ? transition : "none",
-                sizeof(slot->transition) - 1);
-        slot->transition[sizeof(slot->transition) - 1] = '\0';
-        g_native_frame_seq++;
-    }
 }
 
 // nif_native_stats_enable/1 — turn native frame timing on or off.

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -6859,6 +6859,162 @@ static ERL_NIF_TERM nif_scroll_to(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
                                  enif_make_atom(env, "scroll_view_not_found"));
 }
 
+// ── Native frame timing (the half Mob.RenderStats cannot see) ────────────────
+//
+// `Mob.RenderStats` stops at the BEAM boundary. Its `set_root_us` covers the
+// ObjC half of `nif_set_root` only — JSON parse, node construction, the tap
+// table swap — because `[MobViewModel setRoot:transition:]` dispatches to the
+// main thread and returns immediately. Everything SwiftUI then does to build,
+// lay out and display the tree happens after that measurement has closed, so
+// the entire native half of a frame has never been measured on either platform.
+//
+// That is the quantity MOB-126 and MOB-129 are arguing about: whether tearing
+// the view tree down on navigation costs enough to be worth retaining trees per
+// screen. MOB-130 says the wire-format decision must be made on evidence only.
+// None of those can be settled against a number nobody has.
+//
+// What is recorded here is **main-thread busy time**: from the instant the new
+// tree is applied to the view model to the instant the main run loop goes idle
+// again, which is after SwiftUI has built the view tree, laid it out and handed
+// it to Core Animation. That is deliberately the pessimistic reading — anything
+// else queued on the main thread in that window is counted too — because it is
+// also the honest one: a frame is dropped when the main thread is busy, whoever
+// made it busy. Treat a sample as an upper bound on this frame's native cost,
+// not as an attribution.
+//
+// Cost when disabled is one relaxed atomic load per `set_root`. The run loop
+// observer, the timestamps and the lock are all downstream of that check, so an
+// app that never enables this pays for a single integer read per navigation.
+
+#define MOB_NATIVE_FRAME_SAMPLES 240
+
+typedef struct {
+    double apply_us;
+    uint64_t seq;
+    char transition[16];
+} mob_native_frame_t;
+
+// Ring buffer. `g_native_frame_seq` counts every sample ever recorded, so a
+// reader can tell "240 samples, that is all there were" from "240 samples, and
+// 5000 more scrolled past" — the difference decides whether a percentile over
+// this window means anything.
+static mob_native_frame_t g_native_frames[MOB_NATIVE_FRAME_SAMPLES];
+static uint64_t g_native_frame_seq = 0;
+
+// Read on the main thread on every set_root, written from a NIF thread. Atomic
+// rather than lock-guarded so the disabled path costs a load and no more; the
+// relaxed ordering is fine because a sample recorded a frame either side of the
+// flag flipping is not a correctness problem.
+static _Atomic int g_native_stats_enabled = 0;
+
+static NSObject *g_native_stats_lock = nil;
+static dispatch_once_t g_native_stats_once;
+
+static NSObject *mob_native_stats_lock(void) {
+    dispatch_once(&g_native_stats_once, ^{
+      g_native_stats_lock = [NSObject new];
+    });
+    return g_native_stats_lock;
+}
+
+int mob_native_stats_enabled(void) {
+    return atomic_load_explicit(&g_native_stats_enabled, memory_order_relaxed);
+}
+
+void mob_record_native_frame(double apply_us, const char *transition) {
+    NSObject *lock = mob_native_stats_lock();
+    @synchronized(lock) {
+        mob_native_frame_t *slot = &g_native_frames[g_native_frame_seq % MOB_NATIVE_FRAME_SAMPLES];
+        slot->apply_us = apply_us;
+        slot->seq = g_native_frame_seq;
+        // strncpy rather than strlcpy so this stays portable to the Android
+        // build if the same shape is ported; the explicit terminator is what
+        // strncpy does not guarantee.
+        strncpy(slot->transition, transition ? transition : "none",
+                sizeof(slot->transition) - 1);
+        slot->transition[sizeof(slot->transition) - 1] = '\0';
+        g_native_frame_seq++;
+    }
+}
+
+// nif_native_stats_enable/1 — turn native frame timing on or off.
+//
+// Off by default. See the ring buffer above for what is measured and why the
+// disabled path is a single atomic load.
+static ERL_NIF_TERM nif_native_stats_enable(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    char flag[8] = {0};
+    if (!enif_get_atom(env, argv[0], flag, sizeof(flag), ERL_NIF_LATIN1))
+        return enif_make_badarg(env);
+
+    int on = (strcmp(flag, "true") == 0);
+    if (!on && strcmp(flag, "false") != 0)
+        return enif_make_badarg(env);
+
+    // Reset the window when enabling, so a measurement run never reports
+    // samples from an earlier one. Enabling is the natural "start measuring
+    // here" marker and callers reasonably read it that way.
+    if (on) {
+        NSObject *lock = mob_native_stats_lock();
+        @synchronized(lock) {
+            g_native_frame_seq = 0;
+        }
+    }
+    atomic_store_explicit(&g_native_stats_enabled, on, memory_order_relaxed);
+    return enif_make_atom(env, "ok");
+}
+
+// nif_native_stats/0 — JSON of the recorded native frame samples, newest first.
+//
+// {"enabled":bool,"recorded":N,"dropped":M,"samples":[{"apply_us":f,"transition":s,"seq":n},...]}
+//
+// `recorded` is every sample since the window opened; `dropped` is how many
+// scrolled out of the ring. A percentile over `samples` describes the tail of
+// the run only, and `dropped > 0` is what tells the reader that.
+static ERL_NIF_TERM nif_native_stats(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    mob_native_frame_t snapshot[MOB_NATIVE_FRAME_SAMPLES];
+    uint64_t total = 0;
+
+    // Snapshot under the lock, serialize outside it: the main thread takes this
+    // same lock once per set_root, and JSON-encoding 240 samples from a dirty
+    // scheduler while holding it would stall UI work on a thread with no QoS
+    // relationship to it. Same reasoning as nif_element_frames.
+    NSObject *lock = mob_native_stats_lock();
+    @synchronized(lock) {
+        total = g_native_frame_seq;
+        memcpy(snapshot, g_native_frames, sizeof(snapshot));
+    }
+
+    uint64_t held = total < MOB_NATIVE_FRAME_SAMPLES ? total : MOB_NATIVE_FRAME_SAMPLES;
+    NSMutableArray *samples = [NSMutableArray arrayWithCapacity:(NSUInteger)held];
+    // Newest first, matching Mob.RenderStats.frames/0.
+    for (uint64_t i = 0; i < held; i++) {
+        uint64_t seq = total - 1 - i;
+        mob_native_frame_t *f = &snapshot[seq % MOB_NATIVE_FRAME_SAMPLES];
+        [samples addObject:@{
+            @"apply_us" : @(f->apply_us),
+            @"transition" : [NSString stringWithUTF8String:f->transition] ?: @"none",
+            @"seq" : @(f->seq)
+        }];
+    }
+
+    NSDictionary *payload = @{
+        @"enabled" : @(mob_native_stats_enabled() ? YES : NO),
+        @"recorded" : @(total),
+        @"dropped" : @(total > MOB_NATIVE_FRAME_SAMPLES ? total - MOB_NATIVE_FRAME_SAMPLES : 0),
+        @"samples" : samples
+    };
+
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+    if (!jsonData)
+        return enif_make_tuple2(env, enif_make_atom(env, "error"),
+                                enif_make_atom(env, "encode_failed"));
+
+    ErlNifBinary bin;
+    enif_alloc_binary(jsonData.length, &bin);
+    memcpy(bin.data, jsonData.bytes, jsonData.length);
+    return enif_make_binary(env, &bin);
+}
+
 // nif_element_frames/0 — JSON {"id":[x,y,w,h],...} of tagged element frames
 // (logical points). Recorded by MobFrameTracker; see mob_register_frame.
 static ERL_NIF_TERM nif_element_frames(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -7783,6 +7939,8 @@ static ErlNifFunc nif_funcs[] = {
     {"scroll_info", 1, nif_scroll_info, 0},
     {"scroll_to", 3, nif_scroll_to, 0},
     {"element_frames", 0, nif_element_frames, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"native_stats", 0, nif_native_stats, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"native_stats_enable", 1, nif_native_stats_enable, 0},
 #endif
     // ── Core mob functions ───────────────────────────────────────────────────
     {"battery_level", 0, nif_battery_level, 0},

--- a/lib/mob/render_stats.ex
+++ b/lib/mob/render_stats.ex
@@ -620,7 +620,18 @@ defmodule Mob.RenderStats do
             samples
             |> Enum.group_by(& &1["transition"])
             |> Map.new(fn {transition, group} ->
-              {transition, percentiles(Enum.map(group, &%{apply_us: &1["apply_us"]}), :apply_us)}
+              # Drop non-numeric durations rather than sorting them. Elixir term
+              # ordering puts every binary above every number, so one
+              # `"apply_us": "slow"` from a mismatched native half becomes the
+              # p95 and the max: it takes over precisely the half of the
+              # distribution this measurement exists to look at.
+              values =
+                group
+                |> Enum.map(& &1["apply_us"])
+                |> Enum.filter(&is_number/1)
+                |> Enum.map(&%{apply_us: &1})
+
+              {transition, percentiles(values, :apply_us)}
             end)
         }
     end
@@ -633,14 +644,46 @@ defmodule Mob.RenderStats do
   defp native_call(nif, fun, args) do
     apply(nif, fun, args)
   rescue
-    UndefinedFunctionError -> {:error, :unsupported}
-    ErlangError -> {:error, :unsupported}
+    e in UndefinedFunctionError ->
+      # Only this module's own absence. A different UndefinedFunctionError
+      # raised from inside a working NIF is a real bug and should surface.
+      if e.module == nif and e.function == fun,
+        do: {:error, :unsupported},
+        else: reraise(e, __STACKTRACE__)
+
+    e in ErlangError ->
+      # Only the not-loaded stub. A working NIF can raise other erlang terms
+      # (`:system_limit` out of enif_alloc_binary, say), and turning those into
+      # "this platform does not support it" would hide a real failure behind a
+      # message saying nothing is wrong.
+      #
+      # Map.get, not `e.original`: this clause also catches the erlang errors
+      # that Elixir normalises into their own structs, and SystemLimitError has
+      # no :original field. Reading it directly raises KeyError from inside a
+      # rescue, turning a recoverable error into a crash — which is exactly what
+      # this function exists to prevent, and on the example named above.
+      if Map.get(e, :original) == :not_loaded,
+        do: {:error, :unsupported},
+        else: reraise(e, __STACKTRACE__)
   end
 
+  # Shape-check, not just key-check. The payload is well-formed JSON produced by
+  # a native library that may be older or newer than this module, so "parsed" is
+  # not the same as "usable": a `samples` that is a number reaches `length/1`,
+  # and a list of bare numbers reaches `Access.get/3`, both of which raise out of
+  # a function documented to return `{:error, _}` and never take down whatever
+  # is reading stats.
   defp decode_native(json) do
     case :json.decode(json) do
-      %{"samples" => _} = payload -> {:ok, payload}
-      other -> {:error, {:unexpected_payload, other}}
+      %{"samples" => samples} = payload when is_list(samples) ->
+        if Enum.all?(samples, &is_map/1) do
+          {:ok, payload}
+        else
+          {:error, {:unexpected_payload, :sample_not_a_map}}
+        end
+
+      other ->
+        {:error, {:unexpected_payload, other}}
     end
   rescue
     _ -> {:error, :bad_json}

--- a/lib/mob/render_stats.ex
+++ b/lib/mob/render_stats.ex
@@ -535,4 +535,114 @@ defmodule Mob.RenderStats do
     :ets.new(@table, [:named_table, :public, :ordered_set, write_concurrency: true])
     {:ok, %{}}
   end
+
+  # ── Native frame timing ───────────────────────────────────────────────────
+  #
+  # Everything above measures the BEAM half of a frame. `set_root_us` closes
+  # when `nif_set_root` returns, and on iOS that is the moment the new tree is
+  # handed to the main thread, not the moment it is on screen: the SwiftUI
+  # build, layout and display all happen afterwards. The same is true of
+  # Compose on Android. So the native half of every frame has been invisible to
+  # this module since it was written, which is the gap MOB-126 ran into.
+  #
+  # These functions read a native-side ring buffer of main-thread busy time per
+  # applied tree. They are a separate window from `frames/0` on purpose: the
+  # native sample completes asynchronously, well after the BEAM frame it belongs
+  # to has been committed and recorded, so correlating the two would mean
+  # threading an identifier through the wire for a number that is only ever read
+  # by a human deciding whether an optimisation is worth building.
+
+  @doc """
+  Turn native frame timing on, and clear the sample window.
+
+  Off by default. When off, the native side pays one atomic load per
+  `set_root`; the timestamps and the run loop observer are downstream of that
+  check.
+
+  Returns `{:error, :unsupported}` on a platform whose native half has not
+  implemented it yet, and on the host, where there is no native side at all.
+  """
+  @spec native_enable(module()) :: :ok | {:error, :unsupported}
+  def native_enable(nif \\ :mob_nif), do: native_call(nif, :native_stats_enable, [true])
+
+  @doc "Turn native frame timing off. Recorded samples stay readable."
+  @spec native_disable(module()) :: :ok | {:error, :unsupported}
+  def native_disable(nif \\ :mob_nif), do: native_call(nif, :native_stats_enable, [false])
+
+  @doc """
+  Native frame samples, newest first.
+
+  Each sample is `%{apply_us: float(), transition: String.t(), seq: integer()}`.
+  `apply_us` is main-thread busy time from the tree being applied to the run
+  loop going idle, so read it as an upper bound on that frame's native cost
+  rather than as an attribution: anything else queued on the main thread in the
+  same window is inside it.
+  """
+  @spec native_frames(module()) :: {:ok, map()} | {:error, :unsupported | term()}
+  def native_frames(nif \\ :mob_nif) do
+    case native_call(nif, :native_stats, []) do
+      {:error, reason} -> {:error, reason}
+      json when is_binary(json) -> decode_native(json)
+      other -> {:error, other}
+    end
+  end
+
+  @doc """
+  Percentiles of native apply time, split by transition.
+
+  Split because the two populations answer different questions and pooling them
+  hides both: a `"none"` sample is a steady-state re-render into an existing
+  view tree, while `"push"`, `"pop"` and `"reset"` each rebuild the whole tree
+  because the root carries a new identity. The size of that difference is
+  exactly what MOB-126 and MOB-129 are arguing about.
+
+  `dropped` is how many samples scrolled out of the native ring buffer. When it
+  is above zero the percentiles describe the tail of the run, not all of it.
+  """
+  @spec native_summary(module()) :: map() | {:error, :unsupported | term()}
+  def native_summary(nif \\ :mob_nif) do
+    case native_frames(nif) do
+      {:error, reason} ->
+        {:error, reason}
+
+      {:ok, %{"samples" => []} = payload} ->
+        %{samples: 0, recorded: payload["recorded"], dropped: payload["dropped"]}
+
+      {:ok, payload} ->
+        samples = payload["samples"]
+
+        %{
+          samples: length(samples),
+          recorded: payload["recorded"],
+          dropped: payload["dropped"],
+          enabled: payload["enabled"],
+          apply_us:
+            samples
+            |> Enum.group_by(& &1["transition"])
+            |> Map.new(fn {transition, group} ->
+              {transition, percentiles(Enum.map(group, &%{apply_us: &1["apply_us"]}), :apply_us)}
+            end)
+        }
+    end
+  end
+
+  # A NIF that the running platform has not implemented raises UndefinedFunction
+  # (host, where :mob_nif is absent) or ErlangError :nif_not_loaded (a device
+  # whose native half lacks this function). Both mean the same thing to a
+  # caller, and neither should take down whatever is reading stats.
+  defp native_call(nif, fun, args) do
+    apply(nif, fun, args)
+  rescue
+    UndefinedFunctionError -> {:error, :unsupported}
+    ErlangError -> {:error, :unsupported}
+  end
+
+  defp decode_native(json) do
+    case :json.decode(json) do
+      %{"samples" => _} = payload -> {:ok, payload}
+      other -> {:error, {:unexpected_payload, other}}
+    end
+  rescue
+    _ -> {:error, :bad_json}
+  end
 end

--- a/src/mob_nif.erl
+++ b/src/mob_nif.erl
@@ -106,6 +106,8 @@
     scroll_info/1,
     scroll_to/3,
     element_frames/0,
+    native_stats/0,
+    native_stats_enable/1,
     %% Peripheral.VendorUsb (Android USB host; iOS returns :unsupported)
     vendor_usb_list_devices/1,
     vendor_usb_request_permission/1,
@@ -205,6 +207,8 @@
     scroll_info/1,
     scroll_to/3,
     element_frames/0,
+    native_stats/0,
+    native_stats_enable/1,
     %% Storage
     storage_dir/1,
     storage_save_to_photo_library/1,
@@ -360,6 +364,18 @@ scroll_to(_Id, _X, _Y) -> erlang:nif_error(not_loaded).
 %% every rendered node that carries an :id (logical points iOS / dp Android).
 %% Lets an agent locate + drive elements by id without a screenshot.
 element_frames() -> erlang:nif_error(not_loaded).
+
+%% native_stats() -> JSON binary of native frame timings, newest first:
+%%   {"enabled":bool,"recorded":N,"dropped":M,
+%%    "samples":[{"apply_us":F,"transition":S,"seq":N},...]}
+%% Measures main-thread busy time applying a tree, which is the half
+%% Mob.RenderStats cannot see. Off until native_stats_enable(true).
+native_stats() -> erlang:nif_error(not_loaded).
+
+%% native_stats_enable(true | false) -> ok
+%% Enabling also clears the sample window, so a run never reports samples
+%% from an earlier one.
+native_stats_enable(_On) -> erlang:nif_error(not_loaded).
 storage_dir(_Location) -> erlang:nif_error(not_loaded).
 storage_save_to_photo_library(_Path) -> erlang:nif_error(not_loaded).
 storage_save_to_media_store(_Path, _Type) -> erlang:nif_error(not_loaded).

--- a/test/mob/native_frame_stats_test.exs
+++ b/test/mob/native_frame_stats_test.exs
@@ -164,13 +164,108 @@ defmodule Mob.NativeFrameStatsTest do
       # Same reasoning as nif_element_frames: the main thread takes this lock
       # once per set_root, and JSON-encoding the window from a dirty scheduler
       # while holding it stalls UI work on a thread with no QoS relationship.
-      body = nif_body(@nif, "nif_native_stats")
-      snapshot_at = index_of(body, "memcpy(snapshot, g_native_frames")
-      encode_at = index_of(body, "NSJSONSerialization")
-      sync_close = index_of(body, "}\n\n    uint64_t held")
+      #
+      # Asserted against the actual @synchronized block rather than against a
+      # nearby line. The earlier version located the closing brace by looking
+      # for the text that happened to follow it, which passed just as happily
+      # with the memcpy hoisted ABOVE the lock (the regression it is named for)
+      # and failed on an innocent rename or an added comment.
+      critical = synchronized_body(nif_body(@nif, "nif_native_stats"))
 
-      assert snapshot_at < sync_close, "the copy must happen inside @synchronized"
-      assert encode_at > sync_close, "the encode must happen after the lock is released"
+      assert critical =~ "memcpy(snapshot, g_native_frames",
+             "the copy must happen inside @synchronized"
+
+      refute critical =~ "NSJSONSerialization",
+             "the encode must not happen while the lock is held"
+
+      assert nif_body(@nif, "nif_native_stats") =~ "NSJSONSerialization",
+             "and it must still happen somewhere"
+    end
+
+    test "the Swift-callable helpers are outside the debug-only harness guard" do
+      # MobViewModel calls both on every set_root with no knowledge of
+      # MOB_RELEASE: the release pipeline compiles ios/*.swift without the flag
+      # and mob_nif.m with it. Defining these inside the guard links in debug
+      # and fails EVERY release build with an undefined symbol. Only the two
+      # NIFs that read the samples belong inside.
+      code = code_only(@nif)
+
+      writer_at = index_of(code, "void mob_record_native_frame(double apply_us")
+      probe_at = index_of(code, "int mob_native_stats_enabled(void) {")
+      harness_at = index_of(code, "#if !MOB_RELEASE // resume the debug-only harness")
+
+      assert writer_at < harness_at,
+             "mob_record_native_frame is Swift-callable and must not be release-gated"
+
+      assert probe_at < harness_at,
+             "mob_native_stats_enabled is Swift-callable and must not be release-gated"
+
+      # The readers, by contrast, must stay gated: they are harness surface.
+      assert index_of(code, "static ERL_NIF_TERM nif_native_stats(") > harness_at
+    end
+  end
+
+  describe "the measurement's closing bracket" do
+    test "the observer runs after Core Animation's commit, not before it" do
+      # beforeWaiting observers fire in ascending order, and Core Animation's
+      # transaction-commit observer sits at 2000000. SwiftUI evaluates bodies
+      # and lays out inside that commit, so an observer at order 0 fires before
+      # every bit of the work being measured and still reports a plausible
+      # number. This is the same class of silent-wrong-answer as the
+      # CATransaction completion the module rejects, and it has to be pinned
+      # rather than left to a comment.
+      assert code_only(@view_model) =~ "CFIndex.max"
+
+      refute code_only(@view_model) =~ ~r/beforeWaiting\.rawValue,\s*false,\s*0\b/s,
+             "order 0 puts the bracket ahead of the layout being measured"
+    end
+  end
+
+  describe "reading a payload from a mismatched native half" do
+    test "a samples field that is not a list is refused, not crashed on" do
+      defmodule ScalarSamplesNif do
+        def native_stats, do: ~s({"enabled":true,"recorded":1,"dropped":0,"samples":5})
+      end
+
+      assert {:error, {:unexpected_payload, _}} = RenderStats.native_frames(ScalarSamplesNif)
+      assert {:error, {:unexpected_payload, _}} = RenderStats.native_summary(ScalarSamplesNif)
+    end
+
+    test "samples that are not maps are refused" do
+      defmodule BareSamplesNif do
+        def native_stats, do: ~s({"enabled":true,"recorded":3,"dropped":0,"samples":[1,2,3]})
+      end
+
+      assert {:error, {:unexpected_payload, _}} = RenderStats.native_summary(BareSamplesNif)
+    end
+
+    test "a non-numeric duration cannot take over the tail" do
+      # Elixir term ordering puts every binary above every number, so one bad
+      # value becomes both p95 and max: it captures exactly the half of the
+      # distribution the measurement exists to look at.
+      defmodule StringDurationNif do
+        def native_stats do
+          ~s({"enabled":true,"recorded":2,"dropped":0,"samples":[) <>
+            ~s({"apply_us":"slow","transition":"push","seq":1},) <>
+            ~s({"apply_us":3.0,"transition":"push","seq":0}]})
+        end
+      end
+
+      summary = RenderStats.native_summary(StringDurationNif)
+      assert %{"push" => push} = summary.apply_us
+      assert push.n == 1
+      assert push.max == 3.0
+    end
+
+    test "a genuine error from a working NIF is not disguised as :unsupported" do
+      # rescue ErlangError across the board would turn a real failure inside a
+      # loaded NIF into "this platform does not support it", which reads as
+      # nothing being wrong.
+      defmodule AngryNif do
+        def native_stats, do: :erlang.error(:system_limit)
+      end
+
+      assert_raise SystemLimitError, fn -> RenderStats.native_frames(AngryNif) end
     end
 
     test "enabling clears the window so a run cannot report an earlier one" do
@@ -213,6 +308,25 @@ defmodule Mob.NativeFrameStatsTest do
       |> String.replace(~r{^\s*%%.*$}, "")
     end)
     |> Enum.join("\n")
+  end
+
+  # The text between `@synchronized(lock) {` and its matching close, by brace
+  # depth. Locating the close by the line that follows it is what made the
+  # earlier version of the lock test pass with the memcpy hoisted out.
+  defp synchronized_body(body) do
+    [_, after_open] = String.split(body, "@synchronized(lock) {", parts: 2)
+
+    {taken, _} =
+      after_open
+      |> String.graphemes()
+      |> Enum.reduce_while({[], 1}, fn
+        "{", {acc, depth} -> {:cont, {["{" | acc], depth + 1}}
+        "}", {acc, 1} -> {:halt, {acc, 0}}
+        "}", {acc, depth} -> {:cont, {["}" | acc], depth - 1}}
+        c, {acc, depth} -> {:cont, {[c | acc], depth}}
+      end)
+
+    taken |> Enum.reverse() |> Enum.join()
   end
 
   defp nif_body(source, name) do

--- a/test/mob/native_frame_stats_test.exs
+++ b/test/mob/native_frame_stats_test.exs
@@ -1,0 +1,231 @@
+defmodule Mob.NativeFrameStatsTest do
+  @moduledoc """
+  Native frame timing: the half `Mob.RenderStats` could not see (MOB-126).
+
+  `set_root_us` closes when `nif_set_root` returns, and that is the moment the
+  tree is handed to the main thread, not the moment it is on screen. The
+  SwiftUI build, layout and display all happen afterwards, so the native half
+  of every frame was unmeasured. MOB-129 and MOB-130 are both explicitly
+  evidence-gated, and there was no evidence to gate them on.
+
+  The Swift and ObjC halves are asserted against source text because there is
+  no host-side way to run them. Every such assertion goes through `code_only/1`
+  first: an earlier test in this repo passed by matching a string that appeared
+  only inside its own explanatory comment, which is a test that guards nothing.
+  """
+  # credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+  use ExUnit.Case, async: true
+
+  alias Mob.RenderStats
+
+  @view_model File.read!(Path.expand("../../ios/MobViewModel.swift", __DIR__))
+  @nif File.read!(Path.expand("../../ios/mob_nif.m", __DIR__))
+  @erl File.read!(Path.expand("../../src/mob_nif.erl", __DIR__))
+
+  # A NIF module that has not been loaded: every function raises, which is what
+  # a device whose native half predates this feature actually does.
+  defmodule NotLoadedNif do
+    def native_stats, do: :erlang.nif_error(:not_loaded)
+    def native_stats_enable(_on), do: :erlang.nif_error(:not_loaded)
+  end
+
+  # No such functions at all: the host, where :mob_nif does not exist.
+  defmodule AbsentNif do
+  end
+
+  defmodule FakeNif do
+    def native_stats_enable(_on), do: :ok
+
+    def native_stats do
+      ~s({"enabled":true,"recorded":5,"dropped":0,"samples":[) <>
+        ~s({"apply_us":9000.0,"transition":"push","seq":4},) <>
+        ~s({"apply_us":7000.0,"transition":"push","seq":3},) <>
+        ~s({"apply_us":5000.0,"transition":"push","seq":2},) <>
+        ~s({"apply_us":300.0,"transition":"none","seq":1},) <>
+        ~s({"apply_us":100.0,"transition":"none","seq":0}]})
+    end
+  end
+
+  describe "graceful degradation" do
+    test "a native half that has not implemented it reports :unsupported" do
+      # Android has no native_stats yet, so :mob_nif keeps the Erlang stub and
+      # it raises. Reading stats must not take down whatever is reading them.
+      assert {:error, :unsupported} = RenderStats.native_enable(NotLoadedNif)
+      assert {:error, :unsupported} = RenderStats.native_disable(NotLoadedNif)
+      assert {:error, :unsupported} = RenderStats.native_frames(NotLoadedNif)
+      assert {:error, :unsupported} = RenderStats.native_summary(NotLoadedNif)
+    end
+
+    test "the host, with no NIF module at all, reports :unsupported" do
+      assert {:error, :unsupported} = RenderStats.native_enable(AbsentNif)
+      assert {:error, :unsupported} = RenderStats.native_summary(AbsentNif)
+    end
+  end
+
+  describe "native_summary/1" do
+    test "splits percentiles by transition rather than pooling them" do
+      # The whole point of the measurement. A "none" sample re-renders into an
+      # existing view tree; a "push" rebuilds it because the root takes a new
+      # identity. Pooling the two produces a p50 that describes neither, and
+      # the size of the gap is what MOB-126 and MOB-129 argue about.
+      summary = RenderStats.native_summary(FakeNif)
+
+      assert %{"push" => push, "none" => none} = summary.apply_us
+      assert push.n == 3
+      assert none.n == 2
+      assert push.max == 9000.0
+      assert none.max == 300.0
+      assert push.p50 > none.p50
+    end
+
+    test "carries recorded and dropped so a percentile can be read honestly" do
+      summary = RenderStats.native_summary(FakeNif)
+
+      assert summary.samples == 5
+      assert summary.recorded == 5
+      assert summary.dropped == 0
+    end
+
+    test "an empty window is not an error" do
+      defmodule EmptyNif do
+        def native_stats, do: ~s({"enabled":true,"recorded":0,"dropped":0,"samples":[]})
+      end
+
+      assert %{samples: 0, recorded: 0} = RenderStats.native_summary(EmptyNif)
+    end
+
+    test "malformed native JSON does not raise" do
+      defmodule GarbageNif do
+        def native_stats, do: "not json at all"
+      end
+
+      assert {:error, :bad_json} = RenderStats.native_frames(GarbageNif)
+    end
+  end
+
+  describe "the iOS measurement" do
+    test "is gated so a disabled app pays only the enabled check" do
+      # The gate is the entire cost argument. Without it every set_root arms a
+      # run loop observer and takes two timestamps, on the main thread, in
+      # every shipped app that never asked to measure anything.
+      code = code_only(@view_model)
+      assert code =~ "mob_native_stats_enabled()"
+
+      assert code =~ ~r/let measuring = mob_native_stats_enabled\(\) != 0/,
+             "setRoot must decide up front whether it is measuring"
+
+      assert code =~ ~r/if measuring \{\s*self\.measureApply/,
+             "the observer must only be armed when measuring"
+    end
+
+    test "closes on run loop idle, not on the CATransaction that was open" do
+      # CATransaction.setCompletionBlock is the obvious choice and is wrong:
+      # SwiftUI's update routinely lands in a later transaction than the one
+      # open at assignment time, so the completion fires before the work being
+      # measured has happened, and the measurement reads near zero.
+      code = code_only(@view_model)
+      assert code =~ "CFRunLoopActivity.beforeWaiting"
+
+      refute code =~ "setCompletionBlock",
+             "a CATransaction completion closes before SwiftUI has built the tree"
+    end
+
+    test "the observer removes itself" do
+      # repeats: false invalidates it, but an observer left added to the run
+      # loop is a leak per set_root, and this is on the main thread.
+      code = code_only(@view_model)
+      assert code =~ "CFRunLoopRemoveObserver"
+      assert code =~ ~r/CFRunLoopObserverCreateWithHandler\([^)]*/s
+    end
+
+    test "records the transition alongside the duration" do
+      # Without it the two populations cannot be separated on read, and the
+      # summary above is impossible.
+      assert code_only(@view_model) =~ ~r/mob_record_native_frame\(.*, transition\)/
+    end
+  end
+
+  describe "the native half" do
+    test "both NIFs are registered in the function table" do
+      code = code_only(@nif)
+      assert code =~ ~s({"native_stats", 0, nif_native_stats,)
+      assert code =~ ~s({"native_stats_enable", 1, nif_native_stats_enable,)
+    end
+
+    test "the disabled path is an atomic load and nothing else" do
+      # If the enabled flag were guarded by the sample lock instead, every
+      # set_root in every app would take a lock the NIF thread also takes.
+      code = code_only(@nif)
+      assert code =~ "_Atomic int g_native_stats_enabled"
+      assert code =~ "atomic_load_explicit(&g_native_stats_enabled, memory_order_relaxed)"
+    end
+
+    test "the reader snapshots under the lock and encodes outside it" do
+      # Same reasoning as nif_element_frames: the main thread takes this lock
+      # once per set_root, and JSON-encoding the window from a dirty scheduler
+      # while holding it stalls UI work on a thread with no QoS relationship.
+      body = nif_body(@nif, "nif_native_stats")
+      snapshot_at = index_of(body, "memcpy(snapshot, g_native_frames")
+      encode_at = index_of(body, "NSJSONSerialization")
+      sync_close = index_of(body, "}\n\n    uint64_t held")
+
+      assert snapshot_at < sync_close, "the copy must happen inside @synchronized"
+      assert encode_at > sync_close, "the encode must happen after the lock is released"
+    end
+
+    test "enabling clears the window so a run cannot report an earlier one" do
+      assert nif_body(@nif, "nif_native_stats_enable") =~ "g_native_frame_seq = 0"
+    end
+
+    test "the ring buffer reports what scrolled out of it" do
+      # A p95 over 240 samples of a 5000-sample run describes the tail only.
+      # Without `dropped` the reader has no way to know that happened.
+      assert code_only(@nif) =~ ~r/@"dropped" : @\(total > MOB_NATIVE_FRAME_SAMPLES/
+    end
+  end
+
+  describe "the Erlang stub" do
+    test "declares both functions as NIFs, not just exports" do
+      # A function exported but absent from -nifs stays the Erlang stub after
+      # load_nif, so it raises for ever with no error at load time. This repo
+      # has shipped that exact bug before.
+      code = code_only(@erl)
+      [exports, nifs] = String.split(code, "-nifs([", parts: 2)
+
+      assert exports =~ "native_stats/0"
+      assert exports =~ "native_stats_enable/1"
+      assert nifs =~ "native_stats/0"
+      assert nifs =~ "native_stats_enable/1"
+    end
+  end
+
+  # Strip comments before asserting. Written because an assertion that a
+  # comment can satisfy guards nothing, and this repo has been bitten by it:
+  # a test grepped for a string that existed only in the comment explaining
+  # the test. Handles Swift/ObjC `//` and `/* */`, and Erlang `%%`.
+  defp code_only(source) do
+    source
+    |> String.replace(~r{/\*.*?\*/}s, "")
+    |> String.split("\n")
+    |> Enum.map(fn line ->
+      line
+      |> String.replace(~r{^\s*//.*$}, "")
+      |> String.replace(~r{^\s*%%.*$}, "")
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp nif_body(source, name) do
+    code = code_only(source)
+    [_, after_decl] = String.split(code, "static ERL_NIF_TERM #{name}(", parts: 2)
+    [body | _] = String.split(after_decl, "\nstatic ", parts: 2)
+    body
+  end
+
+  defp index_of(haystack, needle) do
+    case :binary.match(haystack, needle) do
+      {at, _} -> at
+      :nomatch -> flunk("expected to find #{inspect(needle)}")
+    end
+  end
+end


### PR DESCRIPTION
MOB-126's premise did not survive the source; the full investigation is on the Linear issue. Short version: `.id(currentNavVersion)` is the **only** thing that makes the transition fire (SwiftUI decides insertion/removal by identity, not by value), Android does the same thing via `AnimatedContent(contentKey:)`, and the JSON to node rebuild it is blamed for happens unconditionally anyway. Options 1 and 3 in the issue are not implementable; option 2 is the substance of MOB-129.

What is real is that **nobody has ever measured the native half of a frame.**

`Mob.RenderStats` measures seven stages and every one is on the BEAM side. `set_root_us` closes when `nif_set_root` returns, and `nif_set_root` finishes by calling `setRoot:transition:`, which dispatches to the main thread and returns. Everything SwiftUI then does to build, lay out and display the tree happens after that measurement closed. Compose is the same shape.

That did not matter until now. MOB-129 is a large change justified entirely by the cost of the navigation teardown, and MOB-130 says the wire-format decision must be made *on evidence only*. Neither can be settled against a number nobody has.

### What is measured

Main-thread busy time, from the tree being applied to the run loop going idle. Deliberately the pessimistic reading (anything else on the main thread in that window counts) and also the honest one: a frame drops when the main thread is busy, whoever made it busy. Documented as an upper bound, not an attribution.

**The closing bracket is a `beforeWaiting` run loop observer.** `CATransaction.setCompletionBlock` is the obvious alternative and is wrong: SwiftUI's update routinely lands in a later transaction than the one open at assignment time, so the completion fires *before* the measured work happens and the number reads near zero. A test pins this, because the wrong version fails silently by reporting something plausible.

**The transition travels with each sample** and `native_summary/1` groups on it rather than pooling. A `"none"` sample re-renders into an existing tree; `"push"`/`"pop"`/`"reset"` rebuild it. The size of that gap is exactly what MOB-126 and MOB-129 argue about.

**Off by default; the disabled path is one relaxed atomic load.** `_Atomic` rather than lock-guarded, so an app that never measures does not take, on the main thread, on every `set_root`, a lock a NIF thread also takes.

Reads degrade to `{:error, :unsupported}` rather than raising: the host has no `:mob_nif`, and a function exported from `mob_nif.erl` but absent from the native library keeps its Erlang stub and raises for ever.

### Scope

**iOS only.** The Android half needs a Choreographer or `doOnPreDraw` bracket in `MobBridge.kt.eex`, which MOB-142 is editing in the same window; sequencing avoids a conflict in a template that has already been the site of two cross-platform divergences in this epic. Android reports `:unsupported`, which is accurate rather than silently zero.

### Tests

16, each mutation-tested: gate removed, `beforeWaiting` swapped for a CATransaction completion, transition dropped, encode moved inside the lock, enable no longer clearing the window, `_Atomic` downgraded to plain `int`, NIFs absent from the function table, and exported-but-not-in-`-nifs` (a bug this repo has shipped: `load_nif` succeeds and the function raises for ever). All 8 native and 3 Elixir mutations were caught.

1421 tests pass. `mix.exs` untouched at 0.7.38. Decision record: `decisions/2026-09-03-measure-the-native-half-of-a-frame.md`.

Native iOS build verified against a real app (mob_plugin_demo pointed at this worktree): the NIF compiles and links. Runtime verification over dist to follow in a comment.