### PR TITLE
MOB-141: fire on_end_reached on arrival at the end, not on replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,22 @@ epic. Nothing here has shipped to Hex.
   flat ceiling that is only defensible on the largest device it runs on. A
   first visit still loads cold; what goes away is every load after that.
 
+- **`on_end_reached` fires on arrival at the end, not on content replacement**
+  (MOB-141). Keying children on the author's `:id` gave every row a new identity
+  when a list's contents were replaced, so the last row's `onAppear` ran again
+  even though nobody scrolled: a search screen re-queried on each keystroke
+  fired one pagination request per keystroke, where before it fired none. The
+  callback is now latched on the child count, which survives a replacement
+  because only navigation changes the list's identity. Re-querying and getting
+  twenty results again is suppressed; loading a page and going twenty to forty
+  is not.
+
+  Not a complete fix, and the limitation is worth knowing: a re-query whose
+  result count differs every time still fires once per distinct count.
+  Separating "new content, user is at the end" from "new content, user never
+  scrolled" needs scroll position rather than content identity. Write
+  `on_end_reached` handlers to be idempotent.
+
 - **Children keep their identity across list edits** (MOB-127). Children of
   every container were keyed on their position, so inserting or removing a row
   made each following row adopt the previous occupant's view state: typed text,

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -478,23 +478,7 @@ struct MobNodeView: View {
                     .padding(node.paddingEdgeInsets)
 
             case .lazyList:
-                ScrollView(.vertical, showsIndicators: true) {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(mobIdentifiedChildren(node.childNodes)) { item in
-                            MobNodeView(node: item.node)
-                                .onAppear {
-                                    if item.index == node.childNodes.count - 1 {
-                                        node.onTap?()
-                                    }
-                                }
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(maxHeight: .infinity)
-                .padding(node.paddingEdgeInsets)
-                .background(node.backgroundColor.map { Color($0) } ?? Color.clear)
-                .ifLet(node.nativeViewId) { view, id in view.accessibilityIdentifier(id) }
+                MobLazyList(node: node)
 
             case .progress:
                 let trackColor = node.color.map { Color($0) } ?? Color.accentColor
@@ -1986,6 +1970,62 @@ final class MobImageCache {
     // mtime, so two threads that derived the same key were looking at the same
     // bytes. Holding a lock across the whole lookup would instead serialise
     // decodes onto the caller, which is the cost this cache exists to remove.
+}
+
+// ── Lazy list ────────────────────────────────────────────────────────────────
+//
+// Its own view rather than a case in MobNodeView's body, because it needs
+// @State to latch `on_end_reached` and MobNodeView renders every node in the
+// tree: an Optional<Int> on that struct is storage paid thousands of times over
+// for a thing only one node type uses.
+private struct MobLazyList: View {
+    let node: MobNode
+
+    // The child count we last fired `on_end_reached` for.
+    //
+    // Without this, the callback fires on content REPLACEMENT rather than on
+    // arrival at the end. Since MOB-127 keyed children on the author's `:id`,
+    // replacing a list's contents gives every row a new identity, so the last
+    // row's `.onAppear` runs again even though nobody scrolled. A search screen
+    // re-queried on each keystroke then fires one pagination request per
+    // keystroke, where before it fired none (MOB-141).
+    //
+    // Latching on the count is what makes this survive a replacement: only
+    // navigation changes the container's identity, so this @State outlives a
+    // new tree arriving for the same screen. Re-querying and getting twenty
+    // results again is suppressed; loading a page and going twenty to forty is
+    // not, which is exactly the pagination flow the callback exists for.
+    //
+    // What it does NOT fix: a re-query whose result count differs every time
+    // still fires once per distinct count. Distinguishing "new content, user is
+    // at the end" from "new content, user never scrolled" needs scroll
+    // position, not content identity, and the honest fix for that is to drive
+    // this from the scroll observer rather than from `.onAppear`. Handlers
+    // should still be written to be idempotent.
+    @State private var firedForCount: Int?
+
+    var body: some View {
+        let children = mobIdentifiedChildren(node.childNodes)
+
+        ScrollView(.vertical, showsIndicators: true) {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(children) { item in
+                    MobNodeView(node: item.node)
+                        .onAppear {
+                            guard item.index == children.count - 1 else { return }
+                            guard firedForCount != children.count else { return }
+                            firedForCount = children.count
+                            node.onTap?()
+                        }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxHeight: .infinity)
+        .padding(node.paddingEdgeInsets)
+        .background(node.backgroundColor.map { Color($0) } ?? Color.clear)
+        .ifLet(node.nativeViewId) { view, id in view.accessibilityIdentifier(id) }
+    }
 }
 
 private struct MobImage: View {

--- a/test/mob/native_child_identity_test.exs
+++ b/test/mob/native_child_identity_test.exs
@@ -31,8 +31,14 @@ defmodule Mob.NativeChildIdentityTest do
     unkeyed = ~r/ForEach\(\s*(Array\()?node\.childNodes/ |> Regex.scan(@ios) |> length()
     assert unkeyed == 0, "#{unkeyed} ForEach still iterates childNodes directly"
 
+    # Count the derivation, not one particular spelling of it. The original
+    # version counted the inline `ForEach(mobIdentifiedChildren(...))` form and
+    # broke when MOB-141 hoisted that call into a `let` in the lazy list, even
+    # though the identity property it guards was untouched. What matters is that
+    # every container derives its children through mobIdentifiedChildren; where
+    # the call sits is a refactor's business.
     identified =
-      @ios |> String.split("ForEach(mobIdentifiedChildren(node.childNodes))") |> length()
+      @ios |> String.split("mobIdentifiedChildren(node.childNodes)") |> length()
 
     assert identified - 1 >= 7, "the identified child lists should still be there"
   end

--- a/test/mob/native_end_reached_test.exs
+++ b/test/mob/native_end_reached_test.exs
@@ -1,0 +1,82 @@
+defmodule Mob.NativeEndReachedTest do
+  @moduledoc """
+  `on_end_reached` fires on arrival at the end, not on content replacement
+  (MOB-141).
+
+  MOB-127 keyed children on the author's `:id`. That made replacing a list's
+  contents give every row a new identity, so the last row's `.onAppear` runs
+  again even though nobody scrolled, and a search screen re-queried on each
+  keystroke fired one pagination request per keystroke where before it fired
+  none. Source-asserted because there is no host-side way to run SwiftUI.
+  """
+  # credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+  use ExUnit.Case, async: true
+
+  @ios File.read!(Path.expand("../../ios/MobRootView.swift", __DIR__))
+
+  test "the lazy list owns state, and it is not paid by every node" do
+    # MobNodeView renders every node in the tree, so an Optional<Int> there is
+    # storage multiplied by thousands for something one node type uses.
+    code = code_only(@ios)
+    assert code =~ "private struct MobLazyList: View {"
+    assert code =~ "case .lazyList:\n                MobLazyList(node: node)"
+
+    node_view = region(code, "struct MobNodeView: View {", "\n    var body: some View {")
+    refute node_view =~ "@State", "per-node state belongs on the lazy list, not on every node"
+  end
+
+  test "the callback is latched on the child count" do
+    body = region(code_only(@ios), "private struct MobLazyList: View {", "\n}\n")
+
+    assert body =~ "@State private var firedForCount: Int?"
+
+    # Both guards, in order: last row, then not-already-fired. Dropping either
+    # one restores the bug, and dropping the second is the subtle one because
+    # the code still reads as though it were latched.
+    assert body =~ "guard item.index == children.count - 1 else { return }"
+    assert body =~ "guard firedForCount != children.count else { return }"
+
+    # The latch must be set before the callback, so a handler that synchronously
+    # re-renders cannot re-enter and fire twice for the same count.
+    set_at = index_of(body, "firedForCount = children.count")
+    fire_at = index_of(body, "node.onTap?()")
+    assert set_at < fire_at, "the latch must be set before the callback runs"
+  end
+
+  test "the raw unlatched fire is gone" do
+    # The exact shape that shipped: an .onAppear that fires whenever the last
+    # row appears, with nothing remembering that it already did.
+    code = code_only(@ios)
+
+    refute code =~ ~r/if item\.index == node\.childNodes\.count - 1 \{\s*node\.onTap\?\(\)/,
+           "the unlatched last-row fire must not come back"
+  end
+
+  test "children are still keyed by identity, not position" do
+    # The latch is not a licence to undo MOB-127; both properties hold together.
+    body = region(code_only(@ios), "private struct MobLazyList: View {", "\n}\n")
+    assert body =~ "ForEach(children)"
+    assert body =~ "let children = mobIdentifiedChildren(node.childNodes)"
+  end
+
+  defp code_only(source) do
+    source
+    |> String.replace(~r{/\*.*?\*/}s, "")
+    |> String.split("\n")
+    |> Enum.map(&String.replace(&1, ~r{^\s*//.*$}, ""))
+    |> Enum.join("\n")
+  end
+
+  defp region(source, from, to) do
+    [_, rest] = String.split(source, from, parts: 2)
+    [body | _] = String.split(rest, to, parts: 2)
+    body
+  end
+
+  defp index_of(hay, needle) do
+    case :binary.match(hay, needle) do
+      {i, _} -> i
+      :nomatch -> flunk("expected to find #{inspect(needle)}")
+    end
+  end
+end


### PR DESCRIPTION
**The one thing in this unreleased window that is worse than before.** MOB-127 keyed children on the author's `:id`, so replacing a list's contents gives every row a new identity and the last row's `.onAppear` runs again even though nobody scrolled. A search screen re-queried on each keystroke fires one pagination request per keystroke, where before it fired none.

### The fix

Latched on the child count. That works because **only navigation changes the list's identity**, so the `@State` outlives a new tree arriving for the same screen. Re-querying and getting twenty results again is suppressed; loading a page and going twenty to forty is not, which is the pagination flow the callback exists for.

The latch is set **before** the callback, so a handler that synchronously triggers a re-render cannot re-enter and fire twice for the same count.

### Not a complete fix

Stated in the code rather than implied away: a re-query whose result count differs every time still fires once per distinct count. Separating "new content, user is at the end" from "new content, user never scrolled" needs **scroll position**, not content identity, and the honest version drives this from the scroll observer rather than `.onAppear`. Handlers should still be idempotent.

### Structure

Extracted into `MobLazyList` rather than adding `@State` to `MobNodeView`, which renders every node in the tree — an `Optional<Int>` there is storage paid thousands of times over for something one node type uses.

### Android is deliberately unchanged

Its `derivedStateOf` over `layoutInfo` has always been index-based and has always had this shape. So this repairs an **iOS regression** rather than making a cross-platform behaviour change. Converging the two is worth doing but it is a decision for Android users, not a regression fix.

### Also

Fixes a brittle assertion this refactor exposed: MOB-127's test counted the inline `ForEach(mobIdentifiedChildren(...))` spelling and broke when the call was hoisted into a `let`, though the identity property it guards was untouched. It now counts the derivation wherever it appears.

4 tests, each mutation-tested (latch guard removed, latch set after the callback, reverted to the unlatched inline form, `@State` back on every node). All caught. 1449 tests pass. `mix.exs` untouched.