### PR TITLE
Release prep 0.7.39: state the upgrade hazards the notes were understating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ Everything below is unreleased work from the MOB-124 rendering-performance
 epic. Nothing here has shipped to Hex.
 
 ### Added
-- **Native frame timing: `Mob.RenderStats.native_enable/1`, `native_frames/1`
-  and `native_summary/1`** (MOB-126). `Mob.RenderStats` measures seven stages
+- **Native frame timing: `Mob.RenderStats.native_enable/1`, `native_disable/1`,
+  `native_frames/1` and `native_summary/1`** (MOB-126). `Mob.RenderStats` measures seven stages
   and every one is on the BEAM side of the boundary: `set_root_us` closes when
   `nif_set_root` returns, and that is the moment the tree is handed to the main
   thread, not the moment it is on screen. Everything SwiftUI does to build, lay
@@ -44,8 +44,13 @@ epic. Nothing here has shipped to Hex.
   Off by default; the disabled path is one relaxed atomic load per `set_root`.
   Read it as an upper bound on a frame's native cost rather than an
   attribution: anything else queued on the main thread in the same window is
-  inside the number. **iOS only for now** — Android returns
-  `{:error, :unsupported}`, which is accurate rather than silently zero. See
+  inside the number.
+
+  **Debug builds only, and iOS only.** The reading NIFs sit inside the same
+  `MOB_RELEASE` guard as the rest of the test harness, so a TestFlight or App
+  Store build returns `{:error, :unsupported}` — profile a debug build.
+  Android returns `{:error, :unsupported}` too, which is accurate rather than
+  silently zero. See
   `decisions/2026-09-03-measure-the-native-half-of-a-frame.md`.
 
 - **`Mob.RenderStats` — per-frame render instrumentation** (MOB-125). Records
@@ -67,8 +72,10 @@ epic. Nothing here has shipped to Hex.
   `lazy_list`. A `row` under a horizontal scroll, and anything deeper than a
   scroll's direct child, stay eager.
 
-  This is the **iOS** half. It is verified to render identically to the eager
-  path but its win is **not** independently measured on iOS — the equivalent
+  This is the **iOS** half, and it needs mob_new 0.4.31+ for the Android one: an
+  app upgrading `mob` alone gets lazy scroll on iOS and not on Android. It is
+  verified to render identically to the eager path but its win is **not**
+  independently measured on iOS — the equivalent
   Android change (in `mob_new`) measures a 500-row screen going from 498.9 ms to
   115.8 ms of main-thread work per frame. See
   `decisions/2026-09-02-lazy-scroll-on-ios.md`.
@@ -110,7 +117,18 @@ epic. Nothing here has shipped to Hex.
   applied to the outgoing screen's handlers and its own ran unthrottled;
   Android never sent the config at all. iOS now resolves against the table
   being built, and Android sends it per composition. Gestures finally honour
-  what the app asked for instead of always using the built-in defaults. See
+  what the app asked for instead of always using the built-in defaults.
+
+  **Action required if you use `throttle: 0`.** That is the documented escape
+  hatch for raw delivery (`guides/events.md`), and because the config never
+  reached native, an app asking for it was silently getting the 33 ms default
+  instead. It now means what it says: every sample is delivered, which on a
+  120 Hz display is four times the rate that screen's mailbox has been
+  receiving. Audit any handler that asked for it. The safe direction of this
+  fix — a handler that asked to be throttled and was not — needs no action.
+
+  `debounce`, `leading` and `trailing` are accepted and stored but not yet
+  acted on by either platform. See
   `decisions/2026-09-02-throttle-config-targets-the-building-table.md` and
   `decisions/2026-09-03-android-throttle-config-per-composition.md`. Needs
   mob_new 0.4.31+ for the Android half.
@@ -150,8 +168,12 @@ epic. Nothing here has shipped to Hex.
   twenty results again is suppressed; loading a page and going twenty to forty
   is not.
 
-  Not a complete fix, and the limitation is worth knowing: a re-query whose
-  result count differs every time still fires once per distinct count.
+  Not a complete fix, and the limitations are worth knowing. A re-query whose
+  result count differs every time still fires once per distinct count. A
+  **windowed** list holding a rolling buffer at constant length fires once and
+  then never again. And a page load that **fails or returns nothing** leaves the
+  count unchanged, so scrolling away and back will not retry it, where
+  previously `.onAppear` would have.
   Separating "new content, user is at the end" from "new content, user never
   scrolled" needs scroll position rather than content identity. Write
   `on_end_reached` handlers to be idempotent.
@@ -170,8 +192,12 @@ epic. Nothing here has shipped to Hex.
   Covers column, row, box, both scroll axes, the lazy list, the sheet body and
   the tab bar. The coercion is scoped to top-level props, so an id nested
   inside a prop value — `tabs: [%{id: 1}]` — still falls back to positional.
-  Needs mob_new 0.4.31+ for the Compose half; both platforms derive keys
-  identically. See `decisions/2026-09-03-children-key-on-author-id.md`.
+
+  Needs mob_new 0.4.31+ for the Compose half, which derives keys the same way
+  from the same rules for those seven containers. **The tab bar is iOS-only**:
+  Compose's `NavigationBar` still iterates tabs positionally, so reordering or
+  inserting a tab moves per-tab state on Android and not on iOS. See
+  `decisions/2026-09-03-children-key-on-author-id.md`.
 
 ### Known issues (found while measuring, not fixed here)
 - *(none outstanding — the two recorded here, MOB-133's 256-element cap and

--- a/guides/components.md
+++ b/guides/components.md
@@ -231,6 +231,38 @@ A vertically scrolling container.
 |------|------|-------------|
 | `padding` | number / token | Padding inside the scroll area |
 | `background` | color | Background color |
+| `lazy` | boolean | Build only the rows currently on screen. Opt-in; see below |
+
+#### `lazy: true`
+
+By default a `:scroll` builds every child up front. With `lazy: true`, a scroll
+whose direct content is a single `column` builds only what is on screen. On a
+500-row screen on a Moto G Power this takes main-thread frame cost from 498.9 ms
+to 115.8 ms (p50), and the worst frame from 1385.9 ms to 164.8 ms. Lazy cost is
+flat in list length where eager grows, so short lists gain nothing and may be
+marginally slower: this is a long-list optimisation.
+
+It is opt-in rather than automatic because laziness has consequences beyond
+speed, and all of them are silent:
+
+* **Rows below the fold are never built**, so they never register a frame.
+  `Mob.Test.element_frames/1` and `Mob.Test.tap_id/2` cannot address them.
+* **`scroll_to(:bottom)` under-scrolls**, because content size reflects only
+  what has been built.
+* **`screenshot_tour` truncates** for the same reason.
+* **Scroll position becomes index-based** rather than pixel-based.
+
+`:lazy_list` already makes that trade explicitly, which is why it is a separate
+component. Applying it silently to every `:scroll` would change harness
+behaviour under apps that never asked for it.
+
+The narrowing is deliberate: only a **vertical** scroll whose sole child is a
+plain `column` qualifies. A `row` under a horizontal scroll would be lazy on the
+wrong axis, and a child carrying `weight` needs its siblings measured, so both
+stay eager. Anything deeper than the scroll's direct child stays eager too.
+
+Available on both platforms from mob 0.7.39 / mob_new 0.4.31. An app that
+upgrades `mob` alone gets it on iOS only.
 
 ### `:spacer`
 
@@ -253,6 +285,65 @@ Inserts fixed space in a row or column, or fills available space when no `size` 
 </Row>
 """
 ```
+
+## Giving children a stable `:id`
+
+Set `:id` on the children of any container and their view state follows the
+child rather than the slot it happens to occupy.
+
+```elixir
+for user <- @users do
+  %{type: :text_field, props: %{id: user.id, text: user.name}, children: []}
+end
+```
+
+Without an `:id`, children are identified by position. Insert a row at the top
+and every row below it becomes a different view to the platform, so each one
+adopts the previous occupant's state: typed text, scroll offset, focus, and any
+in-flight animation all shift by one. With an `:id`, they move with the row.
+
+This is the same idea as `:key` in LiveView's `for` comprehensions, and the same
+failure mode when it is missing.
+
+### What it affects
+
+Anything the platform owns rather than your socket:
+
+* text a user has typed into a `:text_field` but not submitted
+* which field holds focus, and the keyboard's position in it
+* scroll offset inside a nested scroll
+* toggle and slider positions mid-drag
+* animations that are partway through
+
+Values you render from assigns are unaffected either way, because those come
+from the tree on every frame.
+
+### Rules
+
+* **An `:id` is opt-in.** A list without one keeps positional identity, so
+  nothing changes for code that never asked.
+* **Ids only need to be unique among siblings**, not app-wide.
+* **A duplicate falls back to position** for the second occurrence rather than
+  merging two rows.
+* **An authored id and a positional key cannot collide.** They live in separate
+  namespaces, so a child whose id is literally `"3"` is distinct from the child
+  at position 3.
+* **Numbers are coerced**, so `id: user.id` works with integer ids exactly as
+  `id: "#{user.id}"` would.
+
+### Limits worth knowing
+
+The coercion is scoped to top-level props. An id nested inside a prop *value* —
+`tabs: [%{id: 1}]` — is not coerced and falls back to positional.
+
+Coverage differs by platform for one component. Column, row, box, both scroll
+axes, the lazy list and the sheet body key children on both platforms from
+mob 0.7.39 / mob_new 0.4.31. **The tab bar is iOS-only**: Compose's
+`NavigationBar` still iterates tabs positionally, so reordering or inserting a
+tab moves per-tab state on Android and not on iOS.
+
+An app that upgrades `mob` without regenerating from `mob_new` gets the iOS half
+only.
 
 ## List components
 
@@ -282,7 +373,25 @@ A virtualized list that renders rows on demand. Supports `on_end_reached` for pa
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `on_end_reached` | `{pid, tag}` | Fired when the user scrolls near the end: `{:tap, tag}` |
+| `on_end_reached` | `{pid, tag}` | Fired when the last row appears: `{:tap, tag}` |
+
+`on_end_reached` fires when the final row becomes visible, and is latched on the
+row count so that replacing the list's contents does not re-fire it. That
+matters because children key on `:id` (see below): replacing the contents gives
+every row a new identity, which without the latch reads as a fresh arrival at
+the end. A search screen re-queried on each keystroke would otherwise fire one
+pagination request per keystroke.
+
+The latch releases when the count changes, which is what makes pagination work:
+reach the end, load a page, the list grows, the callback re-arms. Three cases it
+does **not** cover, so write the handler to be idempotent:
+
+* a re-query whose result count differs every time still fires once per
+  distinct count;
+* a **windowed** list holding a rolling buffer at constant length fires once and
+  then never again;
+* a page load that fails or returns nothing leaves the count unchanged, so
+  scrolling away and back will not retry it.
 
 ## Content components
 

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -233,6 +233,87 @@ forward range (e.g. 9200+) is tracked separately. Until then, the manual
 
 ---
 
+## A screen feels slow: measuring the render pipeline
+
+Before changing anything, measure. `Mob.RenderStats` records where a frame's
+time actually goes, and it is off by default because it is not free.
+
+Enable it from a connected node (`mix mob.connect`), drive the app, then read
+the summary:
+
+```elixir
+Mob.RenderStats.enable()
+# ... drive the app ...
+Mob.RenderStats.summary()
+```
+
+`summary/0` reports p50, p95 and max per stage, with the sample size `n`
+alongside, because stages do not share a population. `frames/0` returns the raw
+records, newest first, when a percentile hides what you are looking for.
+
+### What the stages mean
+
+| stage | what it covers |
+|---|---|
+| `render_us` | your `render/1` |
+| `expand_us` | `Mob.Composite`, `Mob.List` and `Mob.Component` expansion |
+| `reconcile_us` | `Mob.ComponentRegistry.reconcile/2` |
+| `prepare_us` | the renderer's tree walk: prop resolution, theme tokens, one `register_tap` per handler prop |
+| `register_tap_us` | the `register_tap` calls alone — **nested inside `prepare_us`**, so adding the two double-counts |
+| `encode_us` | `:json.encode` |
+| `set_root_us` | handing the tree to native |
+
+A frame spans two processes: the screen runs `render/1`, expansion and
+reconcile, then hands off to `Mob.Sender`, which runs prepare, encode and
+`set_root`. Frames the sender drops — superseded by a newer tree, or belonging
+to a screen that is no longer active — are recorded with `committed: false`
+rather than discarded, because BEAM-side work that gets thrown away is worth
+knowing about. `summary/0` reports the two populations separately for that
+reason.
+
+Do not compare `total_us` against a frame budget. See the moduledoc for why.
+
+### The native half
+
+`set_root_us` closes when the tree reaches the main thread, **not** when it is
+on screen. Everything the platform then does to build, lay out and display it
+happens after that measurement closed, and on a navigation that is usually the
+larger half of the frame.
+
+```elixir
+Mob.RenderStats.native_enable()
+# ... drive the app ...
+Mob.RenderStats.native_summary()
+```
+
+`native_summary/0` groups by transition, because a `"none"` sample re-renders
+into an existing view tree while `"push"`, `"pop"` and `"reset"` rebuild it. On
+a small screen the two differ by several milliseconds, and pooling them gives a
+median that describes neither.
+
+Read `apply_us` as an **upper bound** on that frame's native cost, not an
+attribution: it is main-thread busy time from the tree being applied to the run
+loop going idle, so anything else queued on the main thread in that window is
+inside the number.
+
+`dropped` tells you how many samples scrolled out of the fixed-size native ring
+buffer. When it is above zero, the percentiles describe the tail of your run
+rather than all of it.
+
+**Availability.** iOS debug builds only. It returns `{:error, :unsupported}` on
+Android, on the host, and in an iOS **release** build, because the reading NIFs
+sit inside the same guard as the rest of the test harness. Profile a debug
+build.
+
+### Cost when enabled
+
+`time/2` reads a `:persistent_term`; `accumulate/2` reads the process
+dictionary. Neither allocates when disabled. The honest cost when enabled is
+dominated by `accumulate/2`, which wraps every `register_tap` call — 615 times
+on a 200-row screen, not once per frame. Measured at roughly 4 µs per dense
+frame on a development Mac and plausibly 20-40 µs on a phone. Against a 27 ms
+frame that is under 0.2%, but it is not nothing, which is why it is opt-in.
+
 ## Distribution in production
 
 In development, `Mob.Dist.ensure_started/1` runs so `mix mob.connect` can

--- a/lib/mob/render_stats.ex
+++ b/lib/mob/render_stats.ex
@@ -552,6 +552,11 @@ defmodule Mob.RenderStats do
   # threading an identifier through the wire for a number that is only ever read
   # by a human deciding whether an optimisation is worth building.
 
+  #
+  # The `nif` argument on all four functions below is a test seam: it defaults to
+  # `:mob_nif` and exists so the tests can inject a stub that raises the way an
+  # unimplemented or unloaded NIF does. Callers should omit it.
+
   @doc """
   Turn native frame timing on, and clear the sample window.
 
@@ -559,13 +564,21 @@ defmodule Mob.RenderStats do
   `set_root`; the timestamps and the run loop observer are downstream of that
   check.
 
-  Returns `{:error, :unsupported}` on a platform whose native half has not
-  implemented it yet, and on the host, where there is no native side at all.
+  Returns `{:error, :unsupported}` in three cases, all of which look identical
+  to a caller: on the host, where there is no native side at all; on a platform
+  whose native half has not implemented it, which today means Android; and in
+  an **iOS release build**, because the reading NIFs sit inside the same
+  `MOB_RELEASE` guard as the rest of the test harness. Profile a debug build.
   """
   @spec native_enable(module()) :: :ok | {:error, :unsupported}
   def native_enable(nif \\ :mob_nif), do: native_call(nif, :native_stats_enable, [true])
 
-  @doc "Turn native frame timing off. Recorded samples stay readable."
+  @doc """
+  Turn native frame timing off. Recorded samples stay readable.
+
+  A sample can still land one apply-window after this returns: an observer
+  already armed when the flag flipped records when it fires.
+  """
   @spec native_disable(module()) :: :ok | {:error, :unsupported}
   def native_disable(nif \\ :mob_nif), do: native_call(nif, :native_stats_enable, [false])
 


### PR DESCRIPTION
Pre-publish review found **nothing wrong with the code** but three places where the notes describe behaviour a user will not actually get. Docs only.

**`throttle: 0` is a live upgrade hazard and only the safe direction was written down.** The MOB-134 entry framed the fix as previously-unthrottled handlers becoming throttled. The reverse also happens and is the dangerous one: `throttle: 0` is the documented escape hatch for raw delivery, and because the config never reached native, an app asking for it was silently getting the 33 ms default. It now means what it says, so a handler that has been receiving ~30 Hz starts receiving **every sample** — 120 Hz on ProMotion, into a screen mailbox.

**The native timing functions are unavailable in an iOS release build** — exactly when someone reaches for a profiler. The reading NIFs are inside the same `MOB_RELEASE` guard as the rest of the harness, so a TestFlight build returns `{:error, :unsupported}` indistinguishably from Android and from the host. Neither the `@doc` nor the changelog said so.

**"Both platforms derive keys identically" was false for the tab bar.** iOS keys it via `mobIdentifiedTabs`; Compose's `NavigationBar` still iterates positionally, so reordering a tab moves per-tab state on Android and not on iOS. The other seven sites do match.

Also: MOB-128 lacked the "needs mob_new 0.4.31+" note its siblings carry; the `on_end_reached` entry described one limitation of the count latch when there are three (a windowed list at constant length fires once ever; a failed page load can never be retried by scrolling); `debounce`/`leading`/`trailing` are stored but acted on by neither platform though the headline said "throttle/debounce reaches native"; `native_disable/1` was missing from the added list.

No version bump here — the bump is a separate commit so the release workflow fires on a reviewed tree. 1449 tests pass.