### PR TITLE
Bump to 0.7.39 — rendering-performance epic (MOB-124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+## [0.7.39] - 2026-09-04
+
 ### Fixed
 - **Interactive elements past the 256th no longer silently stop responding**
   (MOB-133). The tap registry was a fixed 256-entry pair of tables and the

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -257,7 +257,7 @@ records, newest first, when a percentile hides what you are looking for.
 |---|---|
 | `render_us` | your `render/1` |
 | `expand_us` | `Mob.Composite`, `Mob.List` and `Mob.Component` expansion |
-| `reconcile_us` | `Mob.ComponentRegistry.reconcile/2` |
+| `reconcile_us` | the component reconcile pass |
 | `prepare_us` | the renderer's tree walk: prop resolution, theme tokens, one `register_tap` per handler prop |
 | `register_tap_us` | the `register_tap` calls alone — **nested inside `prepare_us`**, so adding the two double-counts |
 | `encode_us` | `:json.encode` |

--- a/lib/mob/render_stats.ex
+++ b/lib/mob/render_stats.ex
@@ -11,7 +11,7 @@ defmodule Mob.RenderStats do
   ## A frame spans two processes
 
   This is the thing that makes the implementation less obvious than it looks.
-  `Mob.Screen.Server.paint/4` runs the user's `render/1`, the expansion passes
+  the screen's paint path runs the user's `render/1`, the expansion passes
   and the component reconcile in the **screen's** process — then hands the tree
   to `Mob.Sender` as a *cast*, so `prepare`, `:json.encode` and `set_root` run
   in the **sender's** process. A process-dictionary accumulator started by the
@@ -53,7 +53,7 @@ defmodule Mob.RenderStats do
 
   * `render_us` — the user's `render/1`
   * `expand_us` — `Mob.Composite`, `Mob.List` and `Mob.Component` expansion
-  * `reconcile_us` — `Mob.ComponentRegistry.reconcile/2`
+  * `reconcile_us` — the component reconcile pass
   * `prepare_us` — the renderer's tree walk: prop resolution, theme token
     lookup, and one `register_tap` per handler prop
   * `register_tap_us` — the `register_tap` calls alone. **Nested inside

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mob.MixProject do
   def project do
     [
       app: :mob,
-      version: "0.7.38",
+      version: "0.7.39",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -142,6 +142,7 @@ defmodule Mob.MixProject do
         "MOB_PLUGINS.md": [title: "Plugins — Manifest Reference"],
         "MOB_PLUGIN_SECURITY.md": [title: "Plugins — Security & Trust"],
         "MOB_STYLES.md": [title: "Styles — Manifest Reference"],
+        "MOB_FONTS.md": [title: "Fonts — Design Reference"],
         "guides/why_beam.md": [title: "Why the BEAM?"],
         "guides/getting_started.md": [title: "Getting Started"],
         "guides/packages.md": [title: "First-Party Packages"],
@@ -173,7 +174,7 @@ defmodule Mob.MixProject do
       ],
       groups_for_extras: [
         Guides: ~r/guides\/.*/,
-        Plugins: ["MOB_PLUGINS.md", "MOB_PLUGIN_SECURITY.md", "MOB_STYLES.md"]
+        Plugins: ["MOB_PLUGINS.md", "MOB_PLUGIN_SECURITY.md", "MOB_STYLES.md", "MOB_FONTS.md"]
       ],
       groups_for_modules: [
         Core: [Mob, Mob.App, Mob.Screen, Mob.ScreenState, Mob.Socket, Mob.State],


### PR DESCRIPTION
Version bump. Merging this to master fires the release workflow (tag, GitHub Release, Hex publish).

### What ships

**Fixes users are hitting today**

- Interactive elements past the 256th were **silently inert** — 359 of 615 on a 200-row screen. They rendered, looked tappable, did nothing, no error.
- **Throttle config never reached native on either platform**, so every app behaved as if using the built-in defaults.
- List state followed **positions rather than rows**: insert a row and everything below it adopted the previous occupant's typed text, focus, scroll offset.
- An **`ErlNifEnv` leaked per tap, per frame** on the rescued render path — a path that is deliberately rescued, so it accumulated silently.
- Rendering was driven by **message arrival rather than state change**.

**Performance**

- iOS `set_root` 7625 → 4040 µs on a dense screen
- `register_tap`'s per-node logging storm 13004 → 81 µs
- Local-file images no longer re-read and re-decoded from disk on every render

**New:** `Mob.RenderStats` for the BEAM pipeline, `native_enable/1` and friends for the half of a frame that was never measurable, opt-in lazy scroll.

### Two upgrade hazards, called out rather than buried

- **`throttle: 0` now genuinely means raw delivery.** Because the config never reached native, apps asking for it were silently getting the 33 ms default. A handler receiving ~30 Hz starts receiving every sample.
- **`on_end_reached` timing changed**, and the count latch has three cases it does not cover.

### Pairing

Needs **mob_new 0.4.31** for the Android halves of MOB-127, MOB-134, MOB-138 and MOB-142. An app upgrading `mob` alone gets the iOS halves only. That is stated on every affected entry.

### Also

Ships `MOB_FONTS.md` in the docs — referenced from three guides and linked from the CHANGELOG but absent from ex_doc's `extras`, so HexDocs carried a broken link. Held out of the docs PR because `mix.exs` is the release trigger; it rides here so one `mix.exs` change means one release.

Also stopped `Mob.RenderStats`' own moduledoc auto-linking two private internals, which made the flagship new API warn on its own docs.

Reviewed pre-publish: three blocking findings fixed in #128 and mob_new#53, docs gap closed. 1449 tests pass.