### PR TITLE
MOB-129: present screens in two slots instead of rebuilding the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Performance
+- **Navigation no longer rebuilds the whole native tree (iOS)** (MOB-129). The
+  root carried `.id(currentNavVersion)`, so every push, pop and reset destroyed
+  and rebuilt the entire SwiftUI tree. On a 1614-node screen a navigation cost
+  **235 ms** against a 65.7 ms steady-state re-render, and the whole 169 ms gap
+  was the identity change: it scales linearly with node count.
+
+  Two slots now sit at fixed positions and a navigation ping-pongs between them,
+  with the slide driven by an animated offset instead of `.transition()` —
+  which only fires on insert and removal, and insert/removal is exactly what
+  costs. A push drops to **76 ms** and a pop to **76 ms**, with the animation
+  unchanged.
+
+  The outgoing slot is deliberately kept, which gives depth-1 retention for
+  free: popping back diffs against that screen's own previous tree rather than
+  rebuilding it. A `reset` releases it, since that screen is unreachable.
+
+  Retention makes the *second* visit cheap regardless of shape. Bouncing
+  between the dense screen and a 37-node one, a pop went from 217 ms to
+  **66 ms** and a push from 26 ms to **8 ms**, because each screen returns to
+  the slot holding its own previous tree.
+
+  **What it does not do.** A first visit to a screen still builds every node
+  that does not yet exist, so a linear drill-down pays full price at each new
+  level; an alternating back-and-forth pays once per screen. It does not touch
+  the 65.7 ms steady-state floor either. And a parked screen is now alive rather than
+  destroyed, so a screen parked with a sheet, web view, video or GPU view up has
+  open issues recorded on MOB-129. Android is unchanged. See
+  `decisions/2026-09-04-two-slot-screen-presentation.md`.
+
+
 ## [0.7.39] - 2026-09-04
 
 ### Fixed

--- a/decisions/2026-09-04-two-slot-screen-presentation.md
+++ b/decisions/2026-09-04-two-slot-screen-presentation.md
@@ -1,0 +1,86 @@
+# Two-slot screen presentation
+
+**Date:** 2026-09-04
+**Issue:** MOB-129
+
+## Context
+
+`MobRootView` rendered the whole app as `MobNodeView(node: root).id(currentNavVersion)`, and `currentNavVersion` incremented on every non-`"none"` transition. `.id()` destroys and rebuilds a SwiftUI subtree, so every push, pop and reset threw away the entire native tree.
+
+MOB-126 shipped native frame timing, which made the cost measurable for the first time. On a 1614-node / 113 KB screen, iPhone 17 Pro simulator, 150 samples per population, 0 dropped:
+
+| transition | p50 |
+|---|---|
+| `none` | 65,723 us |
+| `pop` | 226,244 us |
+| `push` | 234,833 us |
+
+The 169 ms gap scales linearly with node count: a 37-node screen showed a 3.8 ms gap, and 43.6x the nodes gave 44.9x the gap.
+
+Two further measurements shaped the design.
+
+**Building dominates, destroying does not.** Bouncing between the dense screen and a 37-node one isolates the halves: destroying a 1614-node tree costs about 26 ms, building one about 217 ms. So the issue's original framing, "stop discarding the tree", targets the cheap 11%.
+
+**Identity preservation recovers the whole gap.** A one-line probe with a constant `.id()` took `push` from 234,833 us to 63,930 us, landing at the `none` floor, with a teardown delta of -1.4 ms. That is the theoretical maximum, and it says the entire 169 ms is the identity change and nothing else.
+
+## Decision
+
+Navigation no longer changes identity. Two slots sit at fixed structural positions in the root `ZStack` — that position **is** their identity, and no `.id()` is used — and a navigation ping-pongs between them. The slide is driven by an animated `slotOffset` rather than by `.transition()`.
+
+**Why not `.transition()`.** It only fires on insert/remove, and insert/remove is precisely what costs 169 ms. Keeping the modifier means keeping the teardown. Driving the offset directly decouples the animation from identity, which is the whole trick.
+
+**The outgoing slot is not cleared on push or pop.** Holding it gives depth-1 retention for free: popping back writes that screen's tree into the slot that still holds its previous tree, so SwiftUI diffs rather than rebuilds. One level is where nearly all back-navigation lands, and the cost is bounded at exactly two trees rather than growing with stack depth. A `reset` does clear it, because a reset replaces the stack and that screen is unreachable.
+
+**`.equatable()` on the slot root is load-bearing, not an optimisation.** `nif_set_root` allocates a fresh `MobNode` graph on every render, so the active slot's reference always differs and its body always re-runs. The parked slot's reference does *not* change, because the BEAM only sends the active screen's tree. Without the equality check the parked slot would be re-evaluated on every render of the active one, and holding it would cost more than rebuilding it.
+
+The comparison is reference identity (`===`), deliberately not content. Every interactive node's handle prop is `(generation << 12) | slot` and `clear_taps` bumps the generation on every render, so a content comparison is false for any subtree containing a tappable node — which is most of them. Reference identity is the only comparison that can ever be true, and because the graph is rebuilt wholesale, an unchanged reference at a subtree root means the entire subtree is untouched.
+
+**Hit-testing is disabled explicitly on the parked slot** rather than being inferred from its offset. SwiftUI hit-tests over its own display list and does not necessarily honour zero opacity the way UIKit's `hitTest:` honours zero alpha, and `MobBoxSemantics` applies `.contentShape` liberally. A tappable parked screen would resolve handles from a superseded tap-table generation.
+
+**Slide distance comes from the container's real geometry**, not `UIScreen`, so it is right under split view, Stage Manager and rotation. A parked slot's offset is re-applied on resize so it stays off-screen.
+
+## Results
+
+Same rig, 150 samples per population, 0 dropped:
+
+| | before | after |
+|---|---|---|
+| `none` | 65,723 us | 66,594 us |
+| `pop` | 226,244 us | **76,110 us** |
+| `push` | 234,833 us | **75,642 us** |
+
+**159 ms off a push, 150 ms off a pop**, with the animation intact. The remaining 9 ms over the no-animation probe is the cost of both trees being mounted during the slide, which is what `.transition()` did anyway.
+
+Verified on the simulator: the animation plays in the correct direction for both push and pop, both screens are visible simultaneously mid-slide, screens settle at offset 0, and a synthetic touch on the active screen still triggers navigation.
+
+## What this does not do
+
+**A first visit to a screen still builds every node that does not yet exist.** No identity scheme avoids that.
+
+What retention does buy, and it is more than the single-slot probe suggested, is that the *second* visit is cheap regardless of shape. Bouncing between the dense screen and a 37-node one:
+
+| navigation | before | single-slot probe | two slots |
+|---|---|---|---|
+| pop, trivial out / dense in | 217,120 us | 190,314 us | **65,533 us** |
+| push, dense out / trivial in | 25,766 us | 18,659 us | **8,370 us** |
+
+The probe held one slot, so the two screens overwrote each other and every diff was cross-shape, which is why it only saved 12-28%. With two slots each screen returns to the slot holding its **own** previous tree, so after the first round trip both directions diff. That is exactly the shape of list-to-detail-and-back.
+
+The cost is therefore paid once per screen per slot, not once per navigation. A linear drill-down A to B to C to D still builds each new screen; an alternating A-B-A-B pattern builds each once.
+
+**It does not touch the 65.7 ms steady-state floor.** Changing one text node on a dense screen still costs that, because the platform walks the whole tree regardless. That is MOB-144.
+
+**Retention is depth-1.** Popping two levels rebuilds. Deeper retention was not built because its cost grows with stack depth and its benefit was not measured; the ping-pong shape gives the first level for nothing.
+
+## Hazards accepted, and the ones still open
+
+A parked screen is now alive rather than destroyed, which invalidates assumptions elsewhere. Addressed here: hit-testing, and the frame-registry generation is untouched because the parked slot stops re-registering once it stops laying out.
+
+**Still open and NOT fixed here**, because they need a parked screen to actually contain the widget in question:
+
+* `MobSheetView` holds `@State isPresented = true` and `.sheet` presents on the window, so a screen parked with a sheet up may keep it over the new screen.
+* `MobWKWebView` assigns the process-global `g_webview` from both `makeUIView` and `updateUIView`; two live screens with a web view will fight over it.
+* `MobVideoPlayer` keeps playing, audio included, and `MobGpuView` runs unconditionally at 60 fps, so a parked screen with either keeps burning cycles.
+* `MobLazyList`'s `on_end_reached` latch reasons explicitly that "only navigation changes the container's identity" — which this change makes false, so returning to a list already at its end will not re-fire pagination.
+
+Each is small on its own and none is reachable without the corresponding widget on the parked screen. They are recorded on MOB-129 rather than fixed blind.

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -244,6 +244,28 @@ extension MobNode {
 
 // ── Recursive node renderer ────────────────────────────────────────────────
 
+extension MobNodeView: Equatable {
+    /// Reference equality on the node, which is stronger here than it looks.
+    ///
+    /// `nif_set_root` builds a completely fresh `MobNode` graph on every render,
+    /// so two renders never share a node object. An unchanged reference
+    /// therefore means this subtree was not re-sent at all — which is only true
+    /// for a slot the BEAM is not currently painting, i.e. a parked screen.
+    /// Reference equality at the root of such a subtree implies the entire
+    /// subtree is untouched, so short-circuiting it is sound rather than
+    /// merely cheap.
+    ///
+    /// Deliberately NOT a content comparison. Every interactive node's handle
+    /// prop is `(generation << 12) | slot` and `clear_taps` bumps the generation
+    /// on every render, so any content-based equality would be false for any
+    /// subtree containing a tappable node — which is most of them.
+    static func == (lhs: MobNodeView, rhs: MobNodeView) -> Bool {
+        lhs.node === rhs.node
+            && lhs.layoutWeightAxis == rhs.layoutWeightAxis
+            && lhs.lazyContainer == rhs.lazyContainer
+    }
+}
+
 struct MobNodeView: View {
     let node: MobNode
     private let layoutWeightAxis: MobLayoutWeightAxis?
@@ -1772,20 +1794,20 @@ private struct MobSheetView: View {
 // The asset-catalogue path gets one for free; the loose-file path gets nothing.
 // Calling it from a SwiftUI `body`, as MobImage used to, means that
 // read-and-decode runs on the main thread on every evaluation of the node. That
-// is bad in the steady state and much worse across a navigation: MobRootView
-// keys its subtree on .id(currentNavVersion), so a push or a pop tears the
-// whole tree down and rebuilds it, and every local-file image on the incoming
-// screen is decoded from scratch while the transition is mid-animation. A
-// screen with a handful of photos on it is a visible stall.
+// is bad in the steady state, and it used to be much worse across a navigation:
+// the root carried .id(currentNavVersion), so a push or a pop tore the whole
+// tree down and every local-file image on the incoming screen was decoded from
+// scratch mid-animation. MOB-129 removed that identity change, so a navigation
+// into a slot that already holds a similar tree now reuses the image views
+// rather than rebuilding them.
 //
 // Be precise about what this does and does not fix, because the surrounding
 // issue is easy to overclaim. A first visit to a screen is a cold cache by
 // definition, so a forward push to a new screen full of images is helped not at
 // all: that stall needs downsampling, or preparingForDisplay() off the main
 // thread, and both are their own change. What goes away here is every decode
-// AFTER the first: re-rendering a screen already up, and popping back to one
-// visited before, which is the case .id(currentNavVersion) turned from free
-// into full price.
+// AFTER the first: re-rendering a screen already up, and returning to one
+// visited before.
 //
 // This cache is only for the local-file branch. The http(s) branch goes through
 // AsyncImage, which is backed by URLSession's own caching, and is left alone.
@@ -2076,13 +2098,37 @@ private struct MobImage: View {
 public struct MobRootView: View {
     @ObservedObject var model = MobViewModel.shared
     @Environment(\.colorScheme) private var colorScheme
-    @State private var currentRoot: MobNode?
-    @State private var currentTransition: String = "none"
-    // Local mirror of model.navVersion so the .id() change happens INSIDE
-    // the withAnimation block (the model's @Published value changes via
-    // SwiftUI observation, which doesn't carry the animation context and
-    // produces a default crossfade instead of the .move transition).
-    @State private var currentNavVersion: Int = 0
+    // ── Two-slot screen presentation (MOB-129) ──────────────────────────────
+    //
+    // The root used to be one view carrying `.id(currentNavVersion)`, which
+    // destroyed and rebuilt the entire tree on every push, pop and reset.
+    // Measured on a 1614-node screen: a navigation cost 235 ms against a 65.7 ms
+    // steady-state re-render, and the whole 169 ms gap was the identity change.
+    // With identity preserved a navigation costs what a re-render costs.
+    //
+    // So navigation no longer changes identity. Two slots sit at fixed
+    // structural positions in the ZStack — that position IS their identity, and
+    // no `.id()` is needed — and a navigation ping-pongs between them: the
+    // incoming tree goes into whichever slot is not active, and the active flag
+    // moves. The slide is driven by `slotOffset` rather than by `.transition()`,
+    // because `.transition()` only fires on insert/remove and insert/remove is
+    // exactly what costs 169 ms.
+    //
+    // The outgoing slot is deliberately NOT cleared. Holding it gives depth-1
+    // retention for free: popping back puts that screen's tree into the slot
+    // that still holds its previous tree, so SwiftUI diffs rather than rebuilds.
+    // One level is where nearly all back-navigation lands, and the cost is
+    // bounded at exactly two trees rather than growing with stack depth.
+    //
+    // What this does NOT buy: a first visit to a screen whose shape differs from
+    // the outgoing one still builds every node that does not yet exist. Measured
+    // at 12-28% saving there, against 73% when the shapes match. No identity
+    // scheme avoids building nodes that were never built.
+    @State private var slots: [MobNode?] = [nil, nil]
+    @State private var activeSlot: Int = 0
+    @State private var slotOffset: [CGFloat] = [0, 0]
+    @State private var slotOpacity: [Double] = [1, 1]
+    @State private var containerWidth: CGFloat = 400
     @State private var availableSheetHeight: CGFloat = 1
 
     /// Share of the root's height a content-detent sheet may occupy at most.
@@ -2094,16 +2140,9 @@ public struct MobRootView: View {
 
     public var body: some View {
         ZStack {
-            if let root = currentRoot {
-                MobNodeView(node: root)
-                    // .id changes only on navigation (push/pop/reset), so
-                    // typing in a TextField doesn't tear the view down.
-                    // Driven by currentNavVersion (not model.navVersion)
-                    // so the change happens inside withAnimation — see
-                    // .onChange(of: model.rootVersion) below.
-                    .id(currentNavVersion)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .transition(navTransition(currentTransition))
+            if slots[0] != nil || slots[1] != nil {
+                screenSlot(0)
+                screenSlot(1)
             } else {
                 ZStack {
                     Color.black.ignoresSafeArea()
@@ -2147,39 +2186,27 @@ public struct MobRootView: View {
         // becoming an indistinguishable full-screen cover.
         .background {
             GeometryReader { geometry in
-                Color.clear.onChange(of: geometry.size.height, initial: true) { _, height in
-                    availableSheetHeight = max(1, height * Self.sheetHeightCeilingFraction)
-                }
+                Color.clear
+                    .onChange(of: geometry.size.height, initial: true) { _, height in
+                        availableSheetHeight = max(1, height * Self.sheetHeightCeilingFraction)
+                    }
+                    // The slide distance. Read from real geometry rather than
+                    // UIScreen so it is right under split view, Stage Manager
+                    // and rotation, and re-read so a parked screen's parked
+                    // offset stays off-screen after a resize.
+                    .onChange(of: geometry.size.width, initial: true) { _, width in
+                        guard width > 0 else { return }
+                        containerWidth = width
+                        for i in 0..<2 where i != activeSlot && slots[i] != nil {
+                            slotOffset[i] = slotOffset[i] < 0 ? -width : width
+                        }
+                    }
             }
         }
         .environment(\.mobAvailableSheetHeight, availableSheetHeight)
         .ignoresSafeArea(.container, edges: [.bottom, .horizontal])
         .onChange(of: model.rootVersion) {
-            let t = model.transition
-            let newRoot = model.root
-            let newNavVersion = model.navVersion
-            // Capture transition before the animation block so the modifier
-            // sees the right value when the new view is inserted.
-            currentTransition = t
-            // Log every nav transition so log-tail-based checks can verify
-            // the animation fired without resorting to video recording.
-            // Format: [MobNav] transition=<push|pop|reset|none> navVersion=<n>
-            if t != "none" {
-                NSLog("[MobNav] transition=%@ navVersion=%d", t, newNavVersion)
-            }
-            if let animation = navAnimation(t) {
-                withAnimation(animation) {
-                    currentRoot = newRoot
-                    // Apply navVersion inside withAnimation so the .id()
-                    // change carries the animation context — without this
-                    // SwiftUI replaces the view via default crossfade and
-                    // the .move transition never plays.
-                    currentNavVersion = newNavVersion
-                }
-            } else {
-                currentRoot = newRoot
-                currentNavVersion = newNavVersion
-            }
+            applyRoot(model.root, transition: model.transition, navVersion: model.navVersion)
         }
         // Notify Elixir when the OS appearance toggles so subscribers
         // (Mob.Device → Mob.Theme.Adaptive consumers) can re-resolve.
@@ -2190,22 +2217,104 @@ public struct MobRootView: View {
         }
     }
 
-    private func navTransition(_ t: String) -> AnyTransition {
+    /// One presentation slot.
+    ///
+    /// No `.id()`: the slot's fixed structural position in the ZStack is its
+    /// identity, which is the whole point — an identity that never changes is
+    /// what lets SwiftUI diff a new tree into existing views instead of
+    /// rebuilding them.
+    ///
+    /// `.equatable()` is what makes the inactive slot cheap. `nif_set_root`
+    /// allocates a fresh `MobNode` graph on every render, so the active slot's
+    /// reference always differs and its body always re-runs. The inactive slot's
+    /// reference does NOT change, because the BEAM only sends the active
+    /// screen's tree — so an equality check short-circuits its entire subtree.
+    /// Without this the inactive slot would be re-evaluated on every render of
+    /// the active one, and holding it would cost more than rebuilding it.
+    @ViewBuilder
+    private func screenSlot(_ index: Int) -> some View {
+        if let root = slots[index] {
+            MobNodeView(node: root)
+                .equatable()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .offset(x: slotOffset[index])
+                .opacity(slotOpacity[index])
+                // Explicit, not inherited from opacity. SwiftUI hit-tests over
+                // its own display list and does not necessarily honour a zero
+                // opacity the way UIKit's hitTest: honours a zero alpha, and
+                // `MobBoxSemantics` applies `.contentShape` liberally. A parked
+                // screen that can still be tapped would resolve handles from a
+                // superseded tap-table generation.
+                .allowsHitTesting(index == activeSlot)
+                .accessibilityHidden(index != activeSlot)
+        }
+    }
+
+    /// Apply a new root, either in place or as a navigation.
+    ///
+    /// A `"none"` render is the steady-state path and updates the active slot
+    /// directly: same slot, same identity, so SwiftUI diffs. That is the 65.7 ms
+    /// path a navigation now also takes.
+    private func applyRoot(_ newRoot: MobNode?, transition t: String, navVersion: Int) {
+        guard t != "none" else {
+            slots[activeSlot] = newRoot
+            return
+        }
+
+        // Log every nav transition so log-tail-based checks can verify the
+        // animation fired without resorting to video recording.
+        // Format: [MobNav] transition=<push|pop|reset|none> navVersion=<n>
+        NSLog("[MobNav] transition=%@ navVersion=%d", t, navVersion)
+
+        let incoming = 1 - activeSlot
+        let outgoing = activeSlot
+
+        // Seat the incoming tree off-screen on the side it should arrive from,
+        // OUTSIDE any animation, so the placement itself is not animated.
+        slotOffset[incoming] = enterOffset(t)
+        slotOpacity[incoming] = (t == "reset") ? 0 : 1
+        slots[incoming] = newRoot
+        activeSlot = incoming
+
+        let settle = {
+            slotOffset[incoming] = 0
+            slotOpacity[incoming] = 1
+            slotOffset[outgoing] = exitOffset(t)
+            slotOpacity[outgoing] = (t == "reset") ? 0 : 1
+        }
+
+        if let animation = navAnimation(t) {
+            withAnimation(animation, settle)
+        } else {
+            settle()
+        }
+
+        // A reset replaces the stack, so the outgoing screen is unreachable and
+        // holding it is pure cost. Push and pop keep it: that is the depth-1
+        // retention which makes popping back a diff rather than a rebuild.
+        if t == "reset" {
+            slots[outgoing] = nil
+            slotOffset[outgoing] = 0
+            slotOpacity[outgoing] = 1
+        }
+    }
+
+    /// Where an incoming screen starts, before it slides in.
+    private func enterOffset(_ t: String) -> CGFloat {
         switch t {
-        case "push":
-            return .asymmetric(
-                insertion: .move(edge: .trailing),
-                removal: .move(edge: .leading)
-            )
-        case "pop":
-            return .asymmetric(
-                insertion: .move(edge: .leading),
-                removal: .move(edge: .trailing)
-            )
-        case "reset":
-            return .opacity
-        default:
-            return .identity
+        case "push": return containerWidth
+        case "pop": return -containerWidth
+        default: return 0
+        }
+    }
+
+    /// Where an outgoing screen ends up. It stays there, parked off-screen,
+    /// until a later navigation reuses its slot.
+    private func exitOffset(_ t: String) -> CGFloat {
+        switch t {
+        case "push": return -containerWidth
+        case "pop": return containerWidth
+        default: return 0
         }
     }
 

--- a/test/mob/native_screen_slots_test.exs
+++ b/test/mob/native_screen_slots_test.exs
@@ -1,0 +1,180 @@
+defmodule Mob.NativeScreenSlotsTest do
+  @moduledoc """
+  Navigation preserves view identity instead of destroying it (MOB-129).
+
+  The root used to carry `.id(currentNavVersion)`, which destroyed and rebuilt
+  the whole tree on every push, pop and reset. Measured on a 1614-node screen: a
+  navigation cost 235 ms against a 65.7 ms steady-state re-render, and the entire
+  169 ms gap was the identity change. Two fixed slots that ping-pong, with the
+  slide driven by an offset rather than by `.transition()`, brought a navigation
+  to 76 ms.
+
+  Source-asserted because there is no host-side way to run SwiftUI. Every
+  assertion runs on comment-stripped source: the region being guarded is heavily
+  commented with the very words being matched, so an assertion a comment could
+  satisfy would pass against code that does nothing.
+  """
+  # credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+  use ExUnit.Case, async: true
+
+  @ios File.read!(Path.expand("../../ios/MobRootView.swift", __DIR__))
+
+  describe "identity" do
+    test "navigation no longer changes the root's identity" do
+      # The entire measured win. `.id(currentNavVersion)` is what cost 169 ms.
+      code = code_only(@ios)
+
+      refute code =~ ".id(currentNavVersion)",
+             "the nav-version identity is what this issue removed"
+
+      refute code =~ "@State private var currentNavVersion",
+             "and the state backing it should be gone too"
+    end
+
+    test "the slots carry no .id() at all" do
+      # Their fixed structural position in the ZStack IS their identity. Adding
+      # an .id() back, even a stable one, re-opens the door to identity churn.
+      slot =
+        region(code_only(@ios), "private func screenSlot(_ index: Int) -> some View {", "\n    }")
+
+      refute slot =~ ".id(", "a slot must take its identity from its position"
+    end
+
+    test "the transition modifier is gone" do
+      # `.transition()` only fires on insert/remove, and insert/remove is exactly
+      # what costs 169 ms. Keeping it would mean keeping the teardown.
+      code = code_only(@ios)
+      refute code =~ ".transition(navTransition", "transition() requires insert/remove"
+      refute code =~ "private func navTransition", "and its helper is dead"
+    end
+  end
+
+  describe "the two slots" do
+    test "there are exactly two, and one is active" do
+      code = code_only(@ios)
+      assert code =~ "@State private var slots: [MobNode?] = [nil, nil]"
+      assert code =~ "@State private var activeSlot: Int = 0"
+      assert code =~ "screenSlot(0)"
+      assert code =~ "screenSlot(1)"
+    end
+
+    test "a navigation ping-pongs rather than reusing the active slot" do
+      # Writing the incoming tree into the ACTIVE slot would diff it over the
+      # outgoing screen: no second tree to animate, so no transition, and the
+      # retention below becomes impossible.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+      assert body =~ "let incoming = 1 - activeSlot"
+      assert body =~ "let outgoing = activeSlot"
+      assert body =~ "slots[incoming] = newRoot"
+      assert body =~ "activeSlot = incoming"
+    end
+
+    test "a none render updates the active slot in place" do
+      # The steady-state path. Ping-ponging here would make every ordinary
+      # re-render a navigation, which is the bug inverted.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+
+      assert body =~ ~r/guard t != "none" else \{\s*slots\[activeSlot\] = newRoot\s*return\s*\}/,
+             "a none render must write the active slot and return"
+    end
+  end
+
+  describe "depth-1 retention" do
+    test "push and pop keep the outgoing tree; reset drops it" do
+      # Holding the outgoing slot is what makes popping back a diff rather than
+      # a rebuild. A reset replaces the stack, so its outgoing screen is
+      # unreachable and holding it is pure cost.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+
+      assert body =~ ~r/if t == "reset" \{\s*slots\[outgoing\] = nil/,
+             "reset must release the outgoing slot"
+
+      refute body =~ ~r/slots\[outgoing\] = nil\s*\n\s*\}\s*\n\s*\}\s*\z/,
+             "push and pop must NOT clear the outgoing slot"
+    end
+  end
+
+  describe "the parked slot is cheap and inert" do
+    test "the slot root is wrapped in an equality check" do
+      # Without this the parked slot's subtree is re-evaluated on every render of
+      # the active one, and holding it costs more than rebuilding it.
+      slot =
+        region(code_only(@ios), "private func screenSlot(_ index: Int) -> some View {", "\n    }")
+
+      assert slot =~ ".equatable()"
+    end
+
+    test "equality is reference identity, not content" do
+      # Every interactive node's handle prop is (generation << 12) | slot and
+      # clear_taps bumps the generation every render, so a content comparison is
+      # false for any subtree containing a tappable node. Reference identity is
+      # the only comparison that can ever be true.
+      eq = region(code_only(@ios), "extension MobNodeView: Equatable {", "\n}")
+      assert eq =~ "lhs.node === rhs.node"
+      refute eq =~ "lhs.node ==  rhs.node"
+      refute eq =~ "isEqual"
+    end
+
+    test "the parked slot cannot be tapped" do
+      # SwiftUI hit-tests over its own display list and does not necessarily
+      # honour zero opacity the way UIKit honours zero alpha. A tappable parked
+      # screen would resolve handles from a superseded tap-table generation.
+      slot =
+        region(code_only(@ios), "private func screenSlot(_ index: Int) -> some View {", "\n    }")
+
+      assert slot =~ ".allowsHitTesting(index == activeSlot)"
+      assert slot =~ ".accessibilityHidden(index != activeSlot)"
+    end
+  end
+
+  describe "the slide" do
+    test "distance comes from real geometry, not the screen" do
+      # UIScreen.bounds is wrong under split view, Stage Manager and rotation,
+      # which would leave a parked screen partly visible.
+      code = code_only(@ios)
+      assert code =~ "containerWidth = width"
+      refute code =~ "UIScreen.main.bounds.width"
+    end
+
+    test "push and pop enter and exit on opposite sides" do
+      enter = region(code_only(@ios), "private func enterOffset(", "\n    }")
+      exit_ = region(code_only(@ios), "private func exitOffset(", "\n    }")
+
+      assert enter =~ ~r/case "push": return containerWidth/
+      assert enter =~ ~r/case "pop": return -containerWidth/
+      assert exit_ =~ ~r/case "push": return -containerWidth/
+      assert exit_ =~ ~r/case "pop": return containerWidth/
+    end
+
+    test "the incoming tree is seated before the animation, not inside it" do
+      # Seating inside withAnimation would animate the placement itself, so the
+      # incoming screen would slide from wherever it last sat rather than from
+      # off-screen.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+      seat = index_of(body, "slotOffset[incoming] = enterOffset(t)")
+      anim = index_of(body, "withAnimation(animation, settle)")
+      assert seat < anim, "the incoming offset must be seated outside the animation"
+    end
+  end
+
+  defp code_only(source) do
+    source
+    |> String.replace(~r{/\*.*?\*/}s, "")
+    |> String.split("\n")
+    |> Enum.map(&String.replace(&1, ~r{^\s*//.*$}, ""))
+    |> Enum.join("\n")
+  end
+
+  defp region(source, from, to) do
+    [_, rest] = String.split(source, from, parts: 2)
+    [body | _] = String.split(rest, to, parts: 2)
+    body
+  end
+
+  defp index_of(hay, needle) do
+    case :binary.match(hay, needle) do
+      {i, _} -> i
+      :nomatch -> flunk("expected to find #{inspect(needle)}")
+    end
+  end
+end


### PR DESCRIPTION
The root carried `.id(currentNavVersion)`, and `.id()` destroys and rebuilds a SwiftUI subtree — so every push, pop and reset threw away the entire native tree.

### The measurements that shaped this

MOB-126's native timing made it measurable for the first time. 1614-node screen, 150 samples, 0 dropped:

| transition | p50 |
|---|---|
| `none` | 65,723 µs |
| `pop` | 226,244 µs |
| `push` | 234,833 µs |

The 169 ms gap scales linearly with node count (37 nodes → 3.8 ms; 43.6× the nodes gave 44.9× the gap).

Two more measurements changed the design away from the issue title:

- **Destroying a tree costs ~26 ms; building one costs ~217 ms.** "Stop discarding the tree" targets the cheap 11%.
- **A one-line probe with a constant `.id()` took a push to 63.9 ms** — the `none` floor, teardown delta −1.4 ms. The whole 169 ms is the identity change and nothing else.

### The design

Two slots at fixed structural positions in the root ZStack. That position **is** their identity, so there is no `.id()` anywhere, and a navigation ping-pongs between them.

**The slide is an animated offset, not `.transition()`.** `.transition()` only fires on insert/removal, and insert/removal is exactly what costs 169 ms. Driving the offset directly decouples animation from identity — that's the whole trick.

**The outgoing slot is not cleared** on push/pop, giving depth-1 retention for free. That mattered more than the probe suggested:

| navigation | before | single-slot probe | **two slots** |
|---|---|---|---|
| pop, trivial out / dense in | 217.1 ms | 190.3 ms | **65.5 ms** |
| push, dense out / trivial in | 25.8 ms | 18.7 ms | **8.4 ms** |

The probe had one slot, so the screens overwrote each other and every diff was cross-shape. With two, each screen returns to the slot holding its **own** previous tree — which is the shape of list-to-detail-and-back. A `reset` does clear it, since that screen is unreachable.

**`.equatable()` on the slot root is load-bearing.** Without it the parked slot is re-evaluated on every render of the active one and holding it costs more than rebuilding it. The comparison is reference identity, deliberately not content: every interactive node's handle is `(generation << 12) | slot` and `clear_taps` bumps the generation every render, so content equality is false for any subtree containing a tappable node.

### Result

**push 234.8 → 75.6 ms, pop 226.2 → 76.1 ms**, animation intact.

Verified on the simulator by frame extraction: both screens visible simultaneously mid-slide, correct direction for both push and pop, settling at offset 0, and a synthetic touch on the active screen still navigates.

13 tests, each mutation-tested (`.id()` restored, `none` made to ping-pong, outgoing cleared on push/pop, `.equatable()` dropped, content equality, parked slot left hit-testable, offset seated inside the animation, `UIScreen` instead of geometry). All caught.

### Does not fix — recorded on the issue rather than fixed blind

A parked screen is now alive rather than destroyed. A screen parked with a **sheet**, **web view**, **video** or **GPU view** up keeps that widget alive, and `MobLazyList`'s `on_end_reached` latch reasons explicitly on an invariant this inverts. None is reachable without the corresponding widget on the parked screen.

A first visit still builds every node that doesn't yet exist, so a linear drill-down pays full price per level. This doesn't touch the 65.7 ms steady-state floor (MOB-144). **Android is unchanged.**

1462 tests pass. `mix.exs` untouched at 0.7.39.