### PR TITLE
Fix what MOB-129 broke by keeping parked screens alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,30 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   visible screen. `on_end_reached`'s latch clears on activation, restoring the
   pre-MOB-129 behaviour that a navigation used to give it for free.
 
-  Still open, and recorded on MOB-147: a documented `reset_to(...,
-  transition: :push)` retains an unreachable screen because the clear keys on
-  the animation name rather than on whether the stack was replaced; a reset no
-  longer cross-fades; and the layout cost of a parked slot on rotation is
-  reasoned about but unmeasured.
+- **A navigation that replaces the stack releases the screen it replaced**
+  (MOB-147). The release used to key on the animation name, which got it wrong
+  in both directions: `reset_to(..., transition: :push)` is documented, does
+  replace the stack, and was read as a push and retained for ever; while
+  `switch_tab(..., transition: :reset)` is also documented, does NOT replace the
+  stack — a parked tab can be switched back to — and was released, throwing away
+  the retention it should have kept.
+
+  The router now tags a stack-replacing navigation, and native reads the
+  animation from the prefix and the release from the suffix, so neither is
+  inferred from the other. No wire schema or NIF arity change: the transition
+  already travels as an atom whose name native reads directly, and the public
+  `:push | :pop | :reset` vocabulary callers use is unchanged.
+
+- **A reset cross-fades again** (MOB-147). The outgoing screen was released
+  synchronously, removing it in the same turn, so it hard-cut rather than fading
+  — and with `.transition()` gone there was nothing to animate its removal. The
+  release now runs on the animation's completion.
+
+  Still open on MOB-147: the layout cost of a parked slot on a container
+  geometry change. Steady state with both slots warm measures 67.6 ms against
+  65.7 ms for one, about 3%, which suggests the equality check is doing its job.
+  Rotation itself remains unmeasured, and honestly so: a geometry change
+  produces no `set_root`, so the frame instrumentation cannot see it at all.
 
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   `transition: :none` citing this exact hazard; MOB-129 had made it the default
   path. Both now re-seed when the BEAM's value changes.
 
+  Toggles, sliders and text fields re-seed when their screen becomes active,
+  not only when the BEAM's value changes. A value watcher alone misses the
+  common case: slots alternate, so a screen reuses the view identities of the
+  screen two navigations back, and if both carry the same value — `false` for a
+  toggle, `""` for an uncontrolled field — the watcher never fires. For a field
+  with `secure: true` that meant a password crossing screens. Focus is dropped
+  on park too, so a field holding the keyboard does not arrive focused on the
+  next screen.
+
   Also: a parked sheet is dismissed and re-presented on return, rather than
   staying visible and interactive over the incoming screen — `.sheet` presents
   on the window, so the slot's `allowsHitTesting(false)` never reached it, and a
@@ -51,11 +60,15 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   stack — a parked tab can be switched back to — and was released, throwing away
   the retention it should have kept.
 
-  The router now tags a stack-replacing navigation, and native reads the
-  animation from the prefix and the release from the suffix, so neither is
-  inferred from the other. No wire schema or NIF arity change: the transition
-  already travels as an atom whose name native reads directly, and the public
-  `:push | :pop | :reset` vocabulary callers use is unchanged.
+  The flag now rides on the JSON root, and the transition atom keeps its closed
+  `:push | :pop | :reset | :none` vocabulary. A first attempt suffixed the atom
+  instead (`:reset_replace`) and that was wrong: `set_transition/1`'s atom name
+  reaches Android as a raw string, and `MainActivity.kt` matches those four
+  values with an exact `when`, so every `reset_to` would have silently lost its
+  animation — on newly generated apps too, and those files are app-owned and
+  never re-rendered, so no template fix would have reached existing ones. An
+  unknown root key is ignored by both platforms' parsers, so a host that does
+  not read it keeps its current behaviour.
 
 - **A reset cross-fades again** (MOB-147). The outgoing screen was released
   synchronously, removing it in the same turn, so it hard-cut rather than fading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Fixed
+- **A parked screen no longer keeps live resources running, and returning to
+  one no longer breaks the frame registry** (MOB-147, MOB-145). MOB-129 keeps
+  the navigated-away screen mounted so popping back diffs rather than rebuilds.
+  Before it, "not active" and "not alive" were the same state, so several things
+  never had to ask which one they were in. A post-merge review found two of them
+  silently broken rather than merely wasteful.
+
+  **The frame registry refused every write from a screen you popped back to.**
+  The nav generation is still bumped on every navigation and stale writes are
+  still refused, but a parked tracker's `onAppear` never fires again — so a
+  returning screen kept a stamp two navigations old and was rejected for ever.
+  `Mob.Test.element_frames` and `tap_id` read empty for the screen actually on
+  display, silently, for exactly the screens the optimisation retains. Trackers
+  now re-seed when their slot becomes active. Verified on device: 231 frames
+  before a push, 231 again after popping back.
+
+  **Toggles and sliders inherited state across screens.** Neither had any
+  prop-to-state sync, relying on the navigation teardown to re-seed them, so a
+  screen could show the toggle states and slider positions of the screen two
+  navigations back. `Mob.Socket` already raises `ArgumentError` on
+  `transition: :none` citing this exact hazard; MOB-129 had made it the default
+  path. Both now re-seed when the BEAM's value changes.
+
+  Also: a parked sheet is dismissed and re-presented on return, rather than
+  staying visible and interactive over the incoming screen — `.sheet` presents
+  on the window, so the slot's `allowsHitTesting(false)` never reached it, and a
+  park is no longer reported to the BEAM as a user dismissal. A parked video
+  pauses (audio included) and only resumes if it was autoplaying; a parked GPU
+  view stops rendering, having previously run at 60 fps indefinitely behind the
+  visible screen. `on_end_reached`'s latch clears on activation, restoring the
+  pre-MOB-129 behaviour that a navigation used to give it for free.
+
+  Still open, and recorded on MOB-147: a documented `reset_to(...,
+  transition: :push)` retains an unreachable screen because the clear keys on
+  the animation name rather than on whether the stack was replaced; a reset no
+  longer cross-fades; and the layout cost of a parked slot on rotation is
+  reasoned about but unmeasured.
+
+
 ### Performance
 - **Navigation no longer rebuilds the whole native tree (iOS)** (MOB-129). The
   root carried `.id(currentNavVersion)`, so every push, pop and reset destroyed

--- a/decisions/2026-09-04-two-slot-screen-presentation.md
+++ b/decisions/2026-09-04-two-slot-screen-presentation.md
@@ -86,3 +86,64 @@ A parked screen is now alive rather than destroyed, which invalidates assumption
 * `MobLazyList`'s `on_end_reached` latch reasons explicitly that "only navigation changes the container's identity" — which this change makes false, so returning to a list already at its end will not re-fire pagination.
 
 Each is small on its own and none is reachable without the corresponding widget on the parked screen. They are recorded on MOB-129 rather than fixed blind.
+
+## Follow-up: which navigations release the slot they leave (MOB-147)
+
+Retention is only worth paying for when the screen left behind can come back.
+It cannot when its process has been stopped, and three navigations do that:
+`reset_to`, every flavour of `pop`, and the recovery path for a screen that
+crashed and failed to restart. In all of them the retained tree is unreachable
+— the next navigation always writes into the *other* slot — so it is held until
+something happens to overwrite it, which may be a long dwell later.
+
+Four sites qualify: `reset_to`, `pop`, `pop_to` and `pop_to_root`, and both
+recovery branches for a screen that crashed and failed to restart. All are now
+tagged, and the tagged form releases the outgoing slot when the animation
+completes.
+
+Tab switches are deliberately **not** tagged: a parked tab can be switched back
+to, so its tree is worth keeping. That is the one case where retention pays.
+
+**How the tag travels.** As `{transition, :replace}` inside the BEAM, unwrapped
+by `Mob.Renderer` into a plain `:push | :pop | :reset | :none` plus a
+`replaces_stack` key on the JSON root. The first attempt decorated the atom
+itself (`:reset_replace`). That broke Android: `MainActivity.kt.eex` matches
+the transition string against `"push"/"pop"/"reset"` exactly, so a decorated
+value fell through to `else` and every `reset_to` silently lost its animation —
+in generated apps too, and those files are app-owned and never re-rendered, so
+a template fix would not have reached existing ones. Keeping the wire
+vocabulary closed and putting the fact beside it costs nothing: both platforms
+already ignore unknown root keys.
+
+**`:none` stays untagged.** With no animation there is no completion callback
+to release on, and the incoming screen reuses the outgoing one's view
+identities, so releasing the slot would pull the tree out from under it.
+`Mob.Socket.reset_to/4` rejects `:none` outright, but the router still accepts
+raw nav actions — from `Mob.Test.reset_to/4`, which does not validate, and from
+sockets built before a hot code push — so the guard is load-bearing, not dead.
+
+**Tagging pop was measured, not assumed** — on both sides, because there are
+two.
+
+*The pop itself.* The worry was that releasing at animation completion moves a
+teardown onto the main thread at exactly the wrong moment; teardown of a dense
+tree measured ~26 ms earlier in this epic. Over eight pops of the dense screen
+on the iOS simulator, median native apply time went **42.8 ms to 39.4 ms**,
+with a markedly better low end. Reproducible across runs.
+
+*The navigation that pays for it.* The release costs nothing on the pop because
+the cost, if any, lands on the **next** navigation into the freed slot, which
+now builds from empty instead of diffing against the retained tree. Measured as
+`push A→B; pop B→A; push A→C`, eight rounds: **82.1 ms tagged, 84.4 ms
+untagged**. That is noise, and the reason it is noise is that the retention
+being given up was not buying anything here — C is a different screen from B, so
+what it replaces is a cross-shape diff, which this epic already measured as no
+cheaper than a fresh build. Retention pays only when a screen returns to its
+*own* slot, which is exactly the case a pop cannot produce for the screen it
+just destroyed.
+
+*Discarded:* an earlier tagged run of the same harness reported 18.5 ms. It was
+collected under different conditions (no redeploy or reconnect between runs) and
+a repeat under the same conditions as the untagged run gave 82.1 ms. The harness
+is not stable across app states, so only the like-for-like pair is quoted, and
+the claim is limited to "no measurable difference" rather than a win.

--- a/decisions/2026-09-04-two-slot-screen-presentation.md
+++ b/decisions/2026-09-04-two-slot-screen-presentation.md
@@ -74,7 +74,9 @@ The cost is therefore paid once per screen per slot, not once per navigation. A 
 
 ## Hazards accepted, and the ones still open
 
-A parked screen is now alive rather than destroyed, which invalidates assumptions elsewhere. Addressed here: hit-testing, and the frame-registry generation is untouched because the parked slot stops re-registering once it stops laying out.
+A parked screen is now alive rather than destroyed, which invalidates assumptions elsewhere.
+
+**Correction.** An earlier version of this record claimed "the frame-registry generation is untouched because the parked slot stops re-registering once it stops laying out." That reasoned about the outgoing direction only, and it was wrong about the returning one. A post-merge review (MOB-147) found that a parked tracker's `.onAppear` never fires again, so a screen you pop back to keeps a stamp two navigations stale and **every one of its frame writes is refused for ever** — silently emptying `Mob.Test.element_frames` and `tap_id` for exactly the screens this optimisation retains. Fixed by re-seeding the stamp when a slot becomes active; the generation gate itself is kept, because it is what stops an outgoing screen re-registering at mid-animation coordinates.
 
 **Still open and NOT fixed here**, because they need a parked screen to actually contain the widget in question:
 

--- a/ios/MobGpuView.swift
+++ b/ios/MobGpuView.swift
@@ -30,6 +30,7 @@ import SwiftUI
 // MARK: - SwiftUI wrapper
 
 struct MobGpuView: UIViewRepresentable {
+    @Environment(\.mobScreenIsActive) private var isActive
     let node: MobNode
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -47,6 +48,12 @@ struct MobGpuView: UIViewRepresentable {
     }
 
     func updateUIView(_ view: MobGpuMTKView, context: Context) {
+        // Stop rendering while parked. The view runs in continuous mode at
+        // 60 fps, and MOB-129 keeps a navigated-away screen mounted, so without
+        // this a parked GPU view burns the GPU indefinitely behind the screen
+        // the user is looking at.
+        view.isPaused = !isActive
+
         if let shader = node.gpuShaderMSL {
             view.setShader(shader)
         } else {

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -2426,32 +2426,62 @@ public struct MobRootView: View {
         slots[incoming] = newRoot
         activeSlot = incoming
 
+        let crossfading = animation(of: t) == "reset"
+        let releasing = replacesStack(t)
+
         let settle = {
             slotOffset[incoming] = 0
             slotOpacity[incoming] = 1
             slotOffset[outgoing] = exitOffset(t)
-            slotOpacity[outgoing] = (t == "reset") ? 0 : 1
+            slotOpacity[outgoing] = crossfading ? 0 : 1
         }
 
-        if let animation = navAnimation(t) {
-            withAnimation(animation, settle)
-        } else {
-            settle()
-        }
-
-        // A reset replaces the stack, so the outgoing screen is unreachable and
-        // holding it is pure cost. Push and pop keep it: that is the depth-1
-        // retention which makes popping back a diff rather than a rebuild.
-        if t == "reset" {
+        // Release AFTER the animation, not before it.
+        //
+        // Clearing the outgoing slot synchronously removed it from the
+        // hierarchy in the same turn, so a reset hard-cut instead of
+        // cross-fading: the outgoing screen vanished rather than fading, and
+        // there is no `.transition()` any more to animate its removal. Holding
+        // it until the animation completes is what lets the opacity actually
+        // play.
+        let release = {
+            guard releasing else { return }
             slots[outgoing] = nil
             slotOffset[outgoing] = 0
             slotOpacity[outgoing] = 1
         }
+
+        if let anim = navAnimation(t) {
+            withAnimation(anim, settle, completion: release)
+        } else {
+            settle()
+            release()
+        }
+    }
+
+    /// The animation half of a transition.
+    ///
+    /// The router sends `push_replace` / `pop_replace` / `reset_replace` when a
+    /// navigation replaces the stack. Two independent facts travel in one atom:
+    /// the prefix says how to animate, the suffix says the outgoing screen is
+    /// unreachable. Splitting them here means neither is inferred from the
+    /// other, which is the bug this replaced — the release used to key on the
+    /// animation name, so a documented `reset_to(transition: :push)` retained a
+    /// screen nobody could reach, and a `switch_tab(transition: :reset)`
+    /// released one the user can switch straight back to.
+    private func animation(of t: String) -> String {
+        t.hasSuffix("_replace") ? String(t.dropLast("_replace".count)) : t
+    }
+
+    /// Whether this navigation replaced the stack, making the outgoing screen
+    /// unreachable and its retained tree pure cost.
+    private func replacesStack(_ t: String) -> Bool {
+        t.hasSuffix("_replace")
     }
 
     /// Where an incoming screen starts, before it slides in.
     private func enterOffset(_ t: String) -> CGFloat {
-        switch t {
+        switch animation(of: t) {
         case "push": return containerWidth
         case "pop": return -containerWidth
         default: return 0
@@ -2461,7 +2491,7 @@ public struct MobRootView: View {
     /// Where an outgoing screen ends up. It stays there, parked off-screen,
     /// until a later navigation reuses its slot.
     private func exitOffset(_ t: String) -> CGFloat {
-        switch t {
+        switch animation(of: t) {
         case "push": return -containerWidth
         case "pop": return containerWidth
         default: return 0
@@ -2469,7 +2499,7 @@ public struct MobRootView: View {
     }
 
     private func navAnimation(_ t: String) -> Animation? {
-        switch t {
+        switch animation(of: t) {
         case "push", "pop":
             return .spring(response: 0.3, dampingFraction: 0.85)
         case "reset":

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -633,6 +633,11 @@ private struct MobFrameTracker: ViewModifier {
 
     @State private var box = MobFrameBox()
 
+    // Whether this tracker's screen is the one on display. Before MOB-129 a
+    // navigation destroyed the outgoing tree, so a tracker only ever existed on
+    // the live screen and this question could not arise.
+    @Environment(\.mobScreenIsActive) private var isActive
+
     func body(content: Content) -> some View {
         // A sheet's own switch-case view is a zero-size anchor used only to
         // attach `.sheet(isPresented:)` — its real, visible content is
@@ -692,6 +697,35 @@ private struct MobFrameTracker: ViewModifier {
                             // Without this their last frame is reported forever
                             // and Mob.Test.tap_id taps whatever is there now.
                             .onDisappear { mob_unregister_frame(id, box.seq) }
+                            // Re-seed the generation when this screen comes
+                            // back, and re-register at the settled position.
+                            //
+                            // Without this, MOB-129 silently breaks the frame
+                            // registry for exactly the screens it optimises
+                            // for. `mob_bump_frame_generation` still fires on
+                            // every navigation and `mob_register_frame` refuses
+                            // a write stamped older than the current
+                            // generation. `.onAppear` above seeds the stamp
+                            // once, and a parked slot is never removed from the
+                            // hierarchy, so it never fires again — a screen you
+                            // pop back to keeps a stamp two navigations stale
+                            // and every one of its writes is rejected for ever.
+                            // `Mob.Test.element_frames` and `tap_id` then read
+                            // empty for the screen actually on display.
+                            //
+                            // Re-seeding on activation rather than dropping the
+                            // generation gate: the gate exists to stop an
+                            // outgoing screen re-registering at mid-animation
+                            // coordinates while it slides away, and two screens
+                            // sharing an `:id` would otherwise clobber each
+                            // other. Parked trackers still carry a stale stamp
+                            // and are still refused, which is what we want; only
+                            // becoming active clears it.
+                            .onChange(of: isActive) { _, nowActive in
+                                guard nowActive else { return }
+                                box.generation = mob_frame_generation()
+                                record(id, geo.frame(in: .global))
+                            }
                     }
                 )
         } else {
@@ -1223,6 +1257,11 @@ private struct MobVideoPlayer: UIViewControllerRepresentable {
     let loop: Bool
     let controls: Bool
 
+    // MOB-129 keeps a navigated-away screen mounted, so without this a parked
+    // video keeps playing — audio included — behind the screen the user is
+    // actually looking at.
+    @Environment(\.mobScreenIsActive) private var isActive
+
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let vc = AVPlayerViewController()
         let url: URL
@@ -1246,7 +1285,17 @@ private struct MobVideoPlayer: UIViewControllerRepresentable {
         return vc
     }
 
-    func updateUIViewController(_ vc: AVPlayerViewController, context: Context) {}
+    func updateUIViewController(_ vc: AVPlayerViewController, context: Context) {
+        // Pause on park; resume only what was playing itself. A video the user
+        // had paused stays paused, and one that never autoplayed does not start
+        // just because the screen came back.
+        guard let player = vc.player else { return }
+        if isActive {
+            if autoplay, player.timeControlStatus == .paused { player.play() }
+        } else if player.timeControlStatus != .paused {
+            player.pause()
+        }
+    }
 }
 
 // ── Camera preview ────────────────────────────────────────────────────────
@@ -1522,6 +1571,21 @@ private struct MobToggle: View {
             .onChange(of: isOn) { _, newValue in
                 node.onChangeBool?(newValue)
             }
+            // Re-seed from the node when the BEAM's value changes under us.
+            //
+            // `State(initialValue:)` runs once per view identity, and before
+            // MOB-129 a navigation destroyed every identity, so arriving on a
+            // new screen always re-seeded. Two-slot presentation keeps
+            // identities alive across navigation, so without this a toggle
+            // inherits the state of whatever toggle sat at the same position on
+            // the screen that last occupied this slot — which is the screen two
+            // navigations back, not one.
+            //
+            // `lib/mob/socket.ex` raises ArgumentError on `transition: :none`
+            // for exactly this hazard; MOB-129 made it the default path.
+            .onChange(of: node.checked) { _, fromBeam in
+                if fromBeam != isOn { isOn = fromBeam }
+            }
             .frame(maxWidth: .infinity, alignment: .leading)
             // issues.md #8: SwiftUI's Toggle("Label", …) initializer does
             // not propagate the label string into the underlying control's
@@ -1554,6 +1618,13 @@ private struct MobSlider: View {
         Slider(value: $value, in: node.minValue...node.maxValue)
             .onChange(of: value) { _, newValue in
                 node.onChangeFloat?(newValue)
+            }
+            // Re-seed from the node when the BEAM's value changes under us.
+            // See MobToggle above: without this a slider inherits the position
+            // of whatever slider sat at the same slot two navigations back,
+            // because MOB-129 keeps view identities alive across navigation.
+            .onChange(of: node.value) { _, fromBeam in
+                if fromBeam != value { value = fromBeam }
             }
             .tint(node.color.map { Color($0) } ?? Color.accentColor)
             .frame(maxWidth: .infinity)
@@ -1611,6 +1682,33 @@ private struct MobAvailableSheetHeightKey: EnvironmentKey {
     static let defaultValue: CGFloat = 0
 }
 
+/// Whether the screen this view belongs to is the one the user is looking at.
+///
+/// Before MOB-129 there was no such thing: a navigation destroyed the outgoing
+/// tree, so "not active" and "not alive" were the same state and nothing needed
+/// to ask. Two-slot presentation keeps the outgoing screen mounted, which makes
+/// the distinction real and makes several widgets wrong by default — a parked
+/// video keeps playing, a parked sheet stays presented on the window, a parked
+/// GPU view keeps rendering at 60 fps.
+///
+/// Defaults to `true` so anything rendered outside a slot (the startup and
+/// error branches) behaves as before.
+///
+/// Internal rather than private: `MobGpuView.swift` is a separate file and
+/// reads this to pause a parked Metal view, and `private` at file scope is
+/// fileprivate in Swift. Note `swiftc -parse` does not do cross-file access
+/// checking, so getting this wrong type-checks locally and fails the build.
+struct MobScreenIsActiveKey: EnvironmentKey {
+    static let defaultValue: Bool = true
+}
+
+extension EnvironmentValues {
+    var mobScreenIsActive: Bool {
+        get { self[MobScreenIsActiveKey.self] }
+        set { self[MobScreenIsActiveKey.self] = newValue }
+    }
+}
+
 private extension EnvironmentValues {
     var mobAvailableSheetHeight: CGFloat {
         get { self[MobAvailableSheetHeightKey.self] }
@@ -1621,8 +1719,12 @@ private extension EnvironmentValues {
 private struct MobSheetView: View {
     let node: MobNode
     @Environment(\.mobAvailableSheetHeight) private var availableHeight
+    @Environment(\.mobScreenIsActive) private var isActive
     @State private var isPresented = true
     @State private var dismissSent = false
+    // Set when a park dismissed the sheet, so the resume can put it back and
+    // the dismiss is not reported to the BEAM as a user action.
+    @State private var dismissedByPark = false
     // nil until the content has actually been measured. A numeric sentinel
     // here is what produced a 1pt sheet on first presentation: content can
     // only be measured after the sheet is up, so the first detent was
@@ -1635,9 +1737,36 @@ private struct MobSheetView: View {
             .sheet(isPresented: $isPresented, onDismiss: sendDismissOnce) {
                 sheetContent
             }
+            // Dismiss while parked, re-present on return.
+            //
+            // MOB-129 keeps the outgoing screen mounted, and `.sheet` presents
+            // on the WINDOW rather than inside the slot — so the slot's
+            // `.allowsHitTesting(false)` does not reach it. A screen parked
+            // with a sheet up would leave that sheet visible AND interactive
+            // over the incoming screen, or make UIKit refuse the incoming
+            // screen's own presentation.
+            //
+            // `dismissedByPark` keeps the two dismissals apart. A park is not a
+            // user action, so it must not send `on_dismiss` — the BEAM still
+            // believes the sheet is open, which is right, because it is coming
+            // back.
+            .onChange(of: isActive) { _, nowActive in
+                if nowActive {
+                    if dismissedByPark {
+                        dismissedByPark = false
+                        isPresented = true
+                    }
+                } else if isPresented {
+                    dismissedByPark = true
+                    isPresented = false
+                }
+            }
     }
 
     private func sendDismissOnce() {
+        // A park dismissal is bookkeeping, not the user closing the sheet.
+        if dismissedByPark { return }
+
         guard !dismissSent else { return }
         dismissSent = true
         node.onDismiss?()
@@ -2012,9 +2141,10 @@ private struct MobLazyList: View {
     // re-queried on each keystroke then fires one pagination request per
     // keystroke, where before it fired none (MOB-141).
     //
-    // Latching on the count is what makes this survive a replacement: only
-    // navigation changes the container's identity, so this @State outlives a
-    // new tree arriving for the same screen. Re-querying and getting twenty
+    // Latching on the count is what makes this survive a replacement. It used
+    // to be true that only navigation changed the container's identity; since
+    // MOB-129 nothing does, so the latch is cleared explicitly on activation
+    // (below) to keep navigation behaving as it did. Re-querying and getting twenty
     // results again is suppressed; loading a page and going twenty to forty is
     // not, which is exactly the pagination flow the callback exists for.
     //
@@ -2025,6 +2155,19 @@ private struct MobLazyList: View {
     // this from the scroll observer rather than from `.onAppear`. Handlers
     // should still be written to be idempotent.
     @State private var firedForCount: Int?
+
+    // MOB-129 keeps view identity alive across navigation, which invalidates
+    // the reasoning above: `@State` now outlives a navigation too, not just a
+    // re-render. Without this, a list at the same slot position on a different
+    // screen inherits the previous list's latch, and if the two happen to have
+    // the same row count its first page never loads.
+    //
+    // Clearing on activation restores exactly the pre-MOB-129 behaviour, where
+    // `.id(currentNavVersion)` destroyed this state on every navigation. It
+    // does mean returning to a list already at its end re-fires once, which is
+    // what users had before and is the conservative choice: the alternative
+    // silently drops a page load.
+    @Environment(\.mobScreenIsActive) private var isActive
 
     var body: some View {
         let children = mobIdentifiedChildren(node.childNodes)
@@ -2047,6 +2190,9 @@ private struct MobLazyList: View {
         .padding(node.paddingEdgeInsets)
         .background(node.backgroundColor.map { Color($0) } ?? Color.clear)
         .ifLet(node.nativeViewId) { view, id in view.accessibilityIdentifier(id) }
+        .onChange(of: isActive) { _, nowActive in
+            if nowActive { firedForCount = nil }
+        }
     }
 }
 
@@ -2247,6 +2393,10 @@ public struct MobRootView: View {
                 // superseded tap-table generation.
                 .allowsHitTesting(index == activeSlot)
                 .accessibilityHidden(index != activeSlot)
+                // Published so widgets that own live resources can stand down
+                // while parked. Before MOB-129 the outgoing tree was destroyed,
+                // so nothing had to ask.
+                .environment(\.mobScreenIsActive, index == activeSlot)
         }
     }
 

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -1262,8 +1262,7 @@ private struct MobVideoPlayer: UIViewControllerRepresentable {
     // actually looking at.
     @Environment(\.mobScreenIsActive) private var isActive
 
-    func makeUIViewController(context: Context) -> AVPlayerViewController {
-        let vc = AVPlayerViewController()
+    private func makePlayer() -> AVPlayer {
         let url: URL
         if src.hasPrefix("http://") || src.hasPrefix("https://") {
             url = URL(string: src)!
@@ -1271,8 +1270,6 @@ private struct MobVideoPlayer: UIViewControllerRepresentable {
             url = URL(fileURLWithPath: src)
         }
         let player = AVPlayer(url: url)
-        vc.player = player
-        vc.showsPlaybackControls = controls
         if loop {
             NotificationCenter.default.addObserver(
                 forName: .AVPlayerItemDidPlayToEndTime,
@@ -1281,14 +1278,39 @@ private struct MobVideoPlayer: UIViewControllerRepresentable {
                 player.play()
             }
         }
+        return player
+    }
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let vc = AVPlayerViewController()
+        let player = makePlayer()
+        vc.player = player
+        vc.showsPlaybackControls = controls
+        context.coordinator.src = src
         if autoplay { player.play() }
         return vc
     }
 
     final class Coordinator {
-        /// Set while the screen is parked, so the resume fires once on return
-        /// rather than on every render of the active screen.
-        var wasParked = false
+        /// Whether the player was actually playing at the moment its screen was
+        /// parked, and so should resume on return.
+        ///
+        /// Deliberately not "did a park happen". Resuming on `autoplay` alone
+        /// undoes a pause the user made before navigating away: park sees an
+        /// already-paused player and does nothing, and the return sees
+        /// `autoplay && .paused` and starts it. What matters is the state the
+        /// player was in, not how it got parked.
+        var wasPlaying = false
+
+        /// The `src` the current player was built for.
+        ///
+        /// Two-slot presentation deliberately preserves view identity across
+        /// *different* screens: screen C is written into the slot screen A
+        /// left, so C's video representable can be A's, coordinator and all.
+        /// `makeUIViewController` does not run again, so without this the
+        /// player is never rebuilt and C shows A's video — and, because
+        /// `wasPlaying` came from A being parked, plays it unbidden with audio.
+        var src: String?
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -1297,21 +1319,38 @@ private struct MobVideoPlayer: UIViewControllerRepresentable {
         // Pause on park; resume only what was playing itself. A video the user
         // had paused stays paused, and one that never autoplayed does not start
         // just because the screen came back.
+        // A changed `src` means this is a different video in a recycled view.
+        // Rebuild rather than resume: the old player belongs to another screen,
+        // and so does anything `wasPlaying` remembers about it.
+        if context.coordinator.src != src {
+            context.coordinator.src = src
+            context.coordinator.wasPlaying = false
+            let rebuilt = makePlayer()
+            vc.player = rebuilt
+            vc.showsPlaybackControls = controls
+            if autoplay && isActive { rebuilt.play() }
+            return
+        }
+
         guard let player = vc.player else { return }
 
-        // Pause on park. Resume only on the park-to-active TRANSITION, never
-        // merely because the screen is active: this runs on every SwiftUI
-        // update of the active screen, and a fresh node graph arrives on every
-        // BEAM render, so gating on `isActive` alone restarts a video the user
-        // paused within one render of any screen carrying a timer or live data.
+        // Pause on park; resume only what was playing when it was parked.
+        //
+        // Two separate traps here. Gating the resume on `isActive` alone
+        // restarts the video on every render, because this runs on every
+        // SwiftUI update of the active screen and a fresh node graph arrives on
+        // every BEAM render. And gating it on `autoplay` undoes a pause the
+        // user made before navigating away — the park finds it already paused
+        // and does nothing, the return finds `autoplay && .paused` and plays
+        // it. Recording what the player was doing avoids both.
         if isActive {
-            if context.coordinator.wasParked {
-                context.coordinator.wasParked = false
-                if autoplay, player.timeControlStatus == .paused { player.play() }
+            if context.coordinator.wasPlaying {
+                context.coordinator.wasPlaying = false
+                if player.timeControlStatus == .paused { player.play() }
             }
-        } else {
-            context.coordinator.wasParked = true
-            if player.timeControlStatus != .paused { player.pause() }
+        } else if player.timeControlStatus != .paused {
+            context.coordinator.wasPlaying = true
+            player.pause()
         }
     }
 }
@@ -1491,6 +1530,9 @@ private struct MobTextField: View {
     let initialText: String
     @Environment(\.mobScreenIsActive) private var isActive
     @State private var text: String
+    // See MobToggle. Covers the controlled-input sync below as well as the
+    // activation re-seed: both write `text` programmatically, and reporting
+    // either back to the BEAM echoes a value the BEAM just sent.
     @FocusState private var isFocused: Bool
 
     init(node: MobNode, placeholder: String, initialText: String) {
@@ -1540,8 +1582,10 @@ private struct MobTextField: View {
                 // dismiss for terminal actions; "next" intentionally keeps keyboard open
                 if node.returnKeyStr != "next" { isFocused = false }
             }
+            // See MobToggle: compare against the BEAM's value rather than
+            // latching, so a re-seed is silent by construction.
             .onChange(of: text) { _, newValue in
-                node.onChangeStr?(newValue)
+                if newValue != initialText { node.onChangeStr?(newValue) }
             }
             .onChange(of: isFocused) { _, focused in
                 if focused { node.onFocus?() } else { node.onBlur?() }
@@ -1571,7 +1615,9 @@ private struct MobTextField: View {
                     return
                 }
 
-                if text != initialText { text = initialText }
+                if text != initialText {
+                    text = initialText
+                }
             }
             .textFieldStyle(.roundedBorder)
             .frame(maxWidth: .infinity)
@@ -1596,7 +1642,6 @@ private struct MobToggle: View {
     let node: MobNode
     @Environment(\.mobScreenIsActive) private var isActive
     @State private var isOn: Bool
-
     init(node: MobNode) {
         self.node = node
         _isOn = State(initialValue: node.checked)
@@ -1605,8 +1650,13 @@ private struct MobToggle: View {
     var body: some View {
         let label = node.text ?? ""
         Toggle(label, isOn: $isOn)
+            // Report only what the user did. A re-seed assigns the BEAM's own
+            // value, so it compares equal and stays silent; a tap never does.
+            // This replaced a `seeding` latch, which was order-dependent: two
+            // programmatic writes straddling one SwiftUI pass left it armed for
+            // the wrong write and echoed a change the user never made.
             .onChange(of: isOn) { _, newValue in
-                node.onChangeBool?(newValue)
+                if newValue != node.checked { node.onChangeBool?(newValue) }
             }
             // Re-seed when this screen becomes active, not only when the value
             // changes. `onChange(of:)` fires on a VALUE change, and slots
@@ -1615,7 +1665,9 @@ private struct MobToggle: View {
             // changes and C silently inherits whatever the user toggled on A.
             // That is the common case, not an edge one.
             .onChange(of: isActive) { _, nowActive in
-                if nowActive, node.checked != isOn { isOn = node.checked }
+                if nowActive, node.checked != isOn {
+                    isOn = node.checked
+                }
             }
             // Still needed for a BEAM-driven change while the screen is up.
             //
@@ -1630,7 +1682,9 @@ private struct MobToggle: View {
             // `lib/mob/socket.ex` raises ArgumentError on `transition: :none`
             // for exactly this hazard; MOB-129 made it the default path.
             .onChange(of: node.checked) { _, fromBeam in
-                if fromBeam != isOn { isOn = fromBeam }
+                if fromBeam != isOn {
+                    isOn = fromBeam
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             // issues.md #8: SwiftUI's Toggle("Label", …) initializer does
@@ -1646,6 +1700,8 @@ private struct MobToggle: View {
 private struct MobSlider: View {
     let node: MobNode
     @Environment(\.mobScreenIsActive) private var isActive
+    // See MobToggle: distinguishes a programmatic re-seed from a user drag, so
+    // arriving at a screen does not report a `change` the user never made.
     @State private var value: Double
 
     init(node: MobNode) {
@@ -1663,18 +1719,24 @@ private struct MobSlider: View {
         // VoiceOver picks for native UISlider when no explicit step is set.
         let step = (node.maxValue - node.minValue) / 10.0
         Slider(value: $value, in: node.minValue...node.maxValue)
+            // See MobToggle: compare against the BEAM's value rather than
+            // latching, so a re-seed is silent by construction.
             .onChange(of: value) { _, newValue in
-                node.onChangeFloat?(newValue)
+                if newValue != node.value { node.onChangeFloat?(newValue) }
             }
             // Re-seed on activation. See MobToggle: a value-change watcher
             // alone misses the common case where both screens carry the same
             // value, which is exactly when the stale one is invisible.
             .onChange(of: isActive) { _, nowActive in
-                if nowActive, node.value != value { value = node.value }
+                if nowActive, node.value != value {
+                    value = node.value
+                }
             }
             // Still needed for a BEAM-driven change while the screen is up.
             .onChange(of: node.value) { _, fromBeam in
-                if fromBeam != value { value = fromBeam }
+                if fromBeam != value {
+                    value = fromBeam
+                }
             }
             .tint(node.color.map { Color($0) } ?? Color.accentColor)
             .frame(maxWidth: .infinity)
@@ -2325,6 +2387,18 @@ public struct MobRootView: View {
     @State private var slotOffset: [CGFloat] = [0, 0]
     @State private var slotOpacity: [Double] = [1, 1]
     @State private var containerWidth: CGFloat = 400
+
+    /// Monotonic navigation counter, so a deferred release can tell whether the
+    /// navigation it belongs to is still the most recent one.
+    ///
+    /// A slot index cannot answer that. `incoming = 1 - activeSlot` alternates,
+    /// so a captured `outgoing` returns to being non-active every SECOND
+    /// navigation — reset, push, pop inside one animation leaves the reset's
+    /// completion looking at a slot that passes an `activeSlot != outgoing`
+    /// check while holding the tree the pop just retained. It would then
+    /// release the screen the user popped away from, and snap its offset
+    /// outside any animation mid-slide.
+    @State private var navToken: Int = 0
     @State private var availableSheetHeight: CGFloat = 1
 
     /// Share of the root's height a content-detent sheet may occupy at most.
@@ -2482,6 +2556,9 @@ public struct MobRootView: View {
         let crossfading = t == "reset"
         let releasing = replacesStack
 
+        navToken += 1
+        let token = navToken
+
         // Seat the incoming tree off-screen on the side it should arrive from,
         // OUTSIDE any animation, so the placement itself is not animated.
         slotOffset[incoming] = enterOffset(t)
@@ -2505,14 +2582,19 @@ public struct MobRootView: View {
         // it until the animation completes is what lets the opacity actually
         // play.
         let release = {
-            // `activeSlot != outgoing` is the precondition, and it is not
-            // optional. This closure runs on the animation's completion, and a
-            // second navigation arriving before it settles reuses the very slot
-            // it captured — a reset followed within 0.25s by a push makes
-            // `outgoing` the ACTIVE slot. Clearing it then blanks the screen the
-            // user is looking at, and nothing recovers until that screen
-            // repaints, which a mount-once screen never does.
-            guard releasing, activeSlot != outgoing else { return }
+            // Release only if no navigation has happened since this one.
+            //
+            // This closure runs on the animation's completion, so anything can
+            // have happened in between. An `activeSlot != outgoing` check is not
+            // enough: slots alternate, so a captured slot returns to being
+            // non-active every second navigation, and reset-push-pop inside one
+            // animation duration leaves this completion clearing the tree the
+            // pop just retained — and snapping its offset outside any animation
+            // while it is still sliding.
+            //
+            // Comparing the token answers the actual question. It also
+            // subsumes the blanking case, where the slot became active again.
+            guard releasing, token == navToken else { return }
             slots[outgoing] = nil
             slotOffset[outgoing] = 0
             slotOpacity[outgoing] = 1

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -1285,15 +1285,33 @@ private struct MobVideoPlayer: UIViewControllerRepresentable {
         return vc
     }
 
+    final class Coordinator {
+        /// Set while the screen is parked, so the resume fires once on return
+        /// rather than on every render of the active screen.
+        var wasParked = false
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
     func updateUIViewController(_ vc: AVPlayerViewController, context: Context) {
         // Pause on park; resume only what was playing itself. A video the user
         // had paused stays paused, and one that never autoplayed does not start
         // just because the screen came back.
         guard let player = vc.player else { return }
+
+        // Pause on park. Resume only on the park-to-active TRANSITION, never
+        // merely because the screen is active: this runs on every SwiftUI
+        // update of the active screen, and a fresh node graph arrives on every
+        // BEAM render, so gating on `isActive` alone restarts a video the user
+        // paused within one render of any screen carrying a timer or live data.
         if isActive {
-            if autoplay, player.timeControlStatus == .paused { player.play() }
-        } else if player.timeControlStatus != .paused {
-            player.pause()
+            if context.coordinator.wasParked {
+                context.coordinator.wasParked = false
+                if autoplay, player.timeControlStatus == .paused { player.play() }
+            }
+        } else {
+            context.coordinator.wasParked = true
+            if player.timeControlStatus != .paused { player.pause() }
         }
     }
 }
@@ -1471,6 +1489,7 @@ private struct MobTextField: View {
     let node: MobNode
     let placeholder: String
     let initialText: String
+    @Environment(\.mobScreenIsActive) private var isActive
     @State private var text: String
     @FocusState private var isFocused: Bool
 
@@ -1537,6 +1556,23 @@ private struct MobTextField: View {
                     text = newValue
                 }
             }
+            // Re-seed when this screen becomes active. The watcher above fires
+            // on a VALUE change, and slots alternate, so screen C reuses screen
+            // A's view identities — if both fields carry `""`, the default for
+            // an uncontrolled input, the value never changes and C shows what
+            // was typed on A. `secure: true` renders a SecureField, so that is
+            // a password crossing screens, not just a stale string.
+            //
+            // Focus is dropped too: a field that had the keyboard on the
+            // outgoing screen must not arrive focused on the incoming one.
+            .onChange(of: isActive) { _, nowActive in
+                guard nowActive else {
+                    isFocused = false
+                    return
+                }
+
+                if text != initialText { text = initialText }
+            }
             .textFieldStyle(.roundedBorder)
             .frame(maxWidth: .infinity)
             // Only contribute keyboard-toolbar items when THIS field is
@@ -1558,6 +1594,7 @@ private struct MobTextField: View {
 
 private struct MobToggle: View {
     let node: MobNode
+    @Environment(\.mobScreenIsActive) private var isActive
     @State private var isOn: Bool
 
     init(node: MobNode) {
@@ -1571,7 +1608,16 @@ private struct MobToggle: View {
             .onChange(of: isOn) { _, newValue in
                 node.onChangeBool?(newValue)
             }
-            // Re-seed from the node when the BEAM's value changes under us.
+            // Re-seed when this screen becomes active, not only when the value
+            // changes. `onChange(of:)` fires on a VALUE change, and slots
+            // alternate, so screen C reuses screen A's view identities — if
+            // both have `checked == false`, the default, the value never
+            // changes and C silently inherits whatever the user toggled on A.
+            // That is the common case, not an edge one.
+            .onChange(of: isActive) { _, nowActive in
+                if nowActive, node.checked != isOn { isOn = node.checked }
+            }
+            // Still needed for a BEAM-driven change while the screen is up.
             //
             // `State(initialValue:)` runs once per view identity, and before
             // MOB-129 a navigation destroyed every identity, so arriving on a
@@ -1599,6 +1645,7 @@ private struct MobToggle: View {
 
 private struct MobSlider: View {
     let node: MobNode
+    @Environment(\.mobScreenIsActive) private var isActive
     @State private var value: Double
 
     init(node: MobNode) {
@@ -1619,10 +1666,13 @@ private struct MobSlider: View {
             .onChange(of: value) { _, newValue in
                 node.onChangeFloat?(newValue)
             }
-            // Re-seed from the node when the BEAM's value changes under us.
-            // See MobToggle above: without this a slider inherits the position
-            // of whatever slider sat at the same slot two navigations back,
-            // because MOB-129 keeps view identities alive across navigation.
+            // Re-seed on activation. See MobToggle: a value-change watcher
+            // alone misses the common case where both screens carry the same
+            // value, which is exactly when the stale one is invisible.
+            .onChange(of: isActive) { _, nowActive in
+                if nowActive, node.value != value { value = node.value }
+            }
+            // Still needed for a BEAM-driven change while the screen is up.
             .onChange(of: node.value) { _, fromBeam in
                 if fromBeam != value { value = fromBeam }
             }
@@ -2352,7 +2402,12 @@ public struct MobRootView: View {
         .environment(\.mobAvailableSheetHeight, availableSheetHeight)
         .ignoresSafeArea(.container, edges: [.bottom, .horizontal])
         .onChange(of: model.rootVersion) {
-            applyRoot(model.root, transition: model.transition, navVersion: model.navVersion)
+            applyRoot(
+                model.root,
+                transition: model.transition,
+                navVersion: model.navVersion,
+                replacesStack: model.replacesStack
+            )
         }
         // Notify Elixir when the OS appearance toggles so subscribers
         // (Mob.Device → Mob.Theme.Adaptive consumers) can re-resolve.
@@ -2405,7 +2460,12 @@ public struct MobRootView: View {
     /// A `"none"` render is the steady-state path and updates the active slot
     /// directly: same slot, same identity, so SwiftUI diffs. That is the 65.7 ms
     /// path a navigation now also takes.
-    private func applyRoot(_ newRoot: MobNode?, transition t: String, navVersion: Int) {
+    private func applyRoot(
+        _ newRoot: MobNode?,
+        transition t: String,
+        navVersion: Int,
+        replacesStack: Bool
+    ) {
         guard t != "none" else {
             slots[activeSlot] = newRoot
             return
@@ -2419,15 +2479,15 @@ public struct MobRootView: View {
         let incoming = 1 - activeSlot
         let outgoing = activeSlot
 
+        let crossfading = t == "reset"
+        let releasing = replacesStack
+
         // Seat the incoming tree off-screen on the side it should arrive from,
         // OUTSIDE any animation, so the placement itself is not animated.
         slotOffset[incoming] = enterOffset(t)
-        slotOpacity[incoming] = (t == "reset") ? 0 : 1
+        slotOpacity[incoming] = crossfading ? 0 : 1
         slots[incoming] = newRoot
         activeSlot = incoming
-
-        let crossfading = animation(of: t) == "reset"
-        let releasing = replacesStack(t)
 
         let settle = {
             slotOffset[incoming] = 0
@@ -2445,7 +2505,14 @@ public struct MobRootView: View {
         // it until the animation completes is what lets the opacity actually
         // play.
         let release = {
-            guard releasing else { return }
+            // `activeSlot != outgoing` is the precondition, and it is not
+            // optional. This closure runs on the animation's completion, and a
+            // second navigation arriving before it settles reuses the very slot
+            // it captured — a reset followed within 0.25s by a push makes
+            // `outgoing` the ACTIVE slot. Clearing it then blanks the screen the
+            // user is looking at, and nothing recovers until that screen
+            // repaints, which a mount-once screen never does.
+            guard releasing, activeSlot != outgoing else { return }
             slots[outgoing] = nil
             slotOffset[outgoing] = 0
             slotOpacity[outgoing] = 1
@@ -2459,29 +2526,9 @@ public struct MobRootView: View {
         }
     }
 
-    /// The animation half of a transition.
-    ///
-    /// The router sends `push_replace` / `pop_replace` / `reset_replace` when a
-    /// navigation replaces the stack. Two independent facts travel in one atom:
-    /// the prefix says how to animate, the suffix says the outgoing screen is
-    /// unreachable. Splitting them here means neither is inferred from the
-    /// other, which is the bug this replaced — the release used to key on the
-    /// animation name, so a documented `reset_to(transition: :push)` retained a
-    /// screen nobody could reach, and a `switch_tab(transition: :reset)`
-    /// released one the user can switch straight back to.
-    private func animation(of t: String) -> String {
-        t.hasSuffix("_replace") ? String(t.dropLast("_replace".count)) : t
-    }
-
-    /// Whether this navigation replaced the stack, making the outgoing screen
-    /// unreachable and its retained tree pure cost.
-    private func replacesStack(_ t: String) -> Bool {
-        t.hasSuffix("_replace")
-    }
-
     /// Where an incoming screen starts, before it slides in.
     private func enterOffset(_ t: String) -> CGFloat {
-        switch animation(of: t) {
+        switch t {
         case "push": return containerWidth
         case "pop": return -containerWidth
         default: return 0
@@ -2491,7 +2538,7 @@ public struct MobRootView: View {
     /// Where an outgoing screen ends up. It stays there, parked off-screen,
     /// until a later navigation reuses its slot.
     private func exitOffset(_ t: String) -> CGFloat {
-        switch animation(of: t) {
+        switch t {
         case "push": return -containerWidth
         case "pop": return containerWidth
         default: return 0
@@ -2499,7 +2546,7 @@ public struct MobRootView: View {
     }
 
     private func navAnimation(_ t: String) -> Animation? {
-        switch animation(of: t) {
+        switch t {
         case "push", "pop":
             return .spring(response: 0.3, dampingFraction: 0.85)
         case "reset":

--- a/ios/MobViewModel.swift
+++ b/ios/MobViewModel.swift
@@ -47,8 +47,18 @@ import QuartzCore
         }
     }
 
-    @objc public func setRoot(_ node: MobNode?, transition: String) {
+    /// Whether the most recent `setRoot` replaced the navigation stack.
+    ///
+    /// Read by `MobRootView` to decide whether the outgoing screen is still
+    /// reachable and therefore worth retaining. Not `@Published`: it is
+    /// consumed inside the same `rootVersion` change that carried it, and
+    /// publishing it would trigger a second render for a value that never
+    /// changes independently.
+    public var replacesStack: Bool = false
+
+    @objc public func setRoot(_ node: MobNode?, transition: String, replacesStack: Bool) {
         DispatchQueue.main.async {
+            self.replacesStack = replacesStack
             let measuring = mob_native_stats_enabled() != 0
             let start = measuring ? CACurrentMediaTime() : 0
 

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -2628,15 +2628,19 @@ static ERL_NIF_TERM nif_set_root(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     tap_build_count = 0;
     enif_mutex_unlock(tap_mutex);
 
-    // A non-"none" transition is what makes MobViewModel bump navVersion, and
-    // MobRootView keys the whole tree on `.id(currentNavVersion)` — so every
-    // view identity is destroyed and rebuilt. Bump the frame generation in
-    // lockstep: trackers belonging to the outgoing tree captured the old
-    // generation and are refused from here on, which is the only thing that
-    // stops them re-registering at mid-animation coordinates while they slide
-    // away. (`.move` transitions change their global frames continuously, so
-    // they keep firing onChange the whole way out; tree membership alone can't
-    // reject them when both screens tag the same :id.)
+    // Bump the frame generation on a real navigation, so trackers belonging to
+    // the OUTGOING tree — which captured the old generation — are refused from
+    // here on. That is the only thing that stops them re-registering at
+    // mid-animation coordinates while they slide away, and it is also what
+    // keeps two screens sharing an `:id` from clobbering each other's entry.
+    //
+    // Since MOB-129 the outgoing tree is no longer destroyed, so a parked
+    // tracker's stamp stays stale for as long as it is parked. That is the
+    // intended half. The returning half is handled in MobFrameTracker, which
+    // re-seeds its stamp when its slot becomes active again — without that,
+    // a screen you pop back to would be refused for ever. (`.move` transitions change their global
+    // frames continuously, so they keep firing onChange the whole way out; tree membership alone
+    // can't reject them when both screens tag the same :id.)
     if (strcmp(transition, "none") != 0)
         mob_bump_frame_generation();
 

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -2654,7 +2654,18 @@ static ERL_NIF_TERM nif_set_root(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     }
 
     NSString *transitionStr = [NSString stringWithUTF8String:transition];
-    [[MobViewModel shared] setRoot:node transition:transitionStr];
+
+    // Root-only sidecar from Mob.Renderer, set when the navigation REPLACED the
+    // stack. Deliberately not folded into the transition atom: that atom's name
+    // reaches Android as a raw string and MainActivity.kt matches
+    // "push"/"pop"/"reset" with an exact `when`, so any value outside that set
+    // falls through to no animation at all. Keeping the flag here leaves the
+    // wire vocabulary closed, and a host that does not read this key simply
+    // keeps its previous behaviour.
+    id replacesRaw = ((NSDictionary *)json)[@"replaces_stack"];
+    BOOL replacesStack = [replacesRaw isKindOfClass:[NSNumber class]] && [replacesRaw boolValue];
+
+    [[MobViewModel shared] setRoot:node transition:transitionStr replacesStack:replacesStack];
 
     return enif_make_atom(env, "ok");
 }

--- a/lib/mob/renderer.ex
+++ b/lib/mob/renderer.ex
@@ -227,14 +227,24 @@ defmodule Mob.Renderer do
   `transition` is an atom for the nav animation: `:push`, `:pop`, `:reset` or
   `:none`, defaulting to `:none` (instant swap).
 
-  The router additionally sends `:push_replace`, `:pop_replace` and
-  `:reset_replace` for a navigation that REPLACES the stack. Native reads the
-  animation from the prefix and the suffix tells it the outgoing screen is
-  unreachable, so it can release the view tree it would otherwise retain for a
-  return that can never happen. Callers never construct these; `Mob.Socket`
-  still validates the public `:push | :pop | :reset` vocabulary.
+  For a navigation that REPLACES the stack, the router passes
+  `{animation, :replace}` instead. The animation half still reaches
+  `set_transition/1` as a plain atom — the vocabulary native matches on stays
+  closed — and the replacement half is emitted as a `"replaces_stack"` key on
+  the JSON root, which tells native the outgoing screen is unreachable and its
+  retained view tree can be released.
+
+  The flag is deliberately NOT folded into the transition atom. That atom's name
+  reaches Android as a raw string and `MainActivity.kt` matches
+  `"push"`/`"pop"`/`"reset"` with an exact `when`, so any value outside that set
+  falls through to no animation at all. An unknown JSON key is skipped by every
+  parser on both platforms, so a host that does not read it keeps its behaviour.
+
+  Callers never construct the tuple; `Mob.Socket` validates the public
+  `:push | :pop | :reset` vocabulary.
   """
-  @spec render(map(), atom(), module() | atom(), atom()) :: {:ok, :json_tree} | {:error, term()}
+  @spec render(map(), atom(), module() | atom(), atom() | {atom(), :replace}) ::
+          {:ok, :json_tree} | {:error, term()}
   def render(tree, platform, nif \\ @default_nif, transition \\ :none) do
     theme = Theme.current()
 

--- a/lib/mob/renderer.ex
+++ b/lib/mob/renderer.ex
@@ -224,8 +224,15 @@ defmodule Mob.Renderer do
   Loads the active `Mob.Theme`, clears the tap registry, serialises the tree
   to JSON, and calls `set_root/1` on the NIF. Returns `{:ok, :json_tree}`.
 
-  `transition` is an atom (`:push`, `:pop`, `:reset`, `:none`) for the nav
-  animation. Defaults to `:none` (instant swap).
+  `transition` is an atom for the nav animation: `:push`, `:pop`, `:reset` or
+  `:none`, defaulting to `:none` (instant swap).
+
+  The router additionally sends `:push_replace`, `:pop_replace` and
+  `:reset_replace` for a navigation that REPLACES the stack. Native reads the
+  animation from the prefix and the suffix tells it the outgoing screen is
+  unreachable, so it can release the view tree it would otherwise retain for a
+  return that can never happen. Callers never construct these; `Mob.Socket`
+  still validates the public `:push | :pop | :reset` vocabulary.
   """
   @spec render(map(), atom(), module() | atom(), atom()) :: {:ok, :json_tree} | {:error, term()}
   def render(tree, platform, nif \\ @default_nif, transition \\ :none) do

--- a/lib/mob/renderer.ex
+++ b/lib/mob/renderer.ex
@@ -248,10 +248,30 @@ defmodule Mob.Renderer do
       platform: platform
     }
 
+    # Split the animation from the stack-replacement flag. The router sends
+    # `{animation, :replace}` for a navigation that replaces the stack; native
+    # needs both facts and they must not be inferred from each other.
+    #
+    # The animation goes on the existing channel with an UNCHANGED vocabulary,
+    # because `set_transition/1`'s atom name reaches Android as a raw string and
+    # `MainActivity.kt` matches it exactly. The flag rides on the JSON root,
+    # where an unknown key is ignored by both platforms' parsers, so an old host
+    # simply keeps its current behaviour instead of losing its animation.
+    {animation, replaces_stack?} =
+      case transition do
+        {anim, :replace} -> {anim, true}
+        anim -> {anim, false}
+      end
+
     nif.clear_taps()
-    nif.set_transition(transition)
+    nif.set_transition(animation)
 
     prepared = Mob.RenderStats.time(:prepare_us, fn -> prepare(tree, nif, platform, ctx) end)
+
+    # Root-only sidecar. `mob_node_from_dict` and Compose's `toMobNode` both
+    # read named keys and ignore the rest, so this is additive on the wire:
+    # a host that does not know it behaves exactly as it did.
+    prepared = if replaces_stack?, do: Map.put(prepared, "replaces_stack", true), else: prepared
 
     json =
       Mob.RenderStats.time(:encode_us, fn ->

--- a/lib/mob/router.ex
+++ b/lib/mob/router.ex
@@ -528,7 +528,14 @@ defmodule Mob.Router do
       Mob.Nav.history(state.nav) != [] ->
         state = drop_entry(state, dead_pid)
         [previous | rest] = Mob.Nav.history(state.nav)
-        state = make_current(%{state | nav: Mob.Nav.put_history(state.nav, rest)}, previous, :pop)
+
+        state =
+          make_current(
+            %{state | nav: Mob.Nav.put_history(state.nav, rest)},
+            previous,
+            replacing(:pop)
+          )
+
         paint(previous, :none, state)
         state
 
@@ -548,7 +555,10 @@ defmodule Mob.Router do
       # switch/3 parks the dead entry under the outgoing stack; drop it straight
       # after, so nothing can restore a corpse by switching back.
       nav = Mob.Nav.drop_parked(nav, &(&1.pid == entry.pid))
-      state = make_current(%{state | nav: nav}, live, :pop)
+      # Tagged for the same reason the sibling recovery branch is: `entry` is a
+      # corpse and has just been dropped from the parked list, so the tree the
+      # presenter is holding for it can never be shown again.
+      state = make_current(%{state | nav: nav}, live, replacing(:pop))
       paint(live, :none, state)
       state
     else
@@ -694,7 +704,11 @@ defmodule Mob.Router do
         state = stop_screen(state.current, state)
 
         state =
-          make_current(%{state | nav: Mob.Nav.put_history(state.nav, rest)}, previous, :pop)
+          make_current(
+            %{state | nav: Mob.Nav.put_history(state.nav, rest)},
+            previous,
+            replacing(:pop)
+          )
 
         do_paint(previous, :none, state, mode)
         state
@@ -712,7 +726,10 @@ defmodule Mob.Router do
         ]
 
         state = Enum.reduce(discarded, state, &stop_screen/2)
-        state = make_current(%{state | nav: Mob.Nav.put_history(state.nav, [])}, root, :pop)
+
+        state =
+          make_current(%{state | nav: Mob.Nav.put_history(state.nav, [])}, root, replacing(:pop))
+
         do_paint(root, :none, state, mode)
         state
 
@@ -909,7 +926,11 @@ defmodule Mob.Router do
         state = Enum.reduce(discarded, state, &stop_screen/2)
 
         state =
-          make_current(%{state | nav: Mob.Nav.put_history(state.nav, rest)}, previous, :pop)
+          make_current(
+            %{state | nav: Mob.Nav.put_history(state.nav, rest)},
+            previous,
+            replacing(:pop)
+          )
 
         do_paint(previous, :none, state, mode)
         state

--- a/lib/mob/router.ex
+++ b/lib/mob/router.ex
@@ -839,17 +839,17 @@ defmodule Mob.Router do
   # :reset)` is also documented, does NOT replace the stack — a parked tab can
   # be switched back to — and was released, throwing away the retention.
   #
-  # Encoded as a suffixed atom rather than a new wire field: `set_transition/1`
-  # already carries an atom end to end and native reads its name directly, so
-  # this needs no NIF arity change, no JSON schema change, and no change to the
-  # public `:push | :pop | :reset` vocabulary callers use. An older native build
-  # that does not know the suffix falls through to its default case: no slide,
-  # no release, which is a cosmetic degrade rather than a break.
-  defp replacing(:push), do: :push_replace
-  defp replacing(:pop), do: :pop_replace
-  defp replacing(:reset), do: :reset_replace
+  # Carried as a TUPLE rather than a suffixed atom. A suffix (`:reset_replace`)
+  # was tried first and was wrong: `set_transition/1`'s atom name reaches
+  # Android as a raw string, and `MainActivity.kt`'s `when` matches
+  # "push"/"pop"/"reset" exactly, so a suffixed value fell to `else` and every
+  # `reset_to` silently lost its animation. Those files are app-owned and never
+  # re-rendered, so a template fix would not have reached existing apps either.
+  # The tuple keeps the wire vocabulary closed — `Mob.Renderer` unwraps it and
+  # still sends a plain `:push | :pop | :reset | :none` — and puts the flag on
+  # the JSON root, which both platforms already ignore when unknown.
   defp replacing(:none), do: :none
-  defp replacing(other), do: other
+  defp replacing(transition), do: {transition, :replace}
 
   defp reset_resolved(new_module, mount_params, transition, state, mode) do
     case start_screen(new_module, mount_params, state) do

--- a/lib/mob/router.ex
+++ b/lib/mob/router.ex
@@ -825,6 +825,32 @@ defmodule Mob.Router do
     end
   end
 
+  # A navigation that REPLACES the navigation stack, tagged so native can tell.
+  #
+  # Native needs two independent facts: which animation to play, and whether the
+  # outgoing screen is still reachable. Since MOB-129 it keeps the outgoing
+  # screen's view tree so popping back diffs rather than rebuilds, and holding a
+  # tree nobody can navigate back to is pure cost.
+  #
+  # Those two facts were conflated because both travelled as one atom. Keying
+  # the release on the animation name got it wrong in both directions:
+  # `reset_to(..., transition: :push)` is documented and replaces the stack, but
+  # read as a push and was retained for ever; `switch_tab(..., transition:
+  # :reset)` is also documented, does NOT replace the stack — a parked tab can
+  # be switched back to — and was released, throwing away the retention.
+  #
+  # Encoded as a suffixed atom rather than a new wire field: `set_transition/1`
+  # already carries an atom end to end and native reads its name directly, so
+  # this needs no NIF arity change, no JSON schema change, and no change to the
+  # public `:push | :pop | :reset` vocabulary callers use. An older native build
+  # that does not know the suffix falls through to its default case: no slide,
+  # no release, which is a cosmetic degrade rather than a break.
+  defp replacing(:push), do: :push_replace
+  defp replacing(:pop), do: :pop_replace
+  defp replacing(:reset), do: :reset_replace
+  defp replacing(:none), do: :none
+  defp replacing(other), do: other
+
   defp reset_resolved(new_module, mount_params, transition, state, mode) do
     case start_screen(new_module, mount_params, state) do
       {:ok, entry, state} ->
@@ -832,7 +858,11 @@ defmodule Mob.Router do
         state = Enum.reduce(discarded, state, &stop_screen/2)
 
         state =
-          make_current(%{state | nav: Mob.Nav.put_history(state.nav, [])}, entry, transition)
+          make_current(
+            %{state | nav: Mob.Nav.put_history(state.nav, [])},
+            entry,
+            replacing(transition)
+          )
 
         do_paint(entry, :none, state, mode)
         state
@@ -861,7 +891,7 @@ defmodule Mob.Router do
         # exited between collection and its synchronous preparation call.
         Mob.ScreenState.delete_all()
         nav = reset_navigation(state.nav, new_module)
-        state = make_current(%{state | nav: nav}, entry, transition)
+        state = make_current(%{state | nav: nav}, entry, replacing(transition))
         do_paint(entry, :none, state, mode)
         state
 

--- a/lib/mob/sender.ex
+++ b/lib/mob/sender.ex
@@ -74,6 +74,21 @@ defmodule Mob.Sender do
   """
   @type screen_ref :: reference() | atom()
 
+  @typedoc """
+  A navigation transition, optionally tagged as replacing the stack.
+
+  The bare atom is the wire vocabulary the platforms understand. The
+  `{transition, :replace}` form additionally says the outgoing screen's process
+  is gone and its retained view tree can be released once the animation ends;
+  `Mob.Renderer` unwraps it and still sends a plain atom.
+
+  Only `activate/2` and `activate_frame/2` take this form. `render/5,6` are
+  always called with a plain atom; the reserved transition is substituted into
+  a pending render inside `handle_cast/2`, after the public function has been
+  called, so the tuple never crosses that boundary.
+  """
+  @type transition :: atom() | {atom(), :replace}
+
   defstruct active: nil,
             pending: %{},
             reserved_transition: nil,
@@ -134,13 +149,13 @@ defmodule Mob.Sender do
 
   A `:none` transition only activates the screen and creates no reservation.
   """
-  @spec activate(screen_ref(), atom()) :: :ok
+  @spec activate(screen_ref(), transition()) :: :ok
   def activate(ref, transition) do
     if running?(), do: GenServer.call(__MODULE__, {:activate, ref, transition}), else: :ok
   end
 
   @doc false
-  @spec activate_frame(screen_ref(), atom()) :: reference() | nil
+  @spec activate_frame(screen_ref(), transition()) :: reference() | nil
   def activate_frame(ref, transition) do
     if running?() do
       GenServer.call(__MODULE__, {:activate_frame, ref, transition})

--- a/mix.exs
+++ b/mix.exs
@@ -207,7 +207,9 @@ defmodule Mob.MixProject do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/onboarding", "test/onboarding/support"]
+  defp elixirc_paths(:test),
+    do: ["lib", "test/support", "test/onboarding", "test/onboarding/support"]
+
   defp elixirc_paths(_), do: ["lib"]
 
   defp package do

--- a/test/mob/component_server_test.exs
+++ b/test/mob/component_server_test.exs
@@ -284,9 +284,13 @@ defmodule Mob.ComponentServerTest do
       assert Mob.ComponentServer.get_handle(pid) == -1
       assert MockNIF.calls() == []
 
+      ref = Process.monitor(pid)
       Process.exit(pid, :shutdown)
-      # terminate/2 runs asynchronously relative to exit; give it a beat.
-      Process.sleep(10)
+
+      # Wait for the process to actually be gone rather than sleeping a fixed
+      # 10 ms and hoping. `terminate/2` runs before the exit signal completes,
+      # so DOWN means the callback has finished — the thing this asserts about.
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 500
       assert MockNIF.calls() == []
     end
 
@@ -303,8 +307,10 @@ defmodule Mob.ComponentServerTest do
 
       assert Mob.ComponentServer.get_handle(pid) == 0
 
+      ref = Process.monitor(pid)
       Process.exit(pid, :shutdown)
-      Process.sleep(10)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 500
       assert {:deregister_component, [0]} in MockNIF.calls()
     end
 
@@ -447,8 +453,9 @@ defmodule Mob.ComponentServerTest do
           send(pid, {:component_event, "tapped", "{}"})
           assert_receive {:component_changed, :exhausted, Recorder}
 
+          ref = Process.monitor(pid)
           Process.exit(pid, :shutdown)
-          Process.sleep(10)
+          assert_receive {:DOWN, ^ref, :process, ^pid, _}, 500
         end)
 
       assert log =~ "component slot pool exhausted"

--- a/test/mob/listener_test.exs
+++ b/test/mob/listener_test.exs
@@ -6,10 +6,7 @@ defmodule Mob.ListenerTest do
   alias Mob.Listener
 
   setup do
-    case Process.whereis(Listener) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Listener)
 
     :ok
   end

--- a/test/mob/native_parked_screen_test.exs
+++ b/test/mob/native_parked_screen_test.exs
@@ -80,6 +80,42 @@ defmodule Mob.NativeParkedScreenTest do
       assert body =~ "onChange(of: node.checked)"
     end
 
+    test "the toggle re-seeds on activation, not only on a value change" do
+      # `onChange(of:)` fires on a VALUE change, and slots alternate — screen C
+      # reuses screen A's view identities. If both carry `checked == false`, the
+      # default, the value never changes and C silently inherits whatever the
+      # user toggled on A. That is the common case, and a value watcher alone
+      # cannot see it.
+      body = region(code_only(@ios), "private struct MobToggle: View {", "\n}\n")
+      assert body =~ "@Environment(\\.mobScreenIsActive) private var isActive"
+
+      assert body =~
+               ~r/\.onChange\(of: isActive\) \{ _, nowActive in\s*if nowActive, node\.checked != isOn/,
+             "the toggle must re-seed when its screen becomes active"
+    end
+
+    test "the slider re-seeds on activation too" do
+      body = region(code_only(@ios), "private struct MobSlider: View {", "\n}\n")
+      assert body =~ "@Environment(\\.mobScreenIsActive) private var isActive"
+
+      assert body =~
+               ~r/\.onChange\(of: isActive\) \{ _, nowActive in\s*if nowActive, node\.value != value/
+    end
+
+    test "the text field re-seeds on activation and drops focus on park" do
+      # `secure: true` renders a SecureField, so an uncontrolled field whose
+      # prop is "" on both screens carries a PASSWORD across screens, not just a
+      # stale string. And a field holding the keyboard on the outgoing screen
+      # must not arrive focused on the incoming one.
+      body = region(code_only(@ios), "private struct MobTextField: View {", "\n}\n")
+      assert body =~ "@Environment(\\.mobScreenIsActive) private var isActive"
+
+      assert body =~ ~r/guard nowActive else \{\s*isFocused = false/,
+             "parking must drop focus"
+
+      assert body =~ "if text != initialText { text = initialText }"
+    end
+
     test "the slider re-seeds from the node" do
       body = region(code_only(@ios), "private struct MobSlider: View {", "\n}\n")
       assert body =~ "onChange(of: node.value)"
@@ -102,6 +138,23 @@ defmodule Mob.NativeParkedScreenTest do
       # would leave the BEAM believing a sheet it will see again is gone.
       body = region(code_only(@ios), "private func sendDismissOnce() {", "\n    }")
       assert body =~ "if dismissedByPark { return }"
+    end
+
+    test "the video resumes on the activation transition, not on every render" do
+      # updateUIViewController runs on EVERY SwiftUI update of the active
+      # screen, and a fresh node graph arrives on every BEAM render — so gating
+      # the resume on `isActive` alone restarts a video the user paused, within
+      # one render, on any screen carrying a timer or live data.
+      body =
+        region(
+          code_only(@ios),
+          "func updateUIViewController(_ vc: AVPlayerViewController",
+          "\n    }"
+        )
+
+      assert body =~ "if context.coordinator.wasParked {"
+      assert body =~ "context.coordinator.wasParked = false"
+      assert body =~ "context.coordinator.wasParked = true"
     end
 
     test "a parked video pauses, and only autoplay resumes it" do
@@ -140,25 +193,43 @@ defmodule Mob.NativeParkedScreenTest do
   # Strips comments while tracking string literals, so a `//` inside a string
   # survives and a trailing comment cannot satisfy an assertion.
   defp code_only(source) do
-    source
-    |> String.split("\n")
-    |> Enum.map(&strip_line/1)
-    |> Enum.join("\n")
+    scan(source, :code, [])
   end
 
-  defp strip_line(line), do: strip_line(line, <<>>, false)
-  defp strip_line(<<>>, acc, _in), do: acc
+  # Scans the whole file as one binary, carrying string and block-comment state
+  # ACROSS lines. A per-line scanner reset `in_string` at every newline, which
+  # breaks on Swift's multi-line `"""` literals — MobGpuView.swift embeds MSL
+  # shader source that way, and a `//` inside it was truncated as if it were a
+  # comment. It also never recognised `/* */`, so commented-out code satisfied a
+  # `=~` assertion: a false pass, the inverse of the bug this replaced.
+  defp scan(<<>>, _state, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
 
-  defp strip_line(<<"\\", c::utf8, rest::binary>>, acc, true),
-    do: strip_line(rest, acc <> <<"\\", c::utf8>>, true)
+  defp scan(<<"\\", c::utf8, rest::binary>>, :string, acc),
+    do: scan(rest, :string, [<<c::utf8>>, "\\" | acc])
 
-  defp strip_line(<<"\"", rest::binary>>, acc, in_s),
-    do: strip_line(rest, acc <> "\"", not in_s)
+  defp scan(<<"\"\"\"", rest::binary>>, :code, acc), do: scan(rest, :multiline, ["\"\"\"" | acc])
+  defp scan(<<"\"\"\"", rest::binary>>, :multiline, acc), do: scan(rest, :code, ["\"\"\"" | acc])
 
-  defp strip_line(<<"//", _::binary>>, acc, false), do: acc
+  defp scan(<<c::utf8, rest::binary>>, :multiline, acc),
+    do: scan(rest, :multiline, [<<c::utf8>> | acc])
 
-  defp strip_line(<<c::utf8, rest::binary>>, acc, in_s),
-    do: strip_line(rest, acc <> <<c::utf8>>, in_s)
+  defp scan(<<"\"", rest::binary>>, :code, acc), do: scan(rest, :string, ["\"" | acc])
+  defp scan(<<"\"", rest::binary>>, :string, acc), do: scan(rest, :code, ["\"" | acc])
+  defp scan(<<c::utf8, rest::binary>>, :string, acc), do: scan(rest, :string, [<<c::utf8>> | acc])
+
+  defp scan(<<"//", rest::binary>>, :code, acc), do: scan(rest, :line_comment, acc)
+  defp scan(<<"\n", rest::binary>>, :line_comment, acc), do: scan(rest, :code, ["\n" | acc])
+  defp scan(<<_::utf8, rest::binary>>, :line_comment, acc), do: scan(rest, :line_comment, acc)
+
+  defp scan(<<"/*", rest::binary>>, :code, acc), do: scan(rest, :block_comment, acc)
+  defp scan(<<"*/", rest::binary>>, :block_comment, acc), do: scan(rest, :code, acc)
+
+  defp scan(<<"\n", rest::binary>>, :block_comment, acc),
+    do: scan(rest, :block_comment, ["\n" | acc])
+
+  defp scan(<<_::utf8, rest::binary>>, :block_comment, acc), do: scan(rest, :block_comment, acc)
+
+  defp scan(<<c::utf8, rest::binary>>, :code, acc), do: scan(rest, :code, [<<c::utf8>> | acc])
 
   defp region(source, from, to) do
     [_, rest] = String.split(source, from, parts: 2)

--- a/test/mob/native_parked_screen_test.exs
+++ b/test/mob/native_parked_screen_test.exs
@@ -14,6 +14,8 @@ defmodule Mob.NativeParkedScreenTest do
   purely by prose.
   """
   # credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+  import Mob.Test.NativeSource
+
   use ExUnit.Case, async: true
 
   @ios File.read!(Path.expand("../../ios/MobRootView.swift", __DIR__))
@@ -63,7 +65,7 @@ defmodule Mob.NativeParkedScreenTest do
       # Dropping the gate would also 'fix' the return path, and would reopen
       # what it exists for: an outgoing screen re-registering at mid-animation
       # coordinates, and two screens sharing an :id clobbering each other.
-      code = code_only(@nif)
+      code = code_only(@nif, :objc)
       assert code =~ "mob_bump_frame_generation();"
       assert code =~ "generation < g_frame_generation"
     end
@@ -113,12 +115,43 @@ defmodule Mob.NativeParkedScreenTest do
       assert body =~ ~r/guard nowActive else \{\s*isFocused = false/,
              "parking must drop focus"
 
-      assert body =~ "if text != initialText { text = initialText }"
+      assert body =~ ~r/if text != initialText \{\s*text = initialText/
     end
 
     test "the slider re-seeds from the node" do
       body = region(code_only(@ios), "private struct MobSlider: View {", "\n}\n")
       assert body =~ "onChange(of: node.value)"
+    end
+  end
+
+  describe "a programmatic re-seed is not reported as a user change (MOB-147 B2)" do
+    # `onChange(of:)` sees a value change and nothing about who caused it, so a
+    # re-seed on activation would fire the callback on the INCOMING screen — and
+    # it fires precisely when the values differ, which is the case the re-seed
+    # exists for. The app's handle_event then runs for a control the user never
+    # touched.
+    #
+    # This was first done with a `seeding` latch, armed by the re-seed and
+    # cleared by the observed change. That was order-dependent: two programmatic
+    # writes straddling one SwiftUI pass left it armed for the wrong write and
+    # leaked a change anyway. Comparing against the BEAM's own value is
+    # stateless — a re-seed writes exactly that value and so compares equal,
+    # while a user's gesture never does.
+    for {control, struct_name, watched, from_beam} <- [
+          {"toggle", "MobToggle", "isOn", "node.checked"},
+          {"slider", "MobSlider", "value", "node.value"},
+          {"text field", "MobTextField", "text", "initialText"}
+        ] do
+      test "the #{control} reports a change only when it differs from the BEAM's value" do
+        body = region(code_only(@ios), "private struct #{unquote(struct_name)}: View {", "\n}\n")
+
+        assert body =~
+                 ~r/\.onChange\(of: #{unquote(watched)}\) \{ _, newValue in\s*if newValue != #{Regex.escape(unquote(from_beam))} \{/,
+               "the change watcher must compare against the BEAM's value"
+
+        refute body =~ "seeding",
+               "the order-dependent latch must not come back"
+      end
     end
   end
 
@@ -140,11 +173,18 @@ defmodule Mob.NativeParkedScreenTest do
       assert body =~ "if dismissedByPark { return }"
     end
 
-    test "the video resumes on the activation transition, not on every render" do
-      # updateUIViewController runs on EVERY SwiftUI update of the active
-      # screen, and a fresh node graph arrives on every BEAM render — so gating
-      # the resume on `isActive` alone restarts a video the user paused, within
-      # one render, on any screen carrying a timer or live data.
+    test "a parked video resumes only if it was playing when parked" do
+      # Two traps. Gating the resume on `isActive` alone restarts the video on
+      # every render, because this runs on every update of the active screen and
+      # a fresh node graph arrives on every BEAM render. And gating it on
+      # `autoplay` undoes a pause the user made before navigating away: the park
+      # finds it already paused and does nothing, the return finds
+      # `autoplay && .paused` and plays it.
+      #
+      # An earlier version of this test asserted exactly that `autoplay` form,
+      # with a failure message claiming "a video the user paused must stay
+      # paused" — a message asserting a property its own assertion could not
+      # detect.
       body =
         region(
           code_only(@ios),
@@ -152,23 +192,48 @@ defmodule Mob.NativeParkedScreenTest do
           "\n    }"
         )
 
-      assert body =~ "if context.coordinator.wasParked {"
-      assert body =~ "context.coordinator.wasParked = false"
-      assert body =~ "context.coordinator.wasParked = true"
-    end
+      assert body =~ "if context.coordinator.wasPlaying {"
 
-    test "a parked video pauses, and only autoplay resumes it" do
-      body =
-        region(
-          code_only(@ios),
-          "func updateUIViewController(_ vc: AVPlayerViewController",
-          "\n    }"
-        )
+      # Pin the CONDITION, not just the assignment. Relaxing this to a bare
+      # `} else {` restores exactly the "did a park happen" semantics this
+      # replaced, and every other assertion here still passes.
+      assert body =~
+               ~r/\} else if player\.timeControlStatus != \.paused \{\s*context\.coordinator\.wasPlaying = true/,
+             "only a player that was actually playing may be marked for resume"
 
       assert body =~ "player.pause()"
+    end
 
-      assert body =~ ~r/if autoplay, player\.timeControlStatus == \.paused \{ player\.play\(\) \}/,
-             "a video the user paused must stay paused across a park"
+    test "a video whose src changed is rebuilt, not resumed" do
+      # Slot reuse preserves view identity across DIFFERENT screens, so screen
+      # C's video representable can be screen A's — coordinator, player and all.
+      # `makeUIViewController` does not run again, so without this C shows A's
+      # video, and `wasPlaying` from A's park starts it playing with audio.
+      body =
+        region(
+          code_only(@ios),
+          "func updateUIViewController(_ vc: AVPlayerViewController",
+          "\n    }"
+        )
+
+      assert body =~ ~r/if context\.coordinator\.src != src \{/,
+             "a changed src must be detected before anything resumes"
+
+      rebuild = region(body, "if context.coordinator.src != src {", "return")
+      assert rebuild =~ "context.coordinator.wasPlaying = false"
+      assert rebuild =~ "vc.player = rebuilt"
+
+      # The guard has to come FIRST. Below it, `wasPlaying` resumes a player
+      # that may belong to another screen.
+      assert index_of(body, "context.coordinator.src != src") <
+               index_of(body, "if context.coordinator.wasPlaying {")
+    end
+
+    test "the coordinator records playback state, not that a park happened" do
+      body = region(code_only(@ios), "final class Coordinator {", "\n    }")
+      assert body =~ "var wasPlaying = false"
+      assert body =~ "var src: String?"
+      refute body =~ "wasParked"
     end
 
     test "a parked GPU view stops rendering" do
@@ -192,48 +257,4 @@ defmodule Mob.NativeParkedScreenTest do
 
   # Strips comments while tracking string literals, so a `//` inside a string
   # survives and a trailing comment cannot satisfy an assertion.
-  defp code_only(source) do
-    scan(source, :code, [])
-  end
-
-  # Scans the whole file as one binary, carrying string and block-comment state
-  # ACROSS lines. A per-line scanner reset `in_string` at every newline, which
-  # breaks on Swift's multi-line `"""` literals — MobGpuView.swift embeds MSL
-  # shader source that way, and a `//` inside it was truncated as if it were a
-  # comment. It also never recognised `/* */`, so commented-out code satisfied a
-  # `=~` assertion: a false pass, the inverse of the bug this replaced.
-  defp scan(<<>>, _state, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
-
-  defp scan(<<"\\", c::utf8, rest::binary>>, :string, acc),
-    do: scan(rest, :string, [<<c::utf8>>, "\\" | acc])
-
-  defp scan(<<"\"\"\"", rest::binary>>, :code, acc), do: scan(rest, :multiline, ["\"\"\"" | acc])
-  defp scan(<<"\"\"\"", rest::binary>>, :multiline, acc), do: scan(rest, :code, ["\"\"\"" | acc])
-
-  defp scan(<<c::utf8, rest::binary>>, :multiline, acc),
-    do: scan(rest, :multiline, [<<c::utf8>> | acc])
-
-  defp scan(<<"\"", rest::binary>>, :code, acc), do: scan(rest, :string, ["\"" | acc])
-  defp scan(<<"\"", rest::binary>>, :string, acc), do: scan(rest, :code, ["\"" | acc])
-  defp scan(<<c::utf8, rest::binary>>, :string, acc), do: scan(rest, :string, [<<c::utf8>> | acc])
-
-  defp scan(<<"//", rest::binary>>, :code, acc), do: scan(rest, :line_comment, acc)
-  defp scan(<<"\n", rest::binary>>, :line_comment, acc), do: scan(rest, :code, ["\n" | acc])
-  defp scan(<<_::utf8, rest::binary>>, :line_comment, acc), do: scan(rest, :line_comment, acc)
-
-  defp scan(<<"/*", rest::binary>>, :code, acc), do: scan(rest, :block_comment, acc)
-  defp scan(<<"*/", rest::binary>>, :block_comment, acc), do: scan(rest, :code, acc)
-
-  defp scan(<<"\n", rest::binary>>, :block_comment, acc),
-    do: scan(rest, :block_comment, ["\n" | acc])
-
-  defp scan(<<_::utf8, rest::binary>>, :block_comment, acc), do: scan(rest, :block_comment, acc)
-
-  defp scan(<<c::utf8, rest::binary>>, :code, acc), do: scan(rest, :code, [<<c::utf8>> | acc])
-
-  defp region(source, from, to) do
-    [_, rest] = String.split(source, from, parts: 2)
-    [body | _] = String.split(rest, to, parts: 2)
-    body
-  end
 end

--- a/test/mob/native_parked_screen_test.exs
+++ b/test/mob/native_parked_screen_test.exs
@@ -1,0 +1,168 @@
+defmodule Mob.NativeParkedScreenTest do
+  @moduledoc """
+  A parked screen stands down; a returning screen wakes up (MOB-147, MOB-145).
+
+  MOB-129 keeps the outgoing screen mounted so popping back diffs rather than
+  rebuilds. Before it, "not active" and "not alive" were the same state, so
+  nothing had to ask which it was. Several things were wrong by default the
+  moment they differed, and a post-merge review found two of them silently
+  broken rather than merely wasteful.
+
+  Source-asserted, on comment-stripped source. The stripper here tracks string
+  literals and strips trailing comments, because the first version of it did
+  neither and a review demonstrated both gaps by leaving an assertion satisfied
+  purely by prose.
+  """
+  # credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+  use ExUnit.Case, async: true
+
+  @ios File.read!(Path.expand("../../ios/MobRootView.swift", __DIR__))
+  @gpu File.read!(Path.expand("../../ios/MobGpuView.swift", __DIR__))
+  @nif File.read!(Path.expand("../../ios/mob_nif.m", __DIR__))
+
+  describe "the active-screen signal" do
+    test "each slot publishes whether it is the active one" do
+      code = code_only(@ios)
+      assert code =~ ".environment(\\.mobScreenIsActive, index == activeSlot)"
+    end
+
+    test "it defaults to true" do
+      # Anything rendered outside a slot — the startup and error branches —
+      # must behave as it did before this existed.
+      key = region(code_only(@ios), "struct MobScreenIsActiveKey: EnvironmentKey {", "\n}")
+      assert key =~ "static let defaultValue: Bool = true"
+    end
+
+    test "it is visible outside MobRootView.swift" do
+      # MobGpuView.swift is a separate file and reads it. `private` at file
+      # scope is fileprivate in Swift, so declaring it private compiles here and
+      # fails there.
+      code = code_only(@ios)
+      refute code =~ "private struct MobScreenIsActiveKey"
+      refute code =~ ~r/private extension EnvironmentValues \{[^}]*mobScreenIsActive/s
+    end
+  end
+
+  describe "the frame registry survives a return (MOB-147 B1)" do
+    test "a tracker re-seeds its generation when its slot becomes active" do
+      # Without this the change silently breaks the registry for exactly the
+      # screens it optimises for. The generation is still bumped on every
+      # navigation and stale writes are still refused, but a parked slot's
+      # .onAppear never fires again — so a screen you pop back to keeps a stamp
+      # two navigations old and every write is rejected for ever.
+      tracker = region(code_only(@ios), "private struct MobFrameTracker: ViewModifier {", "\n}\n")
+
+      assert tracker =~ "@Environment(\\.mobScreenIsActive) private var isActive"
+
+      assert tracker =~
+               ~r/\.onChange\(of: isActive\) \{ _, nowActive in\s*guard nowActive else \{ return \}\s*box\.generation = mob_frame_generation\(\)/,
+             "a returning tracker must re-seed before re-registering"
+    end
+
+    test "the generation gate itself is kept" do
+      # Dropping the gate would also 'fix' the return path, and would reopen
+      # what it exists for: an outgoing screen re-registering at mid-animation
+      # coordinates, and two screens sharing an :id clobbering each other.
+      code = code_only(@nif)
+      assert code =~ "mob_bump_frame_generation();"
+      assert code =~ "generation < g_frame_generation"
+    end
+  end
+
+  describe "cross-screen state does not bleed (MOB-147 B2)" do
+    test "the toggle re-seeds from the node" do
+      # State(initialValue:) runs once per view identity. MOB-129 keeps
+      # identities alive across navigation, so without a sync a toggle inherits
+      # the state of whatever toggle sat at the same slot position two
+      # navigations back. lib/mob/socket.ex raises ArgumentError on
+      # transition: :none for this exact hazard.
+      body = region(code_only(@ios), "private struct MobToggle: View {", "\n}\n")
+      assert body =~ "onChange(of: node.checked)"
+    end
+
+    test "the slider re-seeds from the node" do
+      body = region(code_only(@ios), "private struct MobSlider: View {", "\n}\n")
+      assert body =~ "onChange(of: node.value)"
+    end
+  end
+
+  describe "live resources stand down while parked" do
+    test "a parked sheet is dismissed and re-presented on return" do
+      # .sheet presents on the WINDOW, so the slot's allowsHitTesting(false)
+      # does not reach it: a parked sheet would stay visible AND interactive
+      # over the incoming screen.
+      body = region(code_only(@ios), "private struct MobSheetView: View {", "\n}\n")
+      assert body =~ "@Environment(\\.mobScreenIsActive) private var isActive"
+      assert body =~ "dismissedByPark"
+      assert body =~ ~r/\.onChange\(of: isActive\)/
+    end
+
+    test "a park does not report a dismissal to the BEAM" do
+      # The screen is coming back, so the sheet is not closed. Reporting it
+      # would leave the BEAM believing a sheet it will see again is gone.
+      body = region(code_only(@ios), "private func sendDismissOnce() {", "\n    }")
+      assert body =~ "if dismissedByPark { return }"
+    end
+
+    test "a parked video pauses, and only autoplay resumes it" do
+      body =
+        region(
+          code_only(@ios),
+          "func updateUIViewController(_ vc: AVPlayerViewController",
+          "\n    }"
+        )
+
+      assert body =~ "player.pause()"
+
+      assert body =~ ~r/if autoplay, player\.timeControlStatus == \.paused \{ player\.play\(\) \}/,
+             "a video the user paused must stay paused across a park"
+    end
+
+    test "a parked GPU view stops rendering" do
+      # It runs in continuous mode at 60 fps, so a parked one burns the GPU
+      # indefinitely behind the screen the user is looking at.
+      body = region(code_only(@gpu), "func updateUIView(_ view: MobGpuMTKView", "\n    }")
+      assert body =~ "view.isPaused = !isActive"
+    end
+
+    test "the lazy-list latch clears on activation" do
+      # MOB-141's latch reasoned that only navigation changes the container's
+      # identity. MOB-129 made nothing change it, so a list at the same slot
+      # position on a different screen would inherit the previous list's latch.
+      body = region(code_only(@ios), "private struct MobLazyList: View {", "\n}\n")
+
+      assert body =~
+               ~r/\.onChange\(of: isActive\) \{ _, nowActive in\s*if nowActive \{ firedForCount = nil \}/,
+             "clearing on activation restores the pre-MOB-129 behaviour"
+    end
+  end
+
+  # Strips comments while tracking string literals, so a `//` inside a string
+  # survives and a trailing comment cannot satisfy an assertion.
+  defp code_only(source) do
+    source
+    |> String.split("\n")
+    |> Enum.map(&strip_line/1)
+    |> Enum.join("\n")
+  end
+
+  defp strip_line(line), do: strip_line(line, <<>>, false)
+  defp strip_line(<<>>, acc, _in), do: acc
+
+  defp strip_line(<<"\\", c::utf8, rest::binary>>, acc, true),
+    do: strip_line(rest, acc <> <<"\\", c::utf8>>, true)
+
+  defp strip_line(<<"\"", rest::binary>>, acc, in_s),
+    do: strip_line(rest, acc <> "\"", not in_s)
+
+  defp strip_line(<<"//", _::binary>>, acc, false), do: acc
+
+  defp strip_line(<<c::utf8, rest::binary>>, acc, in_s),
+    do: strip_line(rest, acc <> <<c::utf8>>, in_s)
+
+  defp region(source, from, to) do
+    [_, rest] = String.split(source, from, parts: 2)
+    [body | _] = String.split(rest, to, parts: 2)
+    body
+  end
+end

--- a/test/mob/native_parked_screen_test.exs
+++ b/test/mob/native_parked_screen_test.exs
@@ -57,8 +57,58 @@ defmodule Mob.NativeParkedScreenTest do
       assert tracker =~ "@Environment(\\.mobScreenIsActive) private var isActive"
 
       assert tracker =~
-               ~r/\.onChange\(of: isActive\) \{ _, nowActive in\s*guard nowActive else \{ return \}\s*box\.generation = mob_frame_generation\(\)/,
-             "a returning tracker must re-seed before re-registering"
+               ~r/\.onChange\(of: isActive\) \{ _, nowActive in\s*guard nowActive else \{ return \}\s*box\.generation = mob_frame_generation\(\)\s*record\(id, geo\.frame\(in: \.global\)\)/,
+             "a returning tracker must re-seed AND re-register in the same pass"
+    end
+
+    test "appearing registers, not just re-stamps" do
+      # The other half of the same shape, and it was a live gap: dropping the
+      # `record(...)` from `.onAppear` left the suite green. A view identity
+      # that disappears and comes back (a lazy row scrolled off and on) then
+      # re-stamps itself but registers nothing, so the id is missing from
+      # `element_frames` until some unrelated geometry change writes it.
+      tracker = region(code_only(@ios), "private struct MobFrameTracker: ViewModifier {", "\n}\n")
+      body = region(tracker, ".onAppear {", "\n                            }")
+
+      assert body =~ "box.generation = mob_frame_generation()"
+      assert body =~ "record(id, geo.frame(in: .global))"
+
+      assert index_of(body, "mob_frame_generation()") < index_of(body, "record(id"),
+             "the stamp must be refreshed before the write, or the write is refused"
+    end
+
+    test "the lazy stamp is a fallback for an unstamped tracker, not a re-stamp" do
+      # `record/2` stamps only when the generation is still 0, covering the
+      # non-contractual ordering of `onAppear` against `onChange(initial:)`.
+      # Relaxing that guard to stamp unconditionally would defeat the whole
+      # generation gate: an OUTGOING screen's mid-animation `.move` writes
+      # would re-stamp themselves current and be accepted, which is exactly
+      # what the gate exists to refuse. Nothing caught that before this test.
+      body =
+        region(code_only(@ios), "private func record(_ id: String, _ frame: CGRect) {", "\n    }")
+
+      assert body =~
+               ~r/if box\.generation == 0 \{\s*box\.generation = mob_frame_generation\(\)\s*\}/,
+             "the lazy stamp must be conditional on never having been stamped"
+
+      refute body =~ ~r/^\s*box\.generation = mob_frame_generation\(\)\s*$(?!\s*\})/m
+    end
+
+    test "re-seeding without re-registering would not be a fix" do
+      # Asserting the re-stamp alone is not enough, and this was a live gap:
+      # dropping the `record(...)` left the suite green. A returning screen
+      # would then carry a current generation and have registered nothing, so
+      # `element_frames` and `tap_id` stay empty until some unrelated geometry
+      # change happens to fire the frame watcher — the same silent emptiness
+      # B1 is about, just reached a different way.
+      tracker = region(code_only(@ios), "private struct MobFrameTracker: ViewModifier {", "\n}\n")
+      body = region(tracker, ".onChange(of: isActive)", "\n                            }")
+
+      assert body =~ "box.generation = mob_frame_generation()"
+      assert body =~ "record(id, geo.frame(in: .global))"
+
+      assert index_of(body, "mob_frame_generation()") < index_of(body, "record(id"),
+             "the stamp must be refreshed before the write, or the write is refused"
     end
 
     test "the generation gate itself is kept" do
@@ -162,8 +212,19 @@ defmodule Mob.NativeParkedScreenTest do
       # over the incoming screen.
       body = region(code_only(@ios), "private struct MobSheetView: View {", "\n}\n")
       assert body =~ "@Environment(\\.mobScreenIsActive) private var isActive"
-      assert body =~ "dismissedByPark"
-      assert body =~ ~r/\.onChange\(of: isActive\)/
+
+      watcher = region(body, ".onChange(of: isActive) { _, nowActive in", "\n            }")
+
+      # Parking must actually take the sheet down, and remember that it did.
+      assert watcher =~
+               ~r/\} else if isPresented \{\s*dismissedByPark = true\s*isPresented = false/,
+             "a parked sheet must be dismissed, or it stays over the incoming screen"
+
+      # And returning must put back exactly the sheet the park took down —
+      # only the one the park dismissed, not one the user closed themselves.
+      assert watcher =~
+               ~r/if nowActive \{\s*if dismissedByPark \{\s*dismissedByPark = false\s*isPresented = true/,
+             "a return must re-present only a sheet the park dismissed"
     end
 
     test "a park does not report a dismissal to the BEAM" do

--- a/test/mob/native_screen_slots_test.exs
+++ b/test/mob/native_screen_slots_test.exs
@@ -91,7 +91,7 @@ defmodule Mob.NativeScreenSlotsTest do
              "expected exactly one clear of the outgoing slot, found #{clears - 1}"
 
       # And it must sit behind the release guard, not anywhere earlier.
-      guard_at = index_of(body, "guard releasing else { return }")
+      guard_at = index_of(body, "guard releasing, activeSlot != outgoing else { return }")
       clear_at = index_of(body, "slots[outgoing] = nil")
       assert guard_at < clear_at
     end
@@ -132,42 +132,53 @@ defmodule Mob.NativeScreenSlotsTest do
   end
 
   describe "the release keys on stack replacement, not the animation (MOB-147 S1)" do
-    test "the animation and the replacement flag are read separately" do
-      # Two independent facts travelled as one atom, and keying the release on
-      # the animation name got it wrong in both directions: a documented
-      # `reset_to(transition: :push)` replaces the stack but read as a push and
-      # was retained for ever, while `switch_tab(transition: :reset)` does not
-      # replace it — a parked tab can be switched back to — and was released.
+    test "the flag comes from the view model, not from the transition string" do
+      # A suffixed atom (`:reset_replace`) was tried and was wrong: the atom's
+      # name reaches Android as a raw string and MainActivity.kt matches
+      # "push"/"pop"/"reset" with an exact `when`, so a suffixed value fell to
+      # `else` and every reset silently lost its animation. Keeping the flag off
+      # the transition string keeps that vocabulary closed.
       code = code_only(@ios)
-      assert code =~ "private func animation(of t: String) -> String {"
-      assert code =~ "private func replacesStack(_ t: String) -> Bool {"
-      assert code =~ ~s|t.hasSuffix("_replace")|
+      assert code =~ "replacesStack: model.replacesStack"
+      assert code =~ "let releasing = replacesStack"
+
+      refute code =~ "_replace\"",
+             "the replacement flag must not ride in the transition string"
     end
 
-    test "the offsets and the animation choice read the prefix" do
+    test "the offsets and the animation choice read the transition directly" do
       code = code_only(@ios)
 
       for fun <- ["enterOffset", "exitOffset", "navAnimation"] do
         body = region(code, "private func #{fun}(", "\n    }")
-
-        assert body =~ "switch animation(of: t)",
-               "#{fun} must read the animation from the prefix, not the raw atom"
+        assert body =~ "switch t {", "#{fun} should switch on the plain transition"
       end
     end
 
-    test "the release reads the suffix, never the animation name" do
+    test "both opacity seeds derive from the same crossfade decision" do
+      # One of the two seeds read the raw transition while the other read a
+      # derived value. With a suffixed atom that made a reset cross-fade or
+      # hard-cut depending on which slot it landed in. Binding once and using it
+      # in both places is what makes that unrepresentable.
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
-      assert body =~ "let releasing = replacesStack(t)"
-      assert body =~ "guard releasing else { return }"
+      assert body =~ ~s|let crossfading = t == "reset"|
+      assert body =~ "slotOpacity[incoming] = crossfading ? 0 : 1"
+      assert body =~ "slotOpacity[outgoing] = crossfading ? 0 : 1"
 
-      refute body =~ ~s|if t == "reset" {|,
-             "keying the release on the animation name is the bug this replaced"
+      refute body =~ ~s|slotOpacity[incoming] = (t == "reset")|,
+             "the incoming seed must not re-derive the decision"
+    end
+
+    test "the release refuses to clear a slot that is now active" do
+      # The closure runs on the animation's completion, and a second navigation
+      # arriving before it settles reuses the slot it captured — a reset
+      # followed quickly by a push makes `outgoing` the ACTIVE slot. Without
+      # this guard the release blanks the screen the user is looking at.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+      assert body =~ "guard releasing, activeSlot != outgoing else { return }"
     end
 
     test "the release happens after the animation, not before it" do
-      # Clearing synchronously removed the outgoing screen in the same turn, so
-      # a reset hard-cut instead of cross-fading — there is no .transition() any
-      # more to animate its removal.
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
       assert body =~ "withAnimation(anim, settle, completion: release)"
 
@@ -183,8 +194,9 @@ defmodule Mob.NativeScreenSlotsTest do
       # unreachable and holding it is pure cost.
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
 
-      assert body =~ ~r/guard releasing else \{ return \}\s*slots\[outgoing\] = nil/,
-             "the outgoing slot is released only for a stack replacement"
+      assert body =~
+               ~r/guard releasing, activeSlot != outgoing else \{ return \}\s*slots\[outgoing\] = nil/,
+             "the outgoing slot is released only for a stack replacement, and only if still parked"
     end
   end
 
@@ -263,26 +275,43 @@ defmodule Mob.NativeScreenSlotsTest do
   # Handled line by line, tracking string literals, so a `//` inside a string
   # (a URL, say) survives and a stray `/*` cannot eat the file.
   defp code_only(source) do
-    source
-    |> String.split("\n")
-    |> Enum.map(&strip_line/1)
-    |> Enum.join("\n")
+    scan(source, :code, [])
   end
 
-  defp strip_line(line), do: strip_line(line, <<>>, false)
+  # Scans the whole file as one binary, carrying string and block-comment state
+  # ACROSS lines. A per-line scanner reset `in_string` at every newline, which
+  # breaks on Swift's multi-line `"""` literals — MobGpuView.swift embeds MSL
+  # shader source that way, and a `//` inside it was truncated as if it were a
+  # comment. It also never recognised `/* */`, so commented-out code satisfied a
+  # `=~` assertion: a false pass, the inverse of the bug this replaced.
+  defp scan(<<>>, _state, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
 
-  defp strip_line(<<>>, acc, _in_string), do: acc
+  defp scan(<<"\\", c::utf8, rest::binary>>, :string, acc),
+    do: scan(rest, :string, [<<c::utf8>>, "\\" | acc])
 
-  defp strip_line(<<"\\", c::utf8, rest::binary>>, acc, true),
-    do: strip_line(rest, acc <> <<"\\", c::utf8>>, true)
+  defp scan(<<"\"\"\"", rest::binary>>, :code, acc), do: scan(rest, :multiline, ["\"\"\"" | acc])
+  defp scan(<<"\"\"\"", rest::binary>>, :multiline, acc), do: scan(rest, :code, ["\"\"\"" | acc])
 
-  defp strip_line(<<"\"", rest::binary>>, acc, in_string),
-    do: strip_line(rest, acc <> "\"", not in_string)
+  defp scan(<<c::utf8, rest::binary>>, :multiline, acc),
+    do: scan(rest, :multiline, [<<c::utf8>> | acc])
 
-  defp strip_line(<<"//", _::binary>>, acc, false), do: acc
+  defp scan(<<"\"", rest::binary>>, :code, acc), do: scan(rest, :string, ["\"" | acc])
+  defp scan(<<"\"", rest::binary>>, :string, acc), do: scan(rest, :code, ["\"" | acc])
+  defp scan(<<c::utf8, rest::binary>>, :string, acc), do: scan(rest, :string, [<<c::utf8>> | acc])
 
-  defp strip_line(<<c::utf8, rest::binary>>, acc, in_string),
-    do: strip_line(rest, acc <> <<c::utf8>>, in_string)
+  defp scan(<<"//", rest::binary>>, :code, acc), do: scan(rest, :line_comment, acc)
+  defp scan(<<"\n", rest::binary>>, :line_comment, acc), do: scan(rest, :code, ["\n" | acc])
+  defp scan(<<_::utf8, rest::binary>>, :line_comment, acc), do: scan(rest, :line_comment, acc)
+
+  defp scan(<<"/*", rest::binary>>, :code, acc), do: scan(rest, :block_comment, acc)
+  defp scan(<<"*/", rest::binary>>, :block_comment, acc), do: scan(rest, :code, acc)
+
+  defp scan(<<"\n", rest::binary>>, :block_comment, acc),
+    do: scan(rest, :block_comment, ["\n" | acc])
+
+  defp scan(<<_::utf8, rest::binary>>, :block_comment, acc), do: scan(rest, :block_comment, acc)
+
+  defp scan(<<c::utf8, rest::binary>>, :code, acc), do: scan(rest, :code, [<<c::utf8>> | acc])
 
   defp region(source, from, to) do
     [_, rest] = String.split(source, from, parts: 2)

--- a/test/mob/native_screen_slots_test.exs
+++ b/test/mob/native_screen_slots_test.exs
@@ -80,7 +80,7 @@ defmodule Mob.NativeScreenSlotsTest do
   end
 
   describe "the mutations a post-merge review proved survived" do
-    test "the outgoing slot is cleared in exactly one place, under the reset branch" do
+    test "the outgoing slot is cleared in exactly one place, under the release guard" do
       # Inserting `slots[outgoing] = nil` anywhere else destroys depth-1
       # retention — the headline benefit — and every other test still passed.
       # The original guard rejected one exact textual shape; this counts.
@@ -90,10 +90,10 @@ defmodule Mob.NativeScreenSlotsTest do
       assert clears - 1 == 1,
              "expected exactly one clear of the outgoing slot, found #{clears - 1}"
 
-      # And it must sit under the reset branch, not anywhere earlier.
-      reset_at = index_of(body, ~s|if t == "reset"|)
+      # And it must sit behind the release guard, not anywhere earlier.
+      guard_at = index_of(body, "guard releasing else { return }")
       clear_at = index_of(body, "slots[outgoing] = nil")
-      assert reset_at < clear_at
+      assert guard_at < clear_at
     end
 
     test "a resize keeps a parked slot on the side it parked on" do
@@ -126,8 +126,53 @@ defmodule Mob.NativeScreenSlotsTest do
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
 
       assert body =~
-               ~r/if let animation = navAnimation\(t\) \{\s*withAnimation\(animation, settle\)\s*\} else \{\s*settle\(\)\s*\}/,
-             "both branches must settle"
+               ~r/if let anim = navAnimation\(t\) \{\s*withAnimation\(anim, settle, completion: release\)\s*\} else \{\s*settle\(\)\s*release\(\)\s*\}/,
+             "both branches must settle, and both must release"
+    end
+  end
+
+  describe "the release keys on stack replacement, not the animation (MOB-147 S1)" do
+    test "the animation and the replacement flag are read separately" do
+      # Two independent facts travelled as one atom, and keying the release on
+      # the animation name got it wrong in both directions: a documented
+      # `reset_to(transition: :push)` replaces the stack but read as a push and
+      # was retained for ever, while `switch_tab(transition: :reset)` does not
+      # replace it — a parked tab can be switched back to — and was released.
+      code = code_only(@ios)
+      assert code =~ "private func animation(of t: String) -> String {"
+      assert code =~ "private func replacesStack(_ t: String) -> Bool {"
+      assert code =~ ~s|t.hasSuffix("_replace")|
+    end
+
+    test "the offsets and the animation choice read the prefix" do
+      code = code_only(@ios)
+
+      for fun <- ["enterOffset", "exitOffset", "navAnimation"] do
+        body = region(code, "private func #{fun}(", "\n    }")
+
+        assert body =~ "switch animation(of: t)",
+               "#{fun} must read the animation from the prefix, not the raw atom"
+      end
+    end
+
+    test "the release reads the suffix, never the animation name" do
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+      assert body =~ "let releasing = replacesStack(t)"
+      assert body =~ "guard releasing else { return }"
+
+      refute body =~ ~s|if t == "reset" {|,
+             "keying the release on the animation name is the bug this replaced"
+    end
+
+    test "the release happens after the animation, not before it" do
+      # Clearing synchronously removed the outgoing screen in the same turn, so
+      # a reset hard-cut instead of cross-fading — there is no .transition() any
+      # more to animate its removal.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+      assert body =~ "withAnimation(anim, settle, completion: release)"
+
+      assert body =~ ~r/\} else \{\s*settle\(\)\s*release\(\)\s*\}/,
+             "the non-animated branch must settle and release too"
     end
   end
 
@@ -138,11 +183,8 @@ defmodule Mob.NativeScreenSlotsTest do
       # unreachable and holding it is pure cost.
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
 
-      assert body =~ ~r/if t == "reset" \{\s*slots\[outgoing\] = nil/,
-             "reset must release the outgoing slot"
-
-      refute body =~ ~r/slots\[outgoing\] = nil\s*\n\s*\}\s*\n\s*\}\s*\z/,
-             "push and pop must NOT clear the outgoing slot"
+      assert body =~ ~r/guard releasing else \{ return \}\s*slots\[outgoing\] = nil/,
+             "the outgoing slot is released only for a stack replacement"
     end
   end
 
@@ -204,7 +246,7 @@ defmodule Mob.NativeScreenSlotsTest do
       # off-screen.
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
       seat = index_of(body, "slotOffset[incoming] = enterOffset(t)")
-      anim = index_of(body, "withAnimation(animation, settle)")
+      anim = index_of(body, "withAnimation(anim, settle, completion: release)")
       assert seat < anim, "the incoming offset must be seated outside the animation"
     end
   end

--- a/test/mob/native_screen_slots_test.exs
+++ b/test/mob/native_screen_slots_test.exs
@@ -79,6 +79,58 @@ defmodule Mob.NativeScreenSlotsTest do
     end
   end
 
+  describe "the mutations a post-merge review proved survived" do
+    test "the outgoing slot is cleared in exactly one place, under the reset branch" do
+      # Inserting `slots[outgoing] = nil` anywhere else destroys depth-1
+      # retention — the headline benefit — and every other test still passed.
+      # The original guard rejected one exact textual shape; this counts.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+      clears = body |> String.split("slots[outgoing] = nil") |> length()
+
+      assert clears - 1 == 1,
+             "expected exactly one clear of the outgoing slot, found #{clears - 1}"
+
+      # And it must sit under the reset branch, not anywhere earlier.
+      reset_at = index_of(body, ~s|if t == "reset"|)
+      clear_at = index_of(body, "slots[outgoing] = nil")
+      assert reset_at < clear_at
+    end
+
+    test "a resize keeps a parked slot on the side it parked on" do
+      # Flipping this sign swings the parked slot on screen after any rotation.
+      code = code_only(@ios)
+      assert code =~ "slotOffset[i] = slotOffset[i] < 0 ? -width : width"
+    end
+
+    test "the slot honours its opacity" do
+      # Deleting this makes the reset crossfade machinery dead code while
+      # leaving it in the source, which reads as working.
+      slot =
+        region(code_only(@ios), "private func screenSlot(_ index: Int) -> some View {", "\n    }")
+
+      assert slot =~ ".opacity(slotOpacity[index])"
+    end
+
+    test "the startup branch keys on both slots being empty" do
+      # `if slots[activeSlot] != nil` looks equivalent and is not: it shows the
+      # startup spinner whenever the ACTIVE slot is empty, even though the other
+      # slot still holds a screen.
+      code = code_only(@ios)
+      assert code =~ "if slots[0] != nil || slots[1] != nil"
+      refute code =~ "if slots[activeSlot] != nil"
+    end
+
+    test "a non-animated navigation still settles" do
+      # Dropping settle() from the else branch leaves the incoming screen parked
+      # off-screen for any transition with no animation.
+      body = region(code_only(@ios), "private func applyRoot(", "\n    }")
+
+      assert body =~
+               ~r/if let animation = navAnimation\(t\) \{\s*withAnimation\(animation, settle\)\s*\} else \{\s*settle\(\)\s*\}/,
+             "both branches must settle"
+    end
+  end
+
   describe "depth-1 retention" do
     test "push and pop keep the outgoing tree; reset drops it" do
       # Holding the outgoing slot is what makes popping back a diff rather than
@@ -157,13 +209,38 @@ defmodule Mob.NativeScreenSlotsTest do
     end
   end
 
+  # Strip comments before asserting, so prose next to the code cannot satisfy an
+  # assertion. Two defects a review demonstrated in the first version:
+  #
+  #   * it stripped only FULL-LINE `//` comments, so deleting the real
+  #     `containerWidth = width` and leaving the text in a trailing comment left
+  #     all 13 tests passing;
+  #   * `~r{/\*.*?\*/}s` ran over the whole file, so a string literal containing
+  #     `/*` paired with a later `*/` swallowed ~200 lines of real code.
+  #
+  # Handled line by line, tracking string literals, so a `//` inside a string
+  # (a URL, say) survives and a stray `/*` cannot eat the file.
   defp code_only(source) do
     source
-    |> String.replace(~r{/\*.*?\*/}s, "")
     |> String.split("\n")
-    |> Enum.map(&String.replace(&1, ~r{^\s*//.*$}, ""))
+    |> Enum.map(&strip_line/1)
     |> Enum.join("\n")
   end
+
+  defp strip_line(line), do: strip_line(line, <<>>, false)
+
+  defp strip_line(<<>>, acc, _in_string), do: acc
+
+  defp strip_line(<<"\\", c::utf8, rest::binary>>, acc, true),
+    do: strip_line(rest, acc <> <<"\\", c::utf8>>, true)
+
+  defp strip_line(<<"\"", rest::binary>>, acc, in_string),
+    do: strip_line(rest, acc <> "\"", not in_string)
+
+  defp strip_line(<<"//", _::binary>>, acc, false), do: acc
+
+  defp strip_line(<<c::utf8, rest::binary>>, acc, in_string),
+    do: strip_line(rest, acc <> <<c::utf8>>, in_string)
 
   defp region(source, from, to) do
     [_, rest] = String.split(source, from, parts: 2)

--- a/test/mob/native_screen_slots_test.exs
+++ b/test/mob/native_screen_slots_test.exs
@@ -15,9 +15,13 @@ defmodule Mob.NativeScreenSlotsTest do
   satisfy would pass against code that does nothing.
   """
   # credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+  import Mob.Test.NativeSource
+
   use ExUnit.Case, async: true
 
   @ios File.read!(Path.expand("../../ios/MobRootView.swift", __DIR__))
+  @nif File.read!(Path.expand("../../ios/mob_nif.m", __DIR__))
+  @view_model File.read!(Path.expand("../../ios/MobViewModel.swift", __DIR__))
 
   describe "identity" do
     test "navigation no longer changes the root's identity" do
@@ -91,9 +95,16 @@ defmodule Mob.NativeScreenSlotsTest do
              "expected exactly one clear of the outgoing slot, found #{clears - 1}"
 
       # And it must sit behind the release guard, not anywhere earlier.
-      guard_at = index_of(body, "guard releasing, activeSlot != outgoing else { return }")
+      guard_at = index_of(body, "guard releasing, token == navToken else { return }")
       clear_at = index_of(body, "slots[outgoing] = nil")
       assert guard_at < clear_at
+
+      # The token must be taken AFTER the increment. Swapping those two lines
+      # leaves `token` one behind for ever, the guard never passes, and nothing
+      # is released — the whole feature inert, with every other assertion here
+      # still green.
+      assert index_of(body, "navToken += 1") < index_of(body, "let token = navToken"),
+             "the token must be read after it is bumped, or the guard never passes"
     end
 
     test "a resize keeps a parked slot on the side it parked on" do
@@ -106,7 +117,11 @@ defmodule Mob.NativeScreenSlotsTest do
       # Deleting this makes the reset crossfade machinery dead code while
       # leaving it in the source, which reads as working.
       slot =
-        region(code_only(@ios), "private func screenSlot(_ index: Int) -> some View {", "\n    }")
+        region(
+          code_only(@ios),
+          "private func screenSlot(_ index: Int) -> some View {",
+          "\n    }"
+        )
 
       assert slot =~ ".opacity(slotOpacity[index])"
     end
@@ -146,6 +161,21 @@ defmodule Mob.NativeScreenSlotsTest do
              "the replacement flag must not ride in the transition string"
     end
 
+    test "the native side actually reads the flag off the root" do
+      # Hardcoding `BOOL replacesStack = NO;` makes the whole feature inert end
+      # to end, and every Swift-side assertion still passes — they only check
+      # the consumer. This checks the producer.
+      body = region(code_only(@nif, :objc), "static ERL_NIF_TERM nif_set_root(", "\n}\n")
+      assert body =~ ~s|((NSDictionary *)json)[@"replaces_stack"]|
+      assert body =~ "[replacesRaw isKindOfClass:[NSNumber class]] && [replacesRaw boolValue]"
+      assert body =~ "setRoot:node transition:transitionStr replacesStack:replacesStack"
+
+      # And the view model must keep it, not drop it on the floor.
+      vm = code_only(@view_model)
+      assert vm =~ "public var replacesStack: Bool = false"
+      assert vm =~ "self.replacesStack = replacesStack"
+    end
+
     test "the offsets and the animation choice read the transition directly" do
       code = code_only(@ios)
 
@@ -169,13 +199,20 @@ defmodule Mob.NativeScreenSlotsTest do
              "the incoming seed must not re-derive the decision"
     end
 
-    test "the release refuses to clear a slot that is now active" do
-      # The closure runs on the animation's completion, and a second navigation
-      # arriving before it settles reuses the slot it captured — a reset
-      # followed quickly by a push makes `outgoing` the ACTIVE slot. Without
-      # this guard the release blanks the screen the user is looking at.
+    test "the release refuses to run if another navigation happened since" do
+      # A slot index is not enough state. `incoming = 1 - activeSlot` alternates,
+      # so a captured slot returns to being non-active every SECOND navigation:
+      # reset, push, pop inside one animation duration leaves the reset's
+      # completion passing an `activeSlot != outgoing` check while the slot holds
+      # the tree the pop just retained. It would clear that tree and snap its
+      # offset outside any animation, mid-slide.
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
-      assert body =~ "guard releasing, activeSlot != outgoing else { return }"
+      assert body =~ "navToken += 1"
+      assert body =~ "let token = navToken"
+      assert body =~ "guard releasing, token == navToken else { return }"
+
+      refute body =~ "activeSlot != outgoing",
+             "a slot index only defeats odd-numbered interleaves"
     end
 
     test "the release happens after the animation, not before it" do
@@ -195,8 +232,8 @@ defmodule Mob.NativeScreenSlotsTest do
       body = region(code_only(@ios), "private func applyRoot(", "\n    }")
 
       assert body =~
-               ~r/guard releasing, activeSlot != outgoing else \{ return \}\s*slots\[outgoing\] = nil/,
-             "the outgoing slot is released only for a stack replacement, and only if still parked"
+               ~r/guard releasing, token == navToken else \{ return \}\s*slots\[outgoing\] = nil/,
+             "released only for a stack replacement, and only if no later navigation happened"
     end
   end
 
@@ -205,7 +242,11 @@ defmodule Mob.NativeScreenSlotsTest do
       # Without this the parked slot's subtree is re-evaluated on every render of
       # the active one, and holding it costs more than rebuilding it.
       slot =
-        region(code_only(@ios), "private func screenSlot(_ index: Int) -> some View {", "\n    }")
+        region(
+          code_only(@ios),
+          "private func screenSlot(_ index: Int) -> some View {",
+          "\n    }"
+        )
 
       assert slot =~ ".equatable()"
     end
@@ -226,7 +267,11 @@ defmodule Mob.NativeScreenSlotsTest do
       # honour zero opacity the way UIKit honours zero alpha. A tappable parked
       # screen would resolve handles from a superseded tap-table generation.
       slot =
-        region(code_only(@ios), "private func screenSlot(_ index: Int) -> some View {", "\n    }")
+        region(
+          code_only(@ios),
+          "private func screenSlot(_ index: Int) -> some View {",
+          "\n    }"
+        )
 
       assert slot =~ ".allowsHitTesting(index == activeSlot)"
       assert slot =~ ".accessibilityHidden(index != activeSlot)"
@@ -260,69 +305,6 @@ defmodule Mob.NativeScreenSlotsTest do
       seat = index_of(body, "slotOffset[incoming] = enterOffset(t)")
       anim = index_of(body, "withAnimation(anim, settle, completion: release)")
       assert seat < anim, "the incoming offset must be seated outside the animation"
-    end
-  end
-
-  # Strip comments before asserting, so prose next to the code cannot satisfy an
-  # assertion. Two defects a review demonstrated in the first version:
-  #
-  #   * it stripped only FULL-LINE `//` comments, so deleting the real
-  #     `containerWidth = width` and leaving the text in a trailing comment left
-  #     all 13 tests passing;
-  #   * `~r{/\*.*?\*/}s` ran over the whole file, so a string literal containing
-  #     `/*` paired with a later `*/` swallowed ~200 lines of real code.
-  #
-  # Handled line by line, tracking string literals, so a `//` inside a string
-  # (a URL, say) survives and a stray `/*` cannot eat the file.
-  defp code_only(source) do
-    scan(source, :code, [])
-  end
-
-  # Scans the whole file as one binary, carrying string and block-comment state
-  # ACROSS lines. A per-line scanner reset `in_string` at every newline, which
-  # breaks on Swift's multi-line `"""` literals — MobGpuView.swift embeds MSL
-  # shader source that way, and a `//` inside it was truncated as if it were a
-  # comment. It also never recognised `/* */`, so commented-out code satisfied a
-  # `=~` assertion: a false pass, the inverse of the bug this replaced.
-  defp scan(<<>>, _state, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
-
-  defp scan(<<"\\", c::utf8, rest::binary>>, :string, acc),
-    do: scan(rest, :string, [<<c::utf8>>, "\\" | acc])
-
-  defp scan(<<"\"\"\"", rest::binary>>, :code, acc), do: scan(rest, :multiline, ["\"\"\"" | acc])
-  defp scan(<<"\"\"\"", rest::binary>>, :multiline, acc), do: scan(rest, :code, ["\"\"\"" | acc])
-
-  defp scan(<<c::utf8, rest::binary>>, :multiline, acc),
-    do: scan(rest, :multiline, [<<c::utf8>> | acc])
-
-  defp scan(<<"\"", rest::binary>>, :code, acc), do: scan(rest, :string, ["\"" | acc])
-  defp scan(<<"\"", rest::binary>>, :string, acc), do: scan(rest, :code, ["\"" | acc])
-  defp scan(<<c::utf8, rest::binary>>, :string, acc), do: scan(rest, :string, [<<c::utf8>> | acc])
-
-  defp scan(<<"//", rest::binary>>, :code, acc), do: scan(rest, :line_comment, acc)
-  defp scan(<<"\n", rest::binary>>, :line_comment, acc), do: scan(rest, :code, ["\n" | acc])
-  defp scan(<<_::utf8, rest::binary>>, :line_comment, acc), do: scan(rest, :line_comment, acc)
-
-  defp scan(<<"/*", rest::binary>>, :code, acc), do: scan(rest, :block_comment, acc)
-  defp scan(<<"*/", rest::binary>>, :block_comment, acc), do: scan(rest, :code, acc)
-
-  defp scan(<<"\n", rest::binary>>, :block_comment, acc),
-    do: scan(rest, :block_comment, ["\n" | acc])
-
-  defp scan(<<_::utf8, rest::binary>>, :block_comment, acc), do: scan(rest, :block_comment, acc)
-
-  defp scan(<<c::utf8, rest::binary>>, :code, acc), do: scan(rest, :code, [<<c::utf8>> | acc])
-
-  defp region(source, from, to) do
-    [_, rest] = String.split(source, from, parts: 2)
-    [body | _] = String.split(rest, to, parts: 2)
-    body
-  end
-
-  defp index_of(hay, needle) do
-    case :binary.match(hay, needle) do
-      {i, _} -> i
-      :nomatch -> flunk("expected to find #{inspect(needle)}")
     end
   end
 end

--- a/test/mob/native_source_test.exs
+++ b/test/mob/native_source_test.exs
@@ -1,0 +1,145 @@
+defmodule Mob.Test.NativeSourceTest do
+  @moduledoc """
+  The comment stripper the native assertions run on.
+
+  Every "native side does X" test in this suite is only as good as this
+  module. A stripper that leaves a comment behind lets an assertion pass on
+  prose describing code that was deleted, and one that eats real code makes a
+  correct implementation look missing. Both failures are silent.
+  """
+  use ExUnit.Case, async: true
+
+  import Mob.Test.NativeSource
+
+  describe "comments are removed" do
+    test "a line comment goes, and the newline stays so line numbers hold" do
+      assert code_only("let a = 1 // set a\nlet b = 2\n") == "let a = 1 \nlet b = 2\n"
+    end
+
+    test "a block comment goes" do
+      assert code_only("let a = /* noise */ 1") == "let a =  1"
+    end
+
+    test "commented-out code cannot satisfy an assertion" do
+      refute code_only("// setRoot(node, replacesStack: true)\n") =~ "setRoot"
+    end
+  end
+
+  describe "block comments nest" do
+    # Swift allows `/* /* */ */`. A depth-blind scanner ends the comment at the
+    # first `*/` and hands back the tail as live source, so a call that only
+    # appears inside a commented-out block reads as present.
+    test "an inner close does not end the outer comment" do
+      source = "a()\n/* outer /* inner */ commentedOut() */\nb()\n"
+
+      stripped = code_only(source)
+
+      assert stripped =~ "a()"
+      assert stripped =~ "b()"
+      refute stripped =~ "commentedOut"
+    end
+
+    test "three deep" do
+      refute code_only("/* /* /* x() */ */ */") =~ "x()"
+    end
+
+    # ...but only in Swift. C block comments do not nest, and `ios/*.m` is C.
+    # Applying Swift's rule there has the opposite failure: a comment that
+    # merely *mentions* `/*` — a glob like `ios/*.m`, a quoted C snippet — opens
+    # a level that never closes and swallows the rest of the file, so every
+    # later assertion fails with a message pointing at the assertion.
+    test "not in Objective-C: a comment mentioning a glob does not eat the file" do
+      source = "/* matches ios/*.m */\nsetRoot(c)\n"
+
+      assert code_only(source, :objc) =~ "setRoot(c)"
+      refute code_only(source, :objc) =~ "matches"
+    end
+
+    test "the same input is an unterminated comment in Swift, and says so" do
+      assert_raise RuntimeError, ~r/ended in :block_comment/, fn ->
+        code_only("/* matches ios/*.m */\nsetRoot(c)\n", :swift)
+      end
+    end
+  end
+
+  describe "a stuck scan is loud, not silent" do
+    # Every way this scanner goes wrong leaves it in a non-code state, and from
+    # there it either reports comments as code (false pass) or eats code as
+    # comment (false failure). Raising is what keeps those visible.
+    test "an unterminated string literal raises" do
+      assert_raise RuntimeError, ~r/ended in :string/, fn ->
+        code_only("let s = \"oops\nsetRoot(h)\n")
+      end
+    end
+
+    test "an unterminated block comment raises" do
+      assert_raise RuntimeError, ~r/ended in :block_comment/, fn ->
+        code_only("a()\n/* forgot to close\n")
+      end
+    end
+  end
+
+  describe "Swift raw strings" do
+    # `#"..."#` does not honour `\"` as an escape, so the ordinary escape rule
+    # runs straight past the terminator and leaves the scanner inside a string
+    # for the rest of the file — where every following comment reads as code.
+    test "a trailing backslash does not swallow the terminator" do
+      stripped = code_only(~S|let p = #"C:\path\"#| <> "\nsetRoot(a) // gone\n")
+
+      assert stripped =~ "setRoot(a)"
+      refute stripped =~ "gone"
+    end
+  end
+
+  describe "quotes that are not string delimiters" do
+    # `mob_nif.m` contains `'"'`. Treating that quote as a string delimiter
+    # flips the scanner for the whole rest of the file, and every later
+    # assertion then matches against text it believes is a literal.
+    test "an Objective-C char literal holding a quote does not open a string" do
+      source = ~S|char q = '"'; // gone
+setRoot(node);
+|
+
+      stripped = code_only(source)
+
+      assert stripped =~ "setRoot(node);"
+      refute stripped =~ "gone"
+    end
+
+    test "an escaped char literal is handled too" do
+      assert code_only(~S|char n = '\n'; f();|) =~ "f();"
+    end
+
+    test "a comment marker inside a string literal is not a comment" do
+      assert code_only(~S|let s = "http://example.com"| <> "\n") =~ "http://example.com"
+    end
+
+    test "a comment marker inside a multi-line literal is not a comment" do
+      source = ~s|let shader = """\n// not a comment\n"""\nreal()\n|
+
+      stripped = code_only(source)
+
+      assert stripped =~ "// not a comment"
+      assert stripped =~ "real()"
+    end
+  end
+
+  describe "region/3" do
+    test "returns the text between the markers" do
+      assert region("a FROM body TO c", "FROM", "TO") == " body "
+    end
+
+    # A missing marker used to raise MatchError from String.split's result, or
+    # worse, return an empty region that every later `=~` silently failed
+    # against with a message pointing at the assertion rather than the marker.
+    test "says which marker was missing rather than returning nothing" do
+      assert_raise RuntimeError, ~r/region start not found/, fn ->
+        region("abc", "NOPE", "TO")
+      end
+
+      assert_raise RuntimeError, ~r/region end not found/, fn ->
+        region("a FROM b", "FROM", "NOPE")
+      end
+    end
+  end
+end

--- a/test/mob/nav/multi_stack_test.exs
+++ b/test/mob/nav/multi_stack_test.exs
@@ -126,10 +126,7 @@ defmodule Mob.Nav.MultiStackTest do
   end
 
   setup do
-    case Process.whereis(Mob.Nav.Registry) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, pid} = Mob.Nav.Registry.start_link(TabApp)
     on_exit(fn -> stop_safely(pid) end)

--- a/test/mob/nav/registry_test.exs
+++ b/test/mob/nav/registry_test.exs
@@ -39,10 +39,7 @@ defmodule Mob.Nav.RegistryTest do
 
   setup do
     # Clean up any leftover registry and ensure a fresh state per test
-    case Process.whereis(Mob.Nav.Registry) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     :ok
   end

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -116,19 +116,23 @@ defmodule Mob.Nav.ResetTransitionTest do
   end
 
   describe "the chosen transition reaches the native boundary" do
-    test "a plain reset still cross-fades", %{router: router} do
+    test "a plain reset still cross-fades, and marks the stack replaced", %{router: router} do
       Mob.Router.dispatch(router, "reset_default", %{})
-      assert last_transition() == :reset
+      # `_replace` is the suffix the router adds for a navigation that replaces
+      # the stack. Native reads the animation from the prefix; the suffix tells
+      # it the outgoing screen is unreachable, so the view tree MOB-129 would
+      # otherwise retain for a return can be released. See MOB-147 S1.
+      assert last_transition() == :reset_replace
     end
 
-    test "transition: :push paints a push", %{router: router} do
+    test "transition: :push paints a push and still replaces", %{router: router} do
       Mob.Router.dispatch(router, "reset_push", %{})
-      assert last_transition() == :push
+      assert last_transition() == :push_replace
     end
 
     test "transition: :pop paints a pop", %{router: router} do
       Mob.Router.dispatch(router, "reset_pop", %{})
-      assert last_transition() == :pop
+      assert last_transition() == :pop_replace
     end
 
     test "the stack is still replaced, whatever the animation", %{router: router} do
@@ -164,7 +168,7 @@ defmodule Mob.Nav.ResetTransitionTest do
       # code push. Dropping it would break navigation across an upgrade.
       :ok = GenServer.call(router, {:navigate, {:reset, OtherScreen, %{}}})
 
-      assert last_transition() == :reset
+      assert last_transition() == :reset_replace
       assert Mob.Router.get_current_module(router) == OtherScreen
     end
   end

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -31,6 +31,9 @@ defmodule Mob.Nav.ResetTransitionTest do
     def handle_event("reset_pop", _, socket),
       do: {:noreply, Mob.Socket.reset_to(socket, @other, %{}, transition: :pop)}
 
+    def handle_event("reset_all", _, socket),
+      do: {:noreply, Mob.Socket.reset_to(socket, @other, %{}, scope: :all)}
+
     def handle_event("push_other", _, socket),
       do: {:noreply, Mob.Socket.push_screen(socket, @other)}
   end
@@ -115,6 +118,33 @@ defmodule Mob.Nav.ResetTransitionTest do
   # Whether the frame told native the navigation stack was replaced. Carried on
   # the JSON root rather than in the transition atom, so the transition
   # vocabulary native matches on stays closed — see `replaces?/0`'s callers.
+  # Wait until the navigation has painted at least one frame.
+  #
+  # `Mob.Sender.sync/1` orders only the CALLER's casts, and an async paint
+  # travels router -> screen -> sender, so stepping those processes still races
+  # the flush. How many frames land is not fixed either, which is why callers
+  # assert a property of every frame rather than an exact list.
+  defp await_paint(timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_paint(deadline)
+  end
+
+  defp do_await_paint(deadline) do
+    Mob.Sender.sync(:infinity)
+
+    cond do
+      RecordingNif.roots() != [] ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("no frame was painted within the timeout")
+
+      true ->
+        Process.sleep(10)
+        do_await_paint(deadline)
+    end
+  end
+
   defp replaced_stack? do
     Mob.Sender.sync(:infinity)
     Enum.any?(RecordingNif.roots(), &Map.get(:json.decode(&1), "replaces_stack", false))
@@ -278,12 +308,8 @@ defmodule Mob.Nav.ResetTransitionTest do
       assert :ok = Mob.Test.reset_to(node(), OtherScreen, %{}, transition: :none)
 
       assert Mob.Router.get_current_module(router) == OtherScreen
-      :sys.get_state(:sys.get_state(router).current.pid)
-      Mob.Sender.sync(:infinity)
+      await_paint()
 
-      # Driven synchronously this paints twice; what matters is that no frame
-      # asked for an animation, and that none was tagged.
-      assert RecordingNif.transitions() != []
       assert Enum.all?(RecordingNif.transitions(), &(&1 == :none))
       refute replaced_stack?()
     end
@@ -294,16 +320,12 @@ defmodule Mob.Nav.ResetTransitionTest do
 
       send(router, {:nav_action, {:reset, OtherScreen, %{}, :none}, current})
 
-      # A raw nav action arrives as a message, and its paint is async: the
-      # router tells the incoming screen to render and that screen casts to the
-      # sender. `Mob.Sender.sync/1` only orders the *caller's* own casts, so
-      # step through both processes first or the flush races the paint.
       assert Mob.Router.get_current_module(router) == OtherScreen
-      :sys.get_state(:sys.get_state(router).current.pid)
-      Mob.Sender.sync(:infinity)
+      await_paint()
 
-      assert RecordingNif.roots() != []
-      assert RecordingNif.transitions() == [:none]
+      # Every frame, not an exact list: the count is not fixed and asserting
+      # `== [:none]` was flaky for exactly that reason.
+      assert Enum.all?(RecordingNif.transitions(), &(&1 == :none))
       refute replaced_stack?()
     end
   end
@@ -335,6 +357,20 @@ defmodule Mob.Nav.ResetTransitionTest do
 
       assert Mob.Router.get_current_module(router) == OtherScreen
       assert last_transition() == :pop
+      assert replaced_stack?()
+    end
+  end
+
+  describe "an all-stack reset" do
+    # `scope: :all` discards every parked tab stack as well as the current one,
+    # so it replaces strictly more than the default `scope: :stack` reset. It
+    # went untagged and untested: reverting `replacing/1` on that path alone
+    # left the whole suite green.
+    test "is tagged too", %{router: router} do
+      Mob.Router.dispatch(router, "reset_all", %{})
+
+      assert Mob.Router.get_current_module(router) == OtherScreen
+      assert last_transition() == :reset
       assert replaced_stack?()
     end
   end

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -46,19 +46,30 @@ defmodule Mob.Nav.ResetTransitionTest do
   end
 
   defmodule RecordingNif do
-    def start, do: Agent.start(fn -> [] end, name: __MODULE__)
-    def transitions, do: __MODULE__ |> Agent.get(& &1) |> Enum.reverse()
-    def reset, do: Agent.update(__MODULE__, fn _ -> [] end)
+    def start, do: Agent.start(fn -> [transitions: []] end, name: __MODULE__)
+
+    def transitions,
+      do: __MODULE__ |> Agent.get(&Keyword.get(&1, :transitions, [])) |> Enum.reverse()
+
+    def last_root, do: Agent.get(__MODULE__, &Keyword.get(&1, :last_root))
+    def reset, do: Agent.update(__MODULE__, fn _ -> [transitions: []] end)
 
     def platform, do: :android
     def safe_area, do: {0.0, 0.0, 0.0, 0.0}
     def take_launch_notification, do: :none
     def clear_taps, do: :ok
     def register_tap(_), do: 0
-    def set_root(_json), do: :ok
+
+    def set_root(json) do
+      Agent.update(__MODULE__, fn state -> Keyword.put(state, :last_root, json) end)
+      :ok
+    end
 
     def set_transition(t) do
-      Agent.update(__MODULE__, &[t | &1])
+      Agent.update(__MODULE__, fn state ->
+        Keyword.update(state, :transitions, [t], &[t | &1])
+      end)
+
       :ok
     end
   end
@@ -73,6 +84,18 @@ defmodule Mob.Nav.ResetTransitionTest do
   defp last_transition do
     Mob.Sender.sync(:infinity)
     List.last(RecordingNif.transitions())
+  end
+
+  # Whether the frame told native the navigation stack was replaced. Carried on
+  # the JSON root rather than in the transition atom, so the transition
+  # vocabulary native matches on stays closed — see `replaces?/0`'s callers.
+  defp replaced_stack? do
+    Mob.Sender.sync(:infinity)
+
+    case RecordingNif.last_root() do
+      nil -> false
+      json -> Map.get(:json.decode(json), "replaces_stack", false)
+    end
   end
 
   setup do
@@ -122,17 +145,23 @@ defmodule Mob.Nav.ResetTransitionTest do
       # the stack. Native reads the animation from the prefix; the suffix tells
       # it the outgoing screen is unreachable, so the view tree MOB-129 would
       # otherwise retain for a return can be released. See MOB-147 S1.
-      assert last_transition() == :reset_replace
+      # The atom stays in the closed `:push | :pop | :reset | :none` vocabulary.
+      # Android matches it as a raw string with an exact `when`, so anything
+      # outside that set falls to `else` and silently loses its animation.
+      assert last_transition() == :reset
+      assert replaced_stack?()
     end
 
     test "transition: :push paints a push and still replaces", %{router: router} do
       Mob.Router.dispatch(router, "reset_push", %{})
-      assert last_transition() == :push_replace
+      assert last_transition() == :push
+      assert replaced_stack?()
     end
 
     test "transition: :pop paints a pop", %{router: router} do
       Mob.Router.dispatch(router, "reset_pop", %{})
-      assert last_transition() == :pop_replace
+      assert last_transition() == :pop
+      assert replaced_stack?()
     end
 
     test "the stack is still replaced, whatever the animation", %{router: router} do
@@ -168,7 +197,8 @@ defmodule Mob.Nav.ResetTransitionTest do
       # code push. Dropping it would break navigation across an upgrade.
       :ok = GenServer.call(router, {:navigate, {:reset, OtherScreen, %{}}})
 
-      assert last_transition() == :reset_replace
+      assert last_transition() == :reset
+      assert replaced_stack?()
       assert Mob.Router.get_current_module(router) == OtherScreen
     end
   end

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -30,12 +30,31 @@ defmodule Mob.Nav.ResetTransitionTest do
 
     def handle_event("reset_pop", _, socket),
       do: {:noreply, Mob.Socket.reset_to(socket, @other, %{}, transition: :pop)}
+
+    def handle_event("push_other", _, socket),
+      do: {:noreply, Mob.Socket.push_screen(socket, @other)}
   end
 
   defmodule OtherScreen do
     use Mob.Screen
     def mount(_params, _session, socket), do: {:ok, socket}
     def render(_assigns), do: %{type: :text, props: %{text: "other"}, children: []}
+
+    def handle_event("go_back", _, socket), do: {:noreply, Mob.Socket.pop_screen(socket)}
+
+    def handle_event("push_third", _, socket),
+      do: {:noreply, Mob.Socket.push_screen(socket, Mob.Nav.ResetTransitionTest.ThirdScreen)}
+  end
+
+  defmodule ThirdScreen do
+    use Mob.Screen
+    def mount(_params, _session, socket), do: {:ok, socket}
+    def render(_assigns), do: %{type: :text, props: %{text: "third"}, children: []}
+
+    def handle_event("to_root", _, socket), do: {:noreply, Mob.Socket.pop_to_root(socket)}
+
+    def handle_event("to_other", _, socket),
+      do: {:noreply, Mob.Socket.pop_to(socket, Mob.Nav.ResetTransitionTest.OtherScreen)}
   end
 
   defmodule DemoApp do
@@ -46,13 +65,17 @@ defmodule Mob.Nav.ResetTransitionTest do
   end
 
   defmodule RecordingNif do
-    def start, do: Agent.start(fn -> [transitions: []] end, name: __MODULE__)
+    def start, do: Agent.start(fn -> [transitions: [], roots: []] end, name: __MODULE__)
 
     def transitions,
       do: __MODULE__ |> Agent.get(&Keyword.get(&1, :transitions, [])) |> Enum.reverse()
 
-    def last_root, do: Agent.get(__MODULE__, &Keyword.get(&1, :last_root))
-    def reset, do: Agent.update(__MODULE__, fn _ -> [transitions: []] end)
+    def last_root, do: List.last(roots())
+
+    def roots,
+      do: __MODULE__ |> Agent.get(&Keyword.get(&1, :roots, [])) |> Enum.reverse()
+
+    def reset, do: Agent.update(__MODULE__, fn _ -> [transitions: [], roots: []] end)
 
     def platform, do: :android
     def safe_area, do: {0.0, 0.0, 0.0, 0.0}
@@ -61,7 +84,10 @@ defmodule Mob.Nav.ResetTransitionTest do
     def register_tap(_), do: 0
 
     def set_root(json) do
-      Agent.update(__MODULE__, fn state -> Keyword.put(state, :last_root, json) end)
+      Agent.update(__MODULE__, fn state ->
+        Keyword.update(state, :roots, [json], &[json | &1])
+      end)
+
       :ok
     end
 
@@ -91,11 +117,7 @@ defmodule Mob.Nav.ResetTransitionTest do
   # vocabulary native matches on stays closed — see `replaces?/0`'s callers.
   defp replaced_stack? do
     Mob.Sender.sync(:infinity)
-
-    case RecordingNif.last_root() do
-      nil -> false
-      json -> Map.get(:json.decode(json), "replaces_stack", false)
-    end
+    Enum.any?(RecordingNif.roots(), &Map.get(:json.decode(&1), "replaces_stack", false))
   end
 
   setup do
@@ -141,13 +163,12 @@ defmodule Mob.Nav.ResetTransitionTest do
   describe "the chosen transition reaches the native boundary" do
     test "a plain reset still cross-fades, and marks the stack replaced", %{router: router} do
       Mob.Router.dispatch(router, "reset_default", %{})
-      # `_replace` is the suffix the router adds for a navigation that replaces
-      # the stack. Native reads the animation from the prefix; the suffix tells
-      # it the outgoing screen is unreachable, so the view tree MOB-129 would
-      # otherwise retain for a return can be released. See MOB-147 S1.
-      # The atom stays in the closed `:push | :pop | :reset | :none` vocabulary.
-      # Android matches it as a raw string with an exact `when`, so anything
-      # outside that set falls to `else` and silently loses its animation.
+      # The transition atom stays in the closed `:push | :pop | :reset | :none`
+      # vocabulary; the "stack was replaced" fact rides on the JSON root
+      # instead. Android matches the transition as a raw string with an exact
+      # `when`, so a decorated atom would fall to `else` and silently lose its
+      # animation. The flag tells native the outgoing screen is unreachable, so
+      # the view tree MOB-129 would otherwise retain for a return can go.
       assert last_transition() == :reset
       assert replaced_stack?()
     end
@@ -200,6 +221,121 @@ defmodule Mob.Nav.ResetTransitionTest do
       assert last_transition() == :reset
       assert replaced_stack?()
       assert Mob.Router.get_current_module(router) == OtherScreen
+    end
+  end
+
+  describe "a pop also releases the screen it left behind" do
+    # MOB-147 S3. `pop` stops the outgoing screen's process, so the view tree
+    # the two-slot presenter retains for it can never be shown again: the next
+    # navigation always writes into the *other* slot. Tagging it releases that
+    # tree when the animation ends instead of at the next navigation. Measured
+    # on an iPhone SE over eight pops of a dense screen, this did not cost the
+    # main-thread teardown it might have: median native apply fell 42.8ms ->
+    # 39.4ms. Leaving pop untagged was the inconsistency this closes.
+    test "pop marks the stack replaced", %{router: router} do
+      Mob.Router.dispatch(router, "push_other", %{})
+      Mob.Sender.sync(:infinity)
+      RecordingNif.reset()
+
+      Mob.Router.dispatch(router, "go_back", %{})
+
+      assert last_transition() == :pop
+      assert replaced_stack?()
+    end
+
+    test "a push does not - the screen it leaves is still on the stack", %{router: router} do
+      RecordingNif.reset()
+      Mob.Router.dispatch(router, "push_other", %{})
+      Mob.Sender.sync(:infinity)
+
+      assert :push in RecordingNif.transitions()
+      refute replaced_stack?()
+    end
+  end
+
+  describe "a reset that asks for no animation" do
+    # MOB-147 N2. `Mob.Socket.reset_to/4` rejects `:none`, but the router also
+    # takes raw nav actions - from `Mob.Test.reset_to/4`, which does not
+    # validate, and from sockets built before a hot code push. `:none` must
+    # stay untagged: with no animation there is no completion callback to
+    # release on, and the incoming screen reuses the outgoing one's view
+    # identities, so releasing the slot would pull the tree out from under it.
+    test "the socket API refuses to build one" do
+      assert_raise ArgumentError, fn ->
+        Mob.Socket.reset_to(%Mob.Socket{}, OtherScreen, %{}, transition: :none)
+      end
+    end
+
+    test "but Mob.Test.reset_to/4 does not validate, so the router still sees it",
+         %{router: router} do
+      # This is what makes `replacing(:none)` live rather than dead code, and it
+      # is asserted through the real public API rather than by inspecting an
+      # action shape. `Mob.Test` drives the router by its registered
+      # `:mob_screen` name, so pointing it at this node reaches the router this
+      # test started. If this ever raises, the guard can go — but not before.
+      RecordingNif.reset()
+
+      assert :ok = Mob.Test.reset_to(node(), OtherScreen, %{}, transition: :none)
+
+      assert Mob.Router.get_current_module(router) == OtherScreen
+      :sys.get_state(:sys.get_state(router).current.pid)
+      Mob.Sender.sync(:infinity)
+
+      # Driven synchronously this paints twice; what matters is that no frame
+      # asked for an animation, and that none was tagged.
+      assert RecordingNif.transitions() != []
+      assert Enum.all?(RecordingNif.transitions(), &(&1 == :none))
+      refute replaced_stack?()
+    end
+
+    test "is painted without an animation and without the flag", %{router: router} do
+      current = :sys.get_state(router).current.pid
+      RecordingNif.reset()
+
+      send(router, {:nav_action, {:reset, OtherScreen, %{}, :none}, current})
+
+      # A raw nav action arrives as a message, and its paint is async: the
+      # router tells the incoming screen to render and that screen casts to the
+      # sender. `Mob.Sender.sync/1` only orders the *caller's* own casts, so
+      # step through both processes first or the flush races the paint.
+      assert Mob.Router.get_current_module(router) == OtherScreen
+      :sys.get_state(:sys.get_state(router).current.pid)
+      Mob.Sender.sync(:infinity)
+
+      assert RecordingNif.roots() != []
+      assert RecordingNif.transitions() == [:none]
+      refute replaced_stack?()
+    end
+  end
+
+  describe "every navigation that stops the screen it leaves is tagged" do
+    # MOB-147 S3, review finding (b): the pop path had one test, through
+    # `pop_screen`, while `pop_to`, `pop_to_root` and the failed-restart
+    # recovery went untested. Reverting the tag at three of the four sites left
+    # the whole suite green.
+    setup %{router: router} do
+      Mob.Router.dispatch(router, "push_other", %{})
+      Mob.Router.dispatch(router, "push_third", %{})
+      Mob.Sender.sync(:infinity)
+      assert Mob.Router.get_current_module(router) == ThirdScreen
+      RecordingNif.reset()
+      :ok
+    end
+
+    test "pop_to_root", %{router: router} do
+      Mob.Router.dispatch(router, "to_root", %{})
+
+      assert Mob.Router.get_current_module(router) == HomeScreen
+      assert last_transition() == :pop
+      assert replaced_stack?()
+    end
+
+    test "pop_to a screen mid-stack", %{router: router} do
+      Mob.Router.dispatch(router, "to_other", %{})
+
+      assert Mob.Router.get_current_module(router) == OtherScreen
+      assert last_transition() == :pop
+      assert replaced_stack?()
     end
   end
 end

--- a/test/mob/nav/screen_nav_test.exs
+++ b/test/mob/nav/screen_nav_test.exs
@@ -90,10 +90,7 @@ defmodule Mob.Nav.ScreenNavTest do
   end
 
   setup do
-    case Process.whereis(Mob.Nav.Registry) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, pid} = Mob.Nav.Registry.start_link(DemoApp)
     on_exit(fn -> stop_safely(pid) end)

--- a/test/mob/nav/tab_transition_test.exs
+++ b/test/mob/nav/tab_transition_test.exs
@@ -140,6 +140,20 @@ defmodule Mob.Nav.TabTransitionTest do
     assert Mob.Router.get_current_module(router) == HomeScreen
   end
 
+  test "a tab switch is never marked as replacing the stack", %{router: router} do
+    # The other half of MOB-147 S1. A parked tab can be switched back to, so its
+    # view tree is worth retaining — releasing it throws away exactly the
+    # depth-1 retention MOB-129 exists for. Keying the release on the animation
+    # name got this wrong: `switch_tab(..., transition: :reset)` is documented,
+    # and read as a reset it released a screen the user can return to.
+    for event <- ["settings_push", "home_pop", "settings_default"] do
+      Mob.Router.dispatch(router, event, %{})
+
+      refute List.last(transitions()) |> to_string() |> String.ends_with?("_replace"),
+             "#{event} must not be tagged as a stack replacement"
+    end
+  end
+
   test "legacy switch_tab/2 remains an unanimated swap", %{router: router} do
     Mob.Router.dispatch(router, "settings_default", %{})
     assert List.last(transitions()) == :none

--- a/test/mob/nav/tab_transition_test.exs
+++ b/test/mob/nav/tab_transition_test.exs
@@ -69,19 +69,35 @@ defmodule Mob.Nav.TabTransitionTest do
   end
 
   defmodule RecordingNif do
-    def start, do: Agent.start(fn -> [] end, name: __MODULE__)
-    def transitions, do: __MODULE__ |> Agent.get(& &1) |> Enum.reverse()
-    def reset, do: Agent.update(__MODULE__, fn _ -> [] end)
+    def start, do: Agent.start(fn -> [transitions: [], roots: []] end, name: __MODULE__)
+
+    def transitions,
+      do: __MODULE__ |> Agent.get(&Keyword.get(&1, :transitions, [])) |> Enum.reverse()
+
+    def reset, do: Agent.update(__MODULE__, fn _ -> [transitions: [], roots: []] end)
 
     def platform, do: :android
     def safe_area, do: {0.0, 0.0, 0.0, 0.0}
     def take_launch_notification, do: :none
     def clear_taps, do: :ok
     def register_tap(_), do: 0
-    def set_root(_json), do: :ok
+
+    def set_root(json) do
+      Agent.update(__MODULE__, fn state ->
+        Keyword.update(state, :roots, [json], &[json | &1])
+      end)
+
+      :ok
+    end
+
+    def roots,
+      do: __MODULE__ |> Agent.get(&Keyword.get(&1, :roots, [])) |> Enum.reverse()
 
     def set_transition(transition) do
-      Agent.update(__MODULE__, &[transition | &1])
+      Agent.update(__MODULE__, fn state ->
+        Keyword.update(state, :transitions, [transition], &[transition | &1])
+      end)
+
       :ok
     end
   end
@@ -130,6 +146,21 @@ defmodule Mob.Nav.TabTransitionTest do
     RecordingNif.transitions()
   end
 
+  # Whether ANY frame this navigation painted told native the stack was
+  # replaced. Carried on the JSON root so the transition vocabulary native
+  # matches on stays closed.
+  #
+  # Across every painted frame, not just the last: a navigation paints the
+  # activation frame and then the incoming screen's own render, and only the
+  # first carries the flag. Reading `last_root` alone reported `false` for a
+  # tagged navigation — and, worse, reported `false` when nothing was painted at
+  # all, so `refute replaced_stack?()` passed vacuously. The callers assert
+  # `roots() != []` for that reason.
+  defp replaced_stack? do
+    Mob.Sender.sync(:infinity)
+    Enum.any?(RecordingNif.roots(), &Map.get(:json.decode(&1), "replaces_stack", false))
+  end
+
   test "a directional transition reaches native on first mount and restore", %{router: router} do
     Mob.Router.dispatch(router, "settings_push", %{})
     assert List.last(transitions()) == :push
@@ -143,14 +174,22 @@ defmodule Mob.Nav.TabTransitionTest do
   test "a tab switch is never marked as replacing the stack", %{router: router} do
     # The other half of MOB-147 S1. A parked tab can be switched back to, so its
     # view tree is worth retaining — releasing it throws away exactly the
-    # depth-1 retention MOB-129 exists for. Keying the release on the animation
-    # name got this wrong: `switch_tab(..., transition: :reset)` is documented,
-    # and read as a reset it released a screen the user can return to.
+    # depth-1 retention MOB-129 exists for.
+    #
+    # Read off the JSON root, not off the transition atom. An earlier version
+    # asserted the atom did not end in "_replace", which became vacuous the
+    # moment the flag moved off the transition string: `Mob.Renderer` unwraps
+    # the tuple before `set_transition/1`, so NO atom can carry that suffix and
+    # the assertion could never fail — including for the regression it names.
     for event <- ["settings_push", "home_pop", "settings_default"] do
+      RecordingNif.reset()
       Mob.Router.dispatch(router, event, %{})
+      Mob.Sender.sync(:infinity)
 
-      refute List.last(transitions()) |> to_string() |> String.ends_with?("_replace"),
-             "#{event} must not be tagged as a stack replacement"
+      assert RecordingNif.roots() != [],
+             "#{event} painted nothing, so the refutation below would be vacuous"
+
+      refute replaced_stack?(), "#{event} must not be tagged as a stack replacement"
     end
   end
 

--- a/test/mob/router_hot_path_test.exs
+++ b/test/mob/router_hot_path_test.exs
@@ -71,10 +71,7 @@ defmodule Mob.RouterHotPathTest do
   end
 
   setup do
-    case Process.whereis(Mob.Nav.Registry) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, registry} = Mob.Nav.Registry.start_link(DemoApp)
     on_exit(fn -> stop_safely(registry) end)

--- a/test/mob/screen/isolation_test.exs
+++ b/test/mob/screen/isolation_test.exs
@@ -54,10 +54,7 @@ defmodule Mob.Screen.IsolationTest do
   end
 
   setup do
-    case Process.whereis(Mob.Nav.Registry) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, registry} = Mob.Nav.Registry.start_link(DemoApp)
     on_exit(fn -> stop_safely(registry) end)

--- a/test/mob/screen/restart_test.exs
+++ b/test/mob/screen/restart_test.exs
@@ -90,10 +90,7 @@ defmodule Mob.Screen.RestartTest do
   end
 
   setup do
-    case Process.whereis(Mob.Nav.Registry) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, registry} = Mob.Nav.Registry.start_link(TabApp)
     on_exit(fn -> stop_safely(registry) end)

--- a/test/mob/screen_sender_wiring_test.exs
+++ b/test/mob/screen_sender_wiring_test.exs
@@ -79,10 +79,7 @@ defmodule Mob.ScreenSenderWiringTest do
 
   setup do
     for name <- [Sender, Mob.Nav.Registry] do
-      case Process.whereis(name) do
-        nil -> :ok
-        pid -> GenServer.stop(pid)
-      end
+      Mob.Test.ProcessHelpers.stop_if_running(name)
     end
 
     {:ok, sender} = Sender.start_link([])

--- a/test/mob/sender_test.exs
+++ b/test/mob/sender_test.exs
@@ -39,10 +39,7 @@ defmodule Mob.SenderTest do
   setup do
     # Order matters: a sender left running from an earlier test can still have a
     # flush queued, and it would record into the fresh recorder.
-    case Process.whereis(Sender) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Sender)
 
     case Process.whereis(RecordingNif) do
       nil -> :ok

--- a/test/mob/state_test.exs
+++ b/test/mob/state_test.exs
@@ -15,10 +15,7 @@ defmodule Mob.StateTest do
     end)
 
     # Stop any running State process from a prior test.
-    case Process.whereis(Mob.State) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.State)
 
     {:ok, _} = Mob.State.start_link()
     :ok

--- a/test/support/native_source.ex
+++ b/test/support/native_source.ex
@@ -1,0 +1,161 @@
+defmodule Mob.Test.NativeSource do
+  @moduledoc """
+  Strips comments from Swift and Objective-C sources so the native assertions
+  in the test suite match on code, not on prose.
+
+  These tests read `ios/*.swift` and `ios/*.m` and assert that particular calls
+  are present. Without stripping, a `=~` assertion is satisfied by the very
+  comment that describes the call — including a comment describing code that
+  was deleted, which is a false pass in the direction that matters.
+  """
+
+  @doc """
+  Return `source` with every comment removed and everything else byte-for-byte
+  intact.
+
+  Newlines inside comments are kept so line numbers do not shift.
+
+  Pass `:objc` for `.m` sources, where block comments do NOT nest. Defaults to
+  `:swift`, where they do.
+
+  Raises if the scan does not end back in code. Every way this scanner can go
+  wrong — an unterminated literal, a quoting form it does not know, a `/*`
+  inside a comment — leaves it stuck in some other state, and from there it
+  reports comments as code (a false pass) or eats code as comment (a false
+  failure whose message points at the assertion rather than the cause). Failing
+  loudly is the only way those stay visible.
+  """
+  @spec code_only(binary(), :swift | :objc) :: binary()
+  def code_only(source, language \\ :swift) do
+    case scan(source, :code, [], language) do
+      {:code, out} ->
+        out
+
+      {state, _} ->
+        raise """
+        native source scan ended in #{inspect(state)}, not :code.
+
+        The scanner is stuck, so its output cannot be trusted. Usually an
+        unterminated string or block comment, or a `/*` inside a comment in a
+        Swift file (block comments nest there, so it opens a second level).
+        """
+    end
+  end
+
+  @doc """
+  The text between `from` and `to`, exclusive.
+
+  Raises if either marker is missing, rather than returning a silently empty
+  region that every subsequent assertion would then match nothing against.
+  """
+  @spec region(binary(), binary(), binary()) :: binary()
+  def region(source, from, to) do
+    unless String.contains?(source, from), do: raise("region start not found: #{inspect(from)}")
+    [_, rest] = String.split(source, from, parts: 2)
+
+    unless String.contains?(rest, to), do: raise("region end not found: #{inspect(to)}")
+    [body | _] = String.split(rest, to, parts: 2)
+    body
+  end
+
+  @doc """
+  Byte offset of `needle` in `hay`.
+
+  For asserting that one construct precedes another — a guard before the write
+  it protects, say — which a pair of `=~` assertions cannot express.
+  """
+  @spec index_of(binary(), binary()) :: non_neg_integer()
+  def index_of(hay, needle) do
+    case :binary.match(hay, needle) do
+      {i, _} -> i
+      :nomatch -> raise "expected to find #{inspect(needle)}"
+    end
+  end
+
+  # Scans the whole file as one binary, carrying string and block-comment state
+  # ACROSS lines. A per-line scanner reset `in_string` at every newline, which
+  # breaks on Swift's multi-line `"""` literals — MobGpuView.swift embeds MSL
+  # shader source that way, and a `//` inside it was truncated as if it were a
+  # comment. It also never recognised `/* */`, so commented-out code satisfied a
+  # `=~` assertion: a false pass, the inverse of the bug this replaced.
+  defp scan(<<>>, state, acc, _lang),
+    do: {simplify(state), acc |> Enum.reverse() |> IO.iodata_to_binary()}
+
+  defp scan(<<"\\", c::utf8, rest::binary>>, :string, acc, lang),
+    do: scan(rest, :string, [<<c::utf8>>, "\\" | acc], lang)
+
+  defp scan(<<"\"\"\"", rest::binary>>, :code, acc, lang),
+    do: scan(rest, :multiline, ["\"\"\"" | acc], lang)
+
+  defp scan(<<"\"\"\"", rest::binary>>, :multiline, acc, lang),
+    do: scan(rest, :code, ["\"\"\"" | acc], lang)
+
+  defp scan(<<c::utf8, rest::binary>>, :multiline, acc, lang),
+    do: scan(rest, :multiline, [<<c::utf8>> | acc], lang)
+
+  defp scan(<<"#\"", rest::binary>>, :code, acc, lang),
+    do: scan(rest, :raw_string, ["#\"" | acc], lang)
+
+  defp scan(<<"\"#", rest::binary>>, :raw_string, acc, lang),
+    do: scan(rest, :code, ["\"#" | acc], lang)
+
+  defp scan(<<c::utf8, rest::binary>>, :raw_string, acc, lang),
+    do: scan(rest, :raw_string, [<<c::utf8>> | acc], lang)
+
+  defp scan(<<"\"", rest::binary>>, :code, acc, lang), do: scan(rest, :string, ["\"" | acc], lang)
+  defp scan(<<"\"", rest::binary>>, :string, acc, lang), do: scan(rest, :code, ["\"" | acc], lang)
+
+  defp scan(<<c::utf8, rest::binary>>, :string, acc, lang),
+    do: scan(rest, :string, [<<c::utf8>> | acc], lang)
+
+  # Objective-C character literals. No file the tests currently read contains
+  # `'"'` — `ios/mob_beam.m` has char literals but nothing asserts against it —
+  # so this is defensive, not a fix for a live break. It is cheap and the
+  # failure it prevents is silent: one quoted quote flips the scanner into
+  # :string for the rest of the file, and every later assertion then matches
+  # against text the scanner believes is a literal.
+  defp scan(<<"'\\", c::utf8, "'", rest::binary>>, :code, acc, lang),
+    do: scan(rest, :code, ["'", <<c::utf8>>, "\\'" | acc], lang)
+
+  defp scan(<<"'", c::utf8, "'", rest::binary>>, :code, acc, lang),
+    do: scan(rest, :code, ["'", <<c::utf8>>, "'" | acc], lang)
+
+  defp scan(<<"//", rest::binary>>, :code, acc, lang), do: scan(rest, :line_comment, acc, lang)
+
+  defp scan(<<"\n", rest::binary>>, :line_comment, acc, lang),
+    do: scan(rest, :code, ["\n" | acc], lang)
+
+  defp scan(<<_::utf8, rest::binary>>, :line_comment, acc, lang),
+    do: scan(rest, :line_comment, acc, lang)
+
+  # Swift block comments nest; C's, and so Objective-C's, do not. Tracking depth
+  # matters for the same reason the block-comment case exists at all:
+  # `/* outer /* inner */ code() */` would otherwise leave `code() */` looking
+  # like live source. Applying Swift's rule to a `.m` file has the opposite
+  # failure — a comment that merely mentions `/*` swallows the rest of the file
+  # — which is why the language is a parameter rather than an assumption.
+  defp scan(<<"/*", rest::binary>>, :code, acc, lang), do: scan(rest, {:block, 1}, acc, lang)
+
+  defp scan(<<"/*", rest::binary>>, {:block, n}, acc, :swift),
+    do: scan(rest, {:block, n + 1}, acc, :swift)
+
+  defp scan(<<"/*", rest::binary>>, {:block, n}, acc, :objc),
+    do: scan(rest, {:block, n}, acc, :objc)
+
+  defp scan(<<"*/", rest::binary>>, {:block, 1}, acc, lang), do: scan(rest, :code, acc, lang)
+
+  defp scan(<<"*/", rest::binary>>, {:block, n}, acc, lang),
+    do: scan(rest, {:block, n - 1}, acc, lang)
+
+  defp scan(<<"\n", rest::binary>>, {:block, n}, acc, lang),
+    do: scan(rest, {:block, n}, ["\n" | acc], lang)
+
+  defp scan(<<_::utf8, rest::binary>>, {:block, n}, acc, lang),
+    do: scan(rest, {:block, n}, acc, lang)
+
+  defp scan(<<c::utf8, rest::binary>>, :code, acc, lang),
+    do: scan(rest, :code, [<<c::utf8>> | acc], lang)
+
+  defp simplify({:block, _}), do: :block_comment
+  defp simplify(state), do: state
+end

--- a/test/support/process_helpers.ex
+++ b/test/support/process_helpers.ex
@@ -1,0 +1,47 @@
+defmodule Mob.Test.ProcessHelpers do
+  @moduledoc """
+  Stopping a named process from test setup, without the race.
+
+  The idiom this replaces appeared in nine test files:
+
+      case Process.whereis(Name) do
+        nil -> :ok
+        pid -> GenServer.stop(pid)
+      end
+
+  That is check-then-act across a process boundary. `whereis` returns a live
+  pid, the process exits before `stop` reaches it — a previous test's `on_exit`
+  still draining, a supervisor restarting it, a linked owner going down — and
+  `GenServer.stop/3` exits with `:noproc`, failing whichever test happened to
+  run next.
+
+  It failed exactly once in CI on `Mob.StateTest`, in setup, on a test that has
+  nothing to do with what was being changed. That is the shape of this bug: it
+  moves, it is rare, and it lands on whoever pushed last.
+  """
+
+  @doc """
+  Stop `name` if it is running, tolerating it having already stopped.
+
+  Returns `:ok` either way. Any exit reason is accepted, because a process that
+  is already gone is the state the caller wanted.
+  """
+  @spec stop_if_running(GenServer.name(), timeout()) :: :ok
+  def stop_if_running(name, timeout \\ 5_000) do
+    case Process.whereis(name) do
+      nil ->
+        :ok
+
+      pid ->
+        try do
+          GenServer.stop(pid, :normal, timeout)
+        catch
+          # :noproc — it exited between the whereis and here, which is the race.
+          # :normal / :shutdown — it was already on its way down.
+          :exit, _ -> :ok
+        end
+
+        :ok
+    end
+  end
+end


### PR DESCRIPTION
MOB-129 merged **without** an adversarial review — the only substantial change in that batch that skipped one, and the largest. The review run after the fact (MOB-147) found two blocking defects. The process gap is closed separately in mob#131 / mob_dev#61 / mob_new#55.

### B1 — the frame registry refused every write from a screen you popped back to

Exactly the case MOB-129 optimises for. `mob_bump_frame_generation` still fires on every navigation and `mob_register_frame` still refuses a stale stamp — but a parked tracker is never removed from the hierarchy, so its `.onAppear` never fires again. A → push B → pop A left A's trackers holding generation 1 against a current 3, and **every write was rejected**. `Mob.Test.element_frames` and `tap_id` read empty for the screen actually on display, silently.

**The decision record asserted the opposite.** It reasoned about the outgoing direction — where the behaviour is correct and wanted — and never considered the returning one. That claim is corrected in place rather than quietly dropped.

Fixed by re-seeding the stamp when a slot becomes active, **not** by removing the gate: the gate is what stops an outgoing screen re-registering at mid-animation coordinates as it slides away, and what keeps two screens sharing an `:id` from clobbering each other.

**Verified on device:**

| step | screen | `element_frames` |
|---|---|---|
| A | dense | 231 |
| push B | home | 1 |
| pop back to A | dense | **231** |

Without the fix that last row is 0.

### B2 — toggles and sliders inherited state across screens

Neither had **any** prop-to-state sync; both relied on `.id(currentNavVersion)` destroying their identity to re-seed. With identities alive across navigation, a screen shows the toggle states and slider positions of the screen **two navigations back**.

The decisive evidence is in this repo: `lib/mob/socket.ex` raises `ArgumentError` on `transition: :none` because *"a TextField at the same position inherits the old screen's text and focus"* — and MOB-129 made that the default path for every push and pop.

### The rest

One new environment value, `mobScreenIsActive`, published per slot:

- a **parked sheet** is dismissed and re-presented on return. `.sheet` presents on the *window*, so the slot's `allowsHitTesting(false)` never reached it — it stayed visible **and interactive** over the incoming screen. A park is not reported to the BEAM as a user dismissal.
- a **parked video** pauses, audio included, and only resumes if it was autoplaying
- a **parked GPU view** stops rendering, rather than running at 60 fps indefinitely behind the visible screen
- **`on_end_reached`'s latch** clears on activation, restoring what the navigation teardown used to give it for free

### Tests

12 new, plus 5 added to the MOB-129 file for mutations the review **proved survived** — including inserting an unconditional `slots[outgoing] = nil`, which destroys depth-1 retention (the headline benefit) with all 13 original tests still green. **13 mutations run, all caught.**

The MOB-129 stripper is rewritten. The review demonstrated two holes: it stripped only full-line `//` comments, so deleting the real `containerWidth = width` and leaving the text in a trailing comment passed; and its dotall `/* */` strip swallowed ~200 lines of real code when a string literal containing `/*` was added.

### One review finding refuted by experiment

It predicted that seating the offset outside `withAnimation` coalesces away, so a push following a push would slide in from the wrong side. I recorded two consecutive pushes and extracted frames — **both enter correctly from the trailing edge.** The reviewer flagged that one as reasoning rather than verification and asked for exactly this experiment.

### Not fixed — recorded on MOB-147

A documented `reset_to(..., transition: :push)` retains an unreachable screen, because the clear keys on the animation name rather than on whether the stack was replaced; that needs a wire signal. A reset no longer cross-fades. And the layout cost of a parked slot on a container geometry change is reasoned about but unmeasured.

1479 tests pass. `mix.exs` untouched at 0.7.39.