### PR TITLE
docs(agents): add a verification fidelity ladder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,45 @@ is always better.
 
 Full workflow detail: `guides/agentic_coding.md`.
 
+## Verification fidelity ladder
+
+Run every applicable lower rung, plus the highest rung the change actually
+reaches. Then say which rung you stopped at. "Tests pass" is not a claim about
+a device.
+
+1. **Static.** `mix format --check-formatted`, `mix credo --strict` (ex_slop
+   included), `mix compile --warnings-as-errors`.
+2. **Host unit.** `mix test`. Proves the Elixir logic. Proves nothing about
+   rendering, NIFs, or either platform.
+3. **Simulator or emulator.** Deployed, attached over dist, driven through
+   `Mob.Test` — read `assigns/1` back after the action, don't trust the tap.
+4. **Physical device, both platforms.** The pool is not the world: an
+   API-33-only call crashed on Android 11 and was invisible across an
+   all-Android-13 emulator pool. `tap_xy/3` returns `{:error, :no_effect}` on a
+   real device where the simulator lets it through. iOS needs the cable out
+   before dist RPC works.
+5. **Release build, not debug.** Different linkage, different packaging,
+   different failures. iOS release links plugin NIFs by a separate path
+   (`mob_dev` `decisions/2026-07-07-ios-release-links-plugin-nifs.md`), and a
+   release leaves an `assets/otp.zip` that crash-loops the next debug deploy
+   until it is removed.
+6. **Published artifact.** Built from the packed tarball or the store split,
+   not the working tree. Hex packaging omits repository-root dotfiles, and AGP
+   packs native libs into a release App Bundle that the BEAM needs on the
+   filesystem — debug defaults masked both until an install from Play failed.
+
+Every rung above exists because something got through the one below it.
+
+Two rules that outrank the list:
+
+- **Never substitute a lower rung because a higher one is slow, broken, or
+  inconvenient.** Fix the harness, open an issue, or state plainly that the rung
+  was unavailable and why. An unavailable rung is a fine answer. A silently
+  skipped one is not.
+- **Verify effects, not exit codes.** An exit code proves a tool ran. It does
+  not prove a build happened, a deploy landed, or a screen rendered. After a
+  deploy, prove the app is up and answering before believing anything else.
+
 ## Pre-empt-failure rules — read before you touch anything
 
 These are the things we've burned ourselves on. Following them isn't optional.


### PR DESCRIPTION
## What

Six rungs from static analysis to a published artifact, with the two rules that
outrank them: never substitute a lower rung silently, and verify effects rather
than exit codes.

Rungs 4 to 6 are the ones that have cost real time here — the emulator pool that
was uniformly Android 13 and so could not see an API-33 crash on Android 11, the
release path that links plugin NIFs differently from debug, and the debug
defaults that masked a crash until the app was installed from Play.

## Why

Borrowed from [GenericJam/insider](https://github.com/GenericJam/insider), which
gates agent work on a named fidelity ladder plus one rule: a lower rung may not
stand in for a higher one.

The principle was already here in pieces — "verify effects, not exit codes" in
the agentic guide, the deliberate fast/slow split in `.githooks/pre-push` — but
there was no named ladder an agent could point at, and therefore no vocabulary
for the sentence that matters: *"I verified at rung 3; rung 4 was unavailable
because no device was attached."* Today an agent that runs `mix test` and reports
success is not lying, and that is the problem.

Every rung cites something that actually got past the rung below it, so the list
reads as history rather than process.

## Evidence

Docs only — no code paths touched. `.githooks/pre-push` ran clean on push
(format, Credo `--strict` with ex_slop, compile `--warnings-as-errors`).

## Not included

Deliberately left for a separate discussion rather than bundled here:

- `pre-commit` with insider's `check-test-pairing` co-change gate
- a PR template with an evidence block, and `CODEOWNERS` over `AGENTS.md`,
  `.githooks/` and `decisions/`
- insider's `commit-msg` Conventional Commits hook — **not recommended as
  written**: its regex rejects 30 of the last 40 subjects on `master`, including
  every `Bump to x.y.z` release commit and the `MOB-nnn:` style