### PR TITLE
Make the test suite tell the truth (MOB-154, MOB-119, MOB-123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Added
+- **`mix mob.flake`** — run the suite repeatedly and report which tests are not
+  deterministic. `--runs N`, `--until-failure`, `--keep-going`, `--seed`, and a
+  path to narrow the target. A flake does not announce itself; it fails once on
+  someone else's branch and the natural response is to re-run and move on. This
+  makes looking cheap and deliberate.
+
 ### Fixed
 - **NIFs that wait on the UI thread no longer block the only scheduler**
   (MOB-164). Android runs the BEAM with `-S 1:1` — one normal scheduler — so a
@@ -32,6 +39,34 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   without deciding fails the build. It checks both directions — a flag is
   wrong when it is missing *and* when it is spurious, and the first draft of
   this change flagged two NIFs that do not block.
+
+- **Test-suite races that made every automated verdict unreliable** (MOB-154,
+  MOB-119, MOB-123). A 1-in-20 flake corrupted a mutation-testing result and,
+  a day later, sent a bisect down the wrong path when it appeared in the same
+  run as a real failure.
+
+  `Mob.ComponentRegistry` is a globally-named singleton owning a named ETS
+  table, and two `async: true` modules each started it with
+  `start_supervised/1` — so whichever test won the race owned it, and ExUnit
+  tore it down while the other module was still using it. It now starts in
+  `test_helper.exs`, owned by the run.
+
+  Nineteen `on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)`
+  sites across eleven modules were check-then-act across a process boundary;
+  thirteen further modules had each written the same correct workaround
+  privately, byte for byte. All now use `Mob.Test.ProcessHelpers`, which gains
+  `stop_pid/2`, `await_exit/2` and `eventually/2`.
+
+  All 35 `Process.sleep` calls were classified rather than swept. Twelve are
+  `Process.sleep(:infinity)` — a parked stub, not a wait. Of the 23 finite
+  ones, 8 remain: three are the subject under test in `render_stats_test.exs`,
+  three are the backoff inside a poll loop that has its own deadline, one is a
+  `@doc` example, and one is a genuine bet that is recorded rather than
+  disguised. The other 15 either had nothing to wait for (a `GenServer.call`
+  from the same process is already an ordering barrier) or were replaced with
+  the actual barrier — a ready-message, `Logger.flush/0`, a monitor, or a
+  bounded poll. See
+  `decisions/2026-09-06-tests-wait-for-events-not-durations.md`.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,23 +51,27 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   tore it down while the other module was still using it. It now starts in
   `test_helper.exs`, owned by the run.
 
-  Nineteen `on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)`
-  sites across eleven modules were check-then-act across a process boundary;
+  Fourteen `on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)`
+  sites across six modules were check-then-act across a process boundary;
   thirteen further modules had each written the same correct workaround
-  privately, byte for byte. All now use `Mob.Test.ProcessHelpers`, which gains
-  `stop_pid/2`, `await_exit/2` and `eventually/2`.
+  privately. All now use `Mob.Test.ProcessHelpers`, which gains `stop_pid/2`,
+  `await_exit/2` and `eventually/2`.
 
   All 35 `Process.sleep` calls were classified rather than swept. Twelve are
-  `Process.sleep(:infinity)` — a parked stub, not a wait. Of the 23 finite
-  ones, 8 remain: three are the subject under test in `render_stats_test.exs`,
-  three are the backoff inside a poll loop that has its own deadline, one is a
-  `@doc` example, and one is a genuine bet that is recorded rather than
-  disguised. The other 15 either had nothing to wait for (a `GenServer.call`
-  from the same process is already an ordering barrier) or were replaced with
-  the actual barrier — a ready-message, `Logger.flush/0`, a monitor, or a
-  bounded poll. See
+  `Process.sleep(:infinity)`, which is not a wait. Of the 23 finite ones, 17
+  were dealt with and 6 kept — the kept ones measure elapsed time, back off a
+  poll loop that has its own deadline, or are a genuine bet that is recorded
+  rather than disguised. The 17 either had nothing to wait for (a
+  `GenServer.call` from the process that sent the earlier messages is already
+  an ordering barrier) or were replaced with the actual barrier: a
+  ready-message, `Logger.flush/0`, a monitor, or a bounded poll. See
   `decisions/2026-09-06-tests-wait-for-events-not-durations.md`.
 
+  Also fixes a temp-directory collision between concurrent `mix test` runs:
+  `System.unique_integer/1` is unique per VM, so two suites running at once
+  (a CI matrix on one box) generated the same fixture directory and each
+  `on_exit` deleted the other's files. `ProcessHelpers.tmp_path/1` includes the
+  OS pid.
 
 ### Changed
 - **Input NIFs now run on a dirty IO scheduler.** `tap`, `tap_xy`,

--- a/decisions/2026-09-06-tests-wait-for-events-not-durations.md
+++ b/decisions/2026-09-06-tests-wait-for-events-not-durations.md
@@ -22,13 +22,14 @@ while a concurrent test in the other module was still using it. The loser died
 on `:ets.lookup` against a table that no longer existed.
 
 **Check-then-act across a process boundary.** `on_exit(fn -> if
-Process.alive?(pid), do: GenServer.stop(pid) end)` appeared 19 times across 11
-modules.
+Process.alive?(pid), do: GenServer.stop(pid) end)` appeared 14 times across 6
+modules (12 with `GenServer.stop`, 2 with `Agent.stop`).
 Since MOB-112 the screen owner is linked to the test process, which ExUnit
 exits with `:shutdown` at test end — so the owner is dying concurrently with
 the callback trying to stop it. Thirteen more modules had each independently
-written a correct private `stop_safely/1`, byte for byte identically, which is
-a fair signal it belonged somewhere shared.
+written a correct private helper — twelve named `stop_safely/1` and identical,
+one named `safe_stop/1` and nested inside a `describe` — which is a fair signal
+it belonged somewhere shared.
 
 **Fixed durations standing in for synchronisation.** `Process.exit(pid, :kill)`
 followed by `Process.sleep(10)` followed by an assertion that requires the
@@ -55,49 +56,50 @@ avoided).
 
 ### Not every sleep is a bug
 
-All 35 `Process.sleep` calls were classified rather than swept. Twelve were
-`Process.sleep(:infinity)` — a stub process parked until something kills it,
-not a wait at all. That left 23 finite sleeps, now 8:
+All 35 `Process.sleep` calls were classified rather than swept. Twelve are
+`Process.sleep(:infinity)` — mostly a stub process parked until something kills
+it, which is not a wait at all. That leaves **23 finite sleeps on master**, of
+which **17 were dealt with and 6 kept**. This PR adds 2 of its own (the backoff
+inside `eventually/2`, and a `@doc` example quoting the bad pattern), so the
+tree now has 8.
 
-**Removed because there was never anything to wait for (5).** A `GenServer.call`
-from the same process that sent the earlier messages is already a barrier:
-Erlang orders messages pairwise between two processes, so every `send` is ahead
-of the `call` in the mailbox and has been handled before the reply comes back
-(`event/integration_test.exs` ×3, `nav/screen_nav_test.exs`). And
-`Trace.broadcast/3` folds over the table *in the calling process*, so its
-cleanup is done by the time `dispatch/4` returns `:ok` (`event/trace_test.exs`).
-These sleeps were guarding against nothing.
+The 17 fall into three kinds. Some had **nothing to wait for**: a
+`GenServer.call` from the same process that sent the earlier messages is
+already a barrier, because Erlang orders messages pairwise between two
+processes, so every `send` is ahead of the `call` in the mailbox
+(`event/integration_test.exs`). `Trace.broadcast/3` likewise folds over its
+table *in the calling process*, so cleanup is done by the time `dispatch/4`
+returns `:ok`. Some were **replaced with the real barrier** — a ready-message
+where the test waited on another process to reach a known point,
+`Logger.flush/0` where it waited on handlers to drain, a monitor where it
+waited for an exit. Three were **replaced with a bounded poll**
+(`eventually/2`) for the one shape where pairwise ordering genuinely does not
+help: a GenServer processing a `:DOWN` sent by a *monitor* rather than by the
+test.
 
-**Replaced with the real barrier (8).** A ready-message where the test was
-waiting on another process to reach a known point (`trace_test.exs`,
-`device_test.exs`); `Logger.flush/0` where it was waiting on handlers to drain
-(`native_logger_test.exs` ×2, `theme_host_test.exs` ×2); a monitor where it was
-waiting for an exit.
+The 6 kept: three in `render_stats_test.exs` are the subject under test (it
+measures elapsed time, so time must pass), two are the backoff inside a poll
+loop that has its own deadline (`migration_test.exs`,
+`reset_transition_test.exs`), and one is a genuine bet —
+`router_hot_path_test.exs:206` waits for a message the *screen* sent to the
+router, and the test is neither party. It is left as a sleep and recorded here
+rather than disguised.
 
-**Replaced with a bounded poll (3).** `device_test.exs` (×2) and
-`native_component_examples_test.exs` wait for a GenServer to
-process a `:DOWN` sent by a *monitor*, not by the test. Pairwise ordering does
-not help here — the test never sent that message, so a `call` orders nothing
-against it. `ProcessHelpers.eventually/2` polls with a deadline: it returns as
-soon as the state is right rather than always paying the worst case, and it
-fails with "condition still false after Nms" instead of letting the next
-assertion report something confusing.
+### Pairwise ordering is not a general licence
 
-**Kept, deliberately (8).** Three in `render_stats_test.exs` are the subject
-under test — it measures elapsed time, so time must actually elapse. Three are
-the backoff *inside* a poll loop that has its own deadline (`eventually/2`
-itself, `migration_test.exs`, `reset_transition_test.exs`). One is a `@doc`
-example, quoting the bad pattern in order to name it. One remains a genuine
-bet: `router_hot_path_test.exs:206` waits for a message the *screen* sent to
-the router, and the test is neither party, so it has no ordering guarantee to
-lean on. It is left as a sleep and recorded here rather than disguised.
+The `GenServer.call` argument above holds only when the messages and the call
+have the same sender *and* the same recipient, and the recipient does not
+forward. `nav/screen_nav_test.exs` looked like that case and is not: `send(pid,
+:pop_test)` goes to the **owner**, which forwards to the screen, which may send
+`{:nav_action, ...}` back to the owner. The test is party to none of those
+hops. Deleting its sleep on the pairwise argument left a test that could no
+longer fail: with the regression it exists to catch injected, it passed 3 runs
+out of 3.
 
-One honest caveat about the `Logger.flush/0` swaps: with the barrier deleted
-outright those tests still passed 8 times out of 8 on this machine, so the wait
-is not demonstrably load-bearing here. `flush/0` is kept because it is the
-correct primitive and costs nothing when there is nothing pending, whereas the
-sleep it replaced was a guess that cost 300ms per run. That is a reason, not a
-measurement, and is stated as such.
+The barrier that works there is to sync with the *screen* first. Once the
+screen's `handle_info` has returned, anything it sent the owner is already in
+the owner's mailbox, so a later call from the test queues behind it. With that
+in place the injected regression fails the test, as it should.
 
 ## Consequences
 
@@ -123,3 +125,46 @@ measurement, and is stated as such.
   open-ended set of uninteresting ones. Enumerating the uninteresting set is a
   bet on having seen every shutdown shape, which is the same class of mistake
   as betting on a duration.
+
+- **I asserted counts twice and was wrong both times.** The first draft said the
+  check-then-act idiom appeared "19 times across 11 modules"; the grep that
+  produced it counted five *comment lines describing the idiom* as instances of
+  it. The real figure is 14 across 6. A second draft said 15 sleeps were removed
+  and 8 remained; that subtracted the wrong way and silently counted two sleeps
+  this PR itself added as survivors. The real split is 17 dealt with, 6 kept, 2
+  new. In a change titled "make the test suite tell the truth", both errors are
+  the same class as the bug being fixed: a plausible number nobody re-derived.
+  Every count in this record is now produced by a script over `git show
+  master:<file>` and the working tree, not by reading a grep total.
+
+- **I tried to measure the improvement under load and the instrument was not
+  trustworthy.** Running four full suites concurrently on one laptop, master
+  against this branch interleaved so both saw identical conditions, gave master
+  19/20 failing and the branch 2/20. Re-run later, the same comparison gave
+  master 8/20 and the branch 20/20 — for code that had barely changed between
+  the two measurements. A result that swings that far for the same input is a
+  property of the harness, not of the branch, so **no flake-rate improvement is
+  claimed here.** Sequentially, which is how CI runs, master and this branch are
+  both 25/25 green: no measurable difference either way. The registry fix
+  therefore remains argued from the code, not demonstrated, exactly as stated
+  above.
+
+- **The load harness did earn its keep once.** It surfaced
+  `Mob.StorageTest "delete/1 removes the file"` failing with `{:error, :enoent}`
+  on a file the test had just written. `System.unique_integer/1` is unique per
+  VM, so two concurrent `mix test` runs generate the same temp directory name
+  and each `on_exit` deletes the other's fixtures. That is a real bug, not a
+  harness artefact — a CI matrix on one box hits it — and
+  `ProcessHelpers.tmp_path/1` now includes the OS pid.
+
+- **`component_server_test.exs:309` is load-sensitive on both branches** and is
+  not addressed here: it waits 500ms for a `:DOWN` and an oversubscribed machine
+  exceeds that. Filed separately rather than folded in, because widening the
+  timeout is the tempting wrong fix.
+
+- **Twice I watched a failure go past and lost it**, because the loop running
+  the suite only kept the summary line. Both were unreproducible afterwards.
+  `mix mob.flake` now writes the full log of every failing run to
+  `_build/.../mob_flake/run-N.log` and prints the path. A rare failure may not
+  come back; the artefact is the difference between a lead and a rumour.
+

--- a/decisions/2026-09-06-tests-wait-for-events-not-durations.md
+++ b/decisions/2026-09-06-tests-wait-for-events-not-durations.md
@@ -1,0 +1,125 @@
+# Tests wait for events, not durations
+
+Date: 2026-09-06
+Status: accepted
+Ticket: MOB-154 (with MOB-119, MOB-123)
+
+## Context
+
+A 1-in-20 flake corrupted a mutation-testing verdict, and a day later sent a
+bisect down the wrong path: a real failure and a flake appeared in the same
+run, and the flake was investigated first. That is the actual cost of a noisy
+suite — not the red build, but the hours spent trusting it.
+
+Three mechanisms were behind it.
+
+**A globally-named singleton owned by whichever test started it.**
+`Mob.ComponentRegistry` is named and owns a named ETS table. Two `async: true`
+modules each called `start_supervised({Mob.ComponentRegistry, []})` and
+tolerated `{:error, {:already_started, _}}`. Whichever test won the race owned
+it, and ExUnit tore the process — and its table — down when that test ended,
+while a concurrent test in the other module was still using it. The loser died
+on `:ets.lookup` against a table that no longer existed.
+
+**Check-then-act across a process boundary.** `on_exit(fn -> if
+Process.alive?(pid), do: GenServer.stop(pid) end)` appeared 19 times across 11
+modules.
+Since MOB-112 the screen owner is linked to the test process, which ExUnit
+exits with `:shutdown` at test end — so the owner is dying concurrently with
+the callback trying to stop it. Thirteen more modules had each independently
+written a correct private `stop_safely/1`, byte for byte identically, which is
+a fair signal it belonged somewhere shared.
+
+**Fixed durations standing in for synchronisation.** `Process.exit(pid, :kill)`
+followed by `Process.sleep(10)` followed by an assertion that requires the
+process to be gone.
+
+## Decision
+
+**A test waits for the event it depends on, never for a duration it hopes is
+long enough.** `Process.monitor` plus a `:DOWN`, or `assert_receive`. A monitor
+is not a tighter bet than a sleep — the `:DOWN` cannot arrive before the
+process is gone, so there is nothing left to race.
+
+Shared state that outlives a single test is owned by the **run**, not by
+whichever test got there first. `Mob.ComponentRegistry` now starts in
+`test_helper.exs`, so both setups take the `:already_started` branch, nobody
+owns it, and nobody can tear it down mid-flight. Sharing is safe because every
+entry is keyed by a per-test `screen_pid`.
+
+`Mob.Test.ProcessHelpers` is where these live: `stop_if_running/2` (named),
+`stop_pid/2` (pid), `await_exit/2` (block until actually gone, raising rather
+than continuing on timeout — a helper that returns quietly on timeout leaves
+the caller asserting against a live process, which is the situation being
+avoided).
+
+### Not every sleep is a bug
+
+All 35 `Process.sleep` calls were classified rather than swept. Twelve were
+`Process.sleep(:infinity)` — a stub process parked until something kills it,
+not a wait at all. That left 23 finite sleeps, now 8:
+
+**Removed because there was never anything to wait for (5).** A `GenServer.call`
+from the same process that sent the earlier messages is already a barrier:
+Erlang orders messages pairwise between two processes, so every `send` is ahead
+of the `call` in the mailbox and has been handled before the reply comes back
+(`event/integration_test.exs` ×3, `nav/screen_nav_test.exs`). And
+`Trace.broadcast/3` folds over the table *in the calling process*, so its
+cleanup is done by the time `dispatch/4` returns `:ok` (`event/trace_test.exs`).
+These sleeps were guarding against nothing.
+
+**Replaced with the real barrier (8).** A ready-message where the test was
+waiting on another process to reach a known point (`trace_test.exs`,
+`device_test.exs`); `Logger.flush/0` where it was waiting on handlers to drain
+(`native_logger_test.exs` ×2, `theme_host_test.exs` ×2); a monitor where it was
+waiting for an exit.
+
+**Replaced with a bounded poll (3).** `device_test.exs` (×2) and
+`native_component_examples_test.exs` wait for a GenServer to
+process a `:DOWN` sent by a *monitor*, not by the test. Pairwise ordering does
+not help here — the test never sent that message, so a `call` orders nothing
+against it. `ProcessHelpers.eventually/2` polls with a deadline: it returns as
+soon as the state is right rather than always paying the worst case, and it
+fails with "condition still false after Nms" instead of letting the next
+assertion report something confusing.
+
+**Kept, deliberately (8).** Three in `render_stats_test.exs` are the subject
+under test — it measures elapsed time, so time must actually elapse. Three are
+the backoff *inside* a poll loop that has its own deadline (`eventually/2`
+itself, `migration_test.exs`, `reset_transition_test.exs`). One is a `@doc`
+example, quoting the bad pattern in order to name it. One remains a genuine
+bet: `router_hot_path_test.exs:206` waits for a message the *screen* sent to
+the router, and the test is neither party, so it has no ordering guarantee to
+lean on. It is left as a sleep and recorded here rather than disguised.
+
+One honest caveat about the `Logger.flush/0` swaps: with the barrier deleted
+outright those tests still passed 8 times out of 8 on this machine, so the wait
+is not demonstrably load-bearing here. `flush/0` is kept because it is the
+correct primitive and costs nothing when there is nothing pending, whereas the
+sleep it replaced was a guess that cost 300ms per run. That is a reason, not a
+measurement, and is stated as such.
+
+## Consequences
+
+- `mix mob.flake` runs the suite repeatedly and reports which tests are
+  non-deterministic. Its green output says explicitly that a 1-in-17 flake
+  survives 20 green runs about 30% of the time, because "I ran it 20 times" is
+  the reasoning that let this persist.
+- **The registry race is fixed by construction, not by demonstration.** It did
+  not reproduce here in 25 full-suite runs or 40 concentrated ones, so there is
+  no before-and-after to show. The mechanism is provable by reading the code
+  and it was observed once on this machine; the fix removes the ownership that
+  makes it possible. That is weaker evidence than a reproduction and is stated
+  as such.
+
+- **Tightening `stop_pid/2` broke three tests, and only under a full run.**
+  Making the timeout raise meant replacing a blanket `:exit, _ -> :ok` with
+  enumerated clauses. The enumeration was wrong: a linked owner dying while
+  ExUnit tears the test down exits with `{{:shutdown, {:sys, :terminate, _}},
+  {GenServer, :stop, _}}`, which matched none of them. It passed every file run
+  on its own and failed 3 tests in one full run and 4 in the next. The fix is
+  to invert the logic — special-case only the timeout, treat every other exit
+  as "already gone" — because "did it stop" has one interesting answer and an
+  open-ended set of uninteresting ones. Enumerating the uninteresting set is a
+  bet on having seen every shutdown shape, which is the same class of mistake
+  as betting on a duration.

--- a/lib/mix/tasks/mob.flake.ex
+++ b/lib/mix/tasks/mob.flake.ex
@@ -110,9 +110,22 @@ defmodule Mix.Tasks.Mob.Flake do
 
     Mix.shell().error("\n\n#{length(ordered)} failure(s) in #{runs} run(s):\n")
 
+    # Always write the full log to disk, not just the summarised extract. A rare
+    # failure may not come back: it is entirely possible to watch one go past,
+    # fail to reproduce it in a hundred later runs, and be left with nothing to
+    # go on because the only copy was a summary on a terminal that scrolled.
+    # That happened while building this task. The artefact costs nothing and is
+    # the difference between a lead and a rumour.
+    dir = Path.join([Mix.Project.build_path(), "mob_flake"])
+    File.mkdir_p!(dir)
+
     for {attempt, output} <- ordered do
+      path = Path.join(dir, "run-#{attempt}.log")
+      File.write!(path, output)
+
       Mix.shell().error("── run #{attempt} " <> String.duplicate("─", 50))
       Mix.shell().error(failing_tests(output))
+      Mix.shell().info([:faint, "   full log: #{Path.relative_to_cwd(path)}", :reset])
     end
 
     Mix.shell().info([
@@ -133,20 +146,29 @@ defmodule Mix.Tasks.Mob.Flake do
   # possible bug, and it was in the first version of this function.
   @header ~r/^\s+\d+\) (test|doctest|property) /
 
+  # ExUnit's own trailer. A failure block runs until this, not to the end of the
+  # log — otherwise the last one absorbs the summary and the seed line, which is
+  # exactly the noise this function exists to strip.
+  @summary ~r/^(Finished in |\d+ (test|doctest|property)|Randomized with seed )/
+
   @doc false
-  @spec failing_tests(String.t()) :: [String.t()]
+  @spec failing_tests(String.t()) :: String.t()
   def failing_tests(output) do
     output
     |> String.split("\n")
     |> Enum.reduce([], fn line, acc ->
       cond do
-        Regex.match?(@header, line) -> [[line] | acc]
+        Regex.match?(@header, line) -> [{:open, [line]} | acc]
         acc == [] -> acc
-        true -> [[line | hd(acc)] | tl(acc)]
+        match?([{:closed, _} | _], acc) -> acc
+        Regex.match?(@summary, line) -> [{:closed, elem(hd(acc), 1)} | tl(acc)]
+        true -> [{:open, [line | elem(hd(acc), 1)]} | tl(acc)]
       end
     end)
     |> Enum.reverse()
-    |> Enum.map(fn block -> block |> Enum.reverse() |> Enum.take(8) |> Enum.join("\n") end)
+    |> Enum.map(fn {_, block} ->
+      block |> Enum.reverse() |> Enum.join("\n") |> String.trim_trailing()
+    end)
     |> case do
       [] -> output |> String.split("\n") |> Enum.take(-15) |> Enum.join("\n")
       blocks -> Enum.join(blocks, "\n\n")

--- a/lib/mix/tasks/mob.flake.ex
+++ b/lib/mix/tasks/mob.flake.ex
@@ -1,0 +1,155 @@
+defmodule Mix.Tasks.Mob.Flake do
+  @shortdoc "Run the suite repeatedly to surface flaky tests"
+
+  @moduledoc """
+  Run the test suite until it fails, or a set number of times, and report
+  which tests were not deterministic.
+
+  A flake does not announce itself. It fails once, on someone else's branch,
+  and the natural response is to re-run and move on — which is how a 1-in-17
+  failure survived long enough to corrupt a mutation-testing verdict and send
+  a bisect down the wrong path. This makes looking cheap and deliberate.
+
+      mix mob.flake                    # 20 runs, stop at the first failure
+      mix mob.flake --runs 50          # more attempts
+      mix mob.flake --until-failure    # keep going until one fails
+      mix mob.flake --keep-going       # run them all, report every failure
+      mix mob.flake test/mob/nav       # narrow the target
+      mix mob.flake --seed 0           # fix the seed, so ordering is constant
+
+  ## Reading the result
+
+  A test that fails under `--seed 0` on every run is not flaky, it is broken.
+  This looks for the other kind: tests that pass and fail with everything else
+  held still. Those are almost always a race — a `Process.sleep` standing in
+  for synchronisation, a check-then-act across a process boundary, or shared
+  global state (a named process, an ETS table) whose lifetime is tied to
+  whichever test happened to start it.
+
+  Narrowing helps more than volume. If a failure names one module, run that
+  module 200 times rather than the suite 20 more times.
+  """
+
+  use Mix.Task
+
+  @switches [runs: :integer, until_failure: :boolean, keep_going: :boolean, seed: :integer]
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, paths} = OptionParser.parse!(argv, strict: @switches)
+
+    runs = Keyword.get(opts, :runs, 20)
+    until_failure? = Keyword.get(opts, :until_failure, false)
+    keep_going? = Keyword.get(opts, :keep_going, false)
+    limit = if until_failure?, do: :infinity, else: runs
+
+    Mix.shell().info([
+      :cyan,
+      "Running the suite #{describe(limit)}, ",
+      if(keep_going?, do: "reporting every failure.", else: "stopping at the first failure."),
+      :reset
+    ])
+
+    loop(1, limit, keep_going?, opts, paths, [])
+  end
+
+  defp describe(:infinity), do: "until it fails"
+  defp describe(n), do: "#{n} time(s)"
+
+  defp loop(attempt, limit, keep_going?, opts, paths, failures) do
+    if limit != :infinity and attempt > limit do
+      report(attempt - 1, failures)
+    else
+      case run_once(opts, paths) do
+        :ok ->
+          IO.write(".")
+          loop(attempt + 1, limit, keep_going?, opts, paths, failures)
+
+        {:failed, output} ->
+          IO.write("F")
+          failures = [{attempt, output} | failures]
+
+          if keep_going? and limit != :infinity do
+            loop(attempt + 1, limit, keep_going?, opts, paths, failures)
+          else
+            report(attempt, failures)
+          end
+      end
+    end
+  end
+
+  defp run_once(opts, paths) do
+    args =
+      ["test"] ++
+        paths ++
+        case Keyword.fetch(opts, :seed) do
+          {:ok, seed} -> ["--seed", to_string(seed)]
+          :error -> []
+        end
+
+    # Fresh OS process per run, deliberately: an in-process re-run would share
+    # the ETS tables and named processes that cause most of these failures, so
+    # it could not reproduce them.
+    {output, status} = System.cmd("mix", args, stderr_to_stdout: true, env: [{"MIX_ENV", "test"}])
+
+    if status == 0, do: :ok, else: {:failed, output}
+  end
+
+  defp report(runs, []) do
+    Mix.shell().info([:green, "\n\n#{runs} run(s), no failures.", :reset])
+
+    Mix.shell().info([
+      "\nThat is evidence, not proof. A 1-in-17 flake survives 20 green runs ",
+      "about 30% of the time — narrow the target and raise --runs before ",
+      "concluding a suspected flake is gone."
+    ])
+  end
+
+  defp report(runs, failures) do
+    ordered = Enum.reverse(failures)
+
+    Mix.shell().error("\n\n#{length(ordered)} failure(s) in #{runs} run(s):\n")
+
+    for {attempt, output} <- ordered do
+      Mix.shell().error("── run #{attempt} " <> String.duplicate("─", 50))
+      Mix.shell().error(failing_tests(output))
+    end
+
+    Mix.shell().info([
+      "\nRe-run the named module alone, many times, before changing anything. ",
+      "A failure that only appears in the full suite is usually shared global ",
+      "state, not the test's own logic."
+    ])
+
+    exit({:shutdown, 1})
+  end
+
+  # The whole log is noise; what matters is which tests failed and why.
+  #
+  # Split on failure headers rather than sliding a window over the lines. A
+  # window silently loses any failure near the end of the output — and because
+  # an earlier match makes the fallback unreachable, it loses it without saying
+  # so. For a tool that exists to surface rare failures, that is the worst
+  # possible bug, and it was in the first version of this function.
+  @header ~r/^\s+\d+\) (test|doctest|property) /
+
+  @doc false
+  @spec failing_tests(String.t()) :: [String.t()]
+  def failing_tests(output) do
+    output
+    |> String.split("\n")
+    |> Enum.reduce([], fn line, acc ->
+      cond do
+        Regex.match?(@header, line) -> [[line] | acc]
+        acc == [] -> acc
+        true -> [[line | hd(acc)] | tl(acc)]
+      end
+    end)
+    |> Enum.reverse()
+    |> Enum.map(fn block -> block |> Enum.reverse() |> Enum.take(8) |> Enum.join("\n") end)
+    |> case do
+      [] -> output |> String.split("\n") |> Enum.take(-15) |> Enum.join("\n")
+      blocks -> Enum.join(blocks, "\n\n")
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -216,6 +216,11 @@ defmodule Mob.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/genericjam/mob"},
+      # `lib/mix/tasks/mob.flake.ex` is deliberately absent: it is a
+      # repo-internal tool that shells out to `mix test` in whatever project
+      # loads it, and its docs quote this repo's own bisect history. Every app
+      # depending on mob would otherwise gain a `mix mob.flake`.
+      exclude_patterns: ["lib/mix/tasks/mob.flake.ex"],
       files: ~w(
         lib src priv
         android ios assets

--- a/test/mix/mob_flake_test.exs
+++ b/test/mix/mob_flake_test.exs
@@ -1,0 +1,113 @@
+defmodule Mix.Tasks.Mob.FlakeTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Mob.Flake
+
+  # `mix mob.flake` exists to surface rare failures. If its own parser drops
+  # one, the tool reports green and the flake stays hidden — a worse outcome
+  # than not having the tool, because it launders a guess into a verdict. Two
+  # versions of this parser had exactly that bug (a sliding window that
+  # discarded the last block; a fallback made unreachable by an earlier match),
+  # so the property under test throughout is: nothing is lost.
+
+  defp block(name, mod, i) do
+    line = i * 10
+
+    [
+      "  #{i}) test #{name} (#{mod})",
+      "     test/some/path_test.exs:#{line}",
+      "     Assertion with == failed",
+      "     code:  assert foo() == :bar",
+      "     left:  :baz",
+      "     right: :bar",
+      "     stacktrace:",
+      "       test/some/path_test.exs:#{line}: (test)"
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp run_output(failures) do
+    blocks =
+      failures
+      |> Enum.with_index(1)
+      |> Enum.map_join("\n\n", fn {{name, mod}, i} -> block(name, mod, i) end)
+
+    """
+    Compiling 1 file (.ex)
+    ....
+
+    #{blocks}
+
+    Finished in 0.4 seconds (0.2s async, 0.2s sync)
+    #{length(failures) + 4} tests, #{length(failures)} failures
+
+    Randomized with seed 123456
+    """
+  end
+
+  describe "failing_tests/1" do
+    test "reports every failure, including the last one" do
+      out =
+        run_output([
+          {"alpha does a thing", "My.FirstTest"},
+          {"beta does another", "My.SecondTest"},
+          {"gamma is last", "My.ThirdTest"}
+        ])
+
+      extract = Flake.failing_tests(out)
+
+      # The last block is the one both previous implementations lost.
+      assert extract =~ "alpha does a thing"
+      assert extract =~ "beta does another"
+      assert extract =~ "gamma is last"
+    end
+
+    test "keeps the whole failure body rather than truncating it" do
+      extract = Flake.failing_tests(run_output([{"alpha", "My.Test"}]))
+
+      # A fixed line cap cut ordinary failures off mid-stacktrace, which is the
+      # part that says *where*.
+      assert extract =~ "Assertion with == failed"
+      assert extract =~ "left:  :baz"
+      assert extract =~ "stacktrace:"
+      assert extract =~ "test/some/path_test.exs:10: (test)"
+    end
+
+    test "stops at ExUnit's summary instead of absorbing it" do
+      extract = Flake.failing_tests(run_output([{"alpha", "My.Test"}]))
+
+      refute extract =~ "Finished in",
+             "the run summary is the noise this function exists to strip"
+
+      refute extract =~ "Randomized with seed"
+      refute extract =~ "tests, 1 failures"
+    end
+
+    test "falls back to the tail when the run died before any failure block" do
+      # A compile error produces no `1) test ...` header at all. Returning "" here
+      # would report a failing run with no explanation.
+      out = """
+      == Compilation error in file lib/broken.ex ==
+      ** (SyntaxError) unexpected token
+          lib/broken.ex:12
+      """
+
+      extract = Flake.failing_tests(out)
+
+      assert extract =~ "Compilation error"
+      assert extract =~ "SyntaxError"
+    end
+
+    test "hands back the tail when a run has no failure blocks at all" do
+      clean = "....\n\nFinished in 0.1 seconds\n4 tests, 0 failures\n"
+
+      # Not "": a caller looking at this had a reason to, so show the run's end
+      # rather than an empty string that says nothing about why.
+      assert Flake.failing_tests(clean) =~ "4 tests, 0 failures"
+    end
+
+    test "returns empty for empty input rather than raising" do
+      assert Flake.failing_tests("") == ""
+    end
+  end
+end

--- a/test/mob/component_server_test.exs
+++ b/test/mob/component_server_test.exs
@@ -75,10 +75,7 @@ defmodule Mob.ComponentServerTest do
     # async test file (component_test.exs) may have already started it —
     # start_supervised! would raise on {:already_started, _}, so tolerate
     # that instead of racing to be first.
-    case start_supervised({Mob.ComponentRegistry, []}) do
-      {:ok, _pid} -> :ok
-      {:error, {:already_started, _pid}} -> :ok
-    end
+    Mob.Test.ProcessHelpers.ensure_component_registry()
 
     {:ok, pid} =
       Mob.ComponentServer.start(
@@ -253,10 +250,7 @@ defmodule Mob.ComponentServerTest do
     end
 
     setup do
-      case start_supervised({Mob.ComponentRegistry, []}) do
-        {:ok, _pid} -> :ok
-        {:error, {:already_started, _pid}} -> :ok
-      end
+      Mob.Test.ProcessHelpers.ensure_component_registry()
 
       # Unlinked, fixed-name Agent (mirrors test/mob/renderer_test.exs's
       # MockNIF) — reset rather than restarted, since a prior test in this

--- a/test/mob/component_server_test.exs
+++ b/test/mob/component_server_test.exs
@@ -71,11 +71,9 @@ defmodule Mob.ComponentServerTest do
   end
 
   setup do
-    # Mob.ComponentRegistry registers under a fixed global name. Another
-    # async test file (component_test.exs) may have already started it —
-    # start_supervised! would raise on {:already_started, _}, so tolerate
-    # that instead of racing to be first.
-    Mob.Test.ProcessHelpers.ensure_component_registry()
+    # Mob.ComponentRegistry registers under a fixed global name and is owned by
+    # the run (test_helper.exs), not by whichever async file starts first.
+    {:ok, _} = Mob.Test.ProcessHelpers.ensure_component_registry()
 
     {:ok, pid} =
       Mob.ComponentServer.start(
@@ -250,7 +248,7 @@ defmodule Mob.ComponentServerTest do
     end
 
     setup do
-      Mob.Test.ProcessHelpers.ensure_component_registry()
+      {:ok, _} = Mob.Test.ProcessHelpers.ensure_component_registry()
 
       # Unlinked, fixed-name Agent (mirrors test/mob/renderer_test.exs's
       # MockNIF) — reset rather than restarted, since a prior test in this

--- a/test/mob/component_test.exs
+++ b/test/mob/component_test.exs
@@ -130,11 +130,8 @@ defmodule Mob.ComponentTest do
       # racing to be first (MOB-98: this is the shared-name race that fix
       # already covers on that file's side; this file needed the same
       # tolerance).
-      reg =
-        case start_supervised({Mob.ComponentRegistry, []}) do
-          {:ok, pid} -> pid
-          {:error, {:already_started, pid}} -> pid
-        end
+      :ok = Mob.Test.ProcessHelpers.ensure_component_registry()
+      reg = Process.whereis(Mob.ComponentRegistry)
 
       {:ok, reg: reg}
     end

--- a/test/mob/component_test.exs
+++ b/test/mob/component_test.exs
@@ -123,15 +123,13 @@ defmodule Mob.ComponentTest do
 
   describe "Mob.ComponentRegistry" do
     setup do
-      # Mob.ComponentRegistry registers under a fixed global name. Another
-      # async test file (component_server_test.exs) may have already started
-      # it — start_supervised/1 returns {:error, {:already_started, _}} in
-      # that case rather than raising, so tolerate either order instead of
-      # racing to be first (MOB-98: this is the shared-name race that fix
-      # already covers on that file's side; this file needed the same
-      # tolerance).
-      :ok = Mob.Test.ProcessHelpers.ensure_component_registry()
-      reg = Process.whereis(Mob.ComponentRegistry)
+      # Mob.ComponentRegistry registers under a fixed global name, and the run
+      # owns it (test_helper.exs starts it) rather than whichever async file
+      # got there first. Take the pid from the helper: a separate
+      # Process.whereis/1 here would be the same check-then-act this module
+      # exists to remove, and would hand back nil if anything stopped the
+      # registry in between.
+      {:ok, reg} = Mob.Test.ProcessHelpers.ensure_component_registry()
 
       {:ok, reg: reg}
     end

--- a/test/mob/data_dir_test.exs
+++ b/test/mob/data_dir_test.exs
@@ -12,7 +12,7 @@ defmodule Mob.DataDirTest do
   defp restore(var, val), do: System.put_env(var, val)
 
   test "data_dir/0 returns MOB_DATA_DIR and creates it" do
-    base = Path.join(System.tmp_dir!(), "mob_data_dir_test_#{System.unique_integer([:positive])}")
+    base = Mob.Test.ProcessHelpers.tmp_path("mob_data_dir_test")
     File.rm_rf!(base)
     System.put_env("MOB_DATA_DIR", base)
 
@@ -28,7 +28,7 @@ defmodule Mob.DataDirTest do
   end
 
   test "data_dir/1 returns and creates a subdirectory" do
-    base = Path.join(System.tmp_dir!(), "mob_data_dir_test_#{System.unique_integer([:positive])}")
+    base = Mob.Test.ProcessHelpers.tmp_path("mob_data_dir_test")
     File.rm_rf!(base)
     System.put_env("MOB_DATA_DIR", base)
 

--- a/test/mob/device_test.exs
+++ b/test/mob/device_test.exs
@@ -227,20 +227,34 @@ defmodule Mob.DeviceTest do
     end
 
     test "subscriber pid going down is auto-removed", %{dispatcher: d} do
+      parent = self()
+
       task =
         Task.async(fn ->
           :ok = GenServer.call(d, {:subscribe, self(), [:app]})
-          :done
+          send(parent, :subscribed)
+          receive do: (:finish -> :done)
         end)
 
+      # Prove the entry was actually there before asserting it goes away. Without
+      # this the poll below is satisfied on its first pass by a dispatcher that
+      # never stored the subscriber at all, or stored it under a different key.
+      assert_receive :subscribed
+      assert Map.has_key?(GenServer.call(d, :__test_subscribers__), task.pid)
+
+      send(task.pid, :finish)
       assert Task.await(task) == :done
 
       # The :DOWN comes from the monitor, not from this process, so a call here
-      # orders nothing. Poll until the server has actually pruned the entry.
+      # orders nothing against it. Poll until the server has actually pruned.
       Mob.Test.ProcessHelpers.eventually(fn ->
         subs = GenServer.call(d, :__test_subscribers__)
         not Map.has_key?(subs, task.pid)
       end)
+
+      # Keep a real assertion as the test's own last word, rather than letting a
+      # helper's success be the only thing standing between this test and green.
+      refute Map.has_key?(GenServer.call(d, :__test_subscribers__), task.pid)
     end
 
     test "double-subscribe replaces categories rather than duplicating", %{dispatcher: d} do
@@ -287,18 +301,27 @@ defmodule Mob.DeviceTest do
     end
 
     test "subscriber pid down is removed" do
+      parent = self()
+
       task =
         Task.async(fn ->
           :ok = Mob.Device.IOS.subscribe()
-          :done
+          send(parent, :subscribed)
+          receive do: (:finish -> :done)
         end)
 
+      assert_receive :subscribed
+      assert Map.has_key?(GenServer.call(Mob.Device.IOS, :__test_subscribers__), task.pid)
+
+      send(task.pid, :finish)
       assert Task.await(task) == :done
 
       Mob.Test.ProcessHelpers.eventually(fn ->
         subs = GenServer.call(Mob.Device.IOS, :__test_subscribers__)
         not Map.has_key?(subs, task.pid)
       end)
+
+      refute Map.has_key?(GenServer.call(Mob.Device.IOS, :__test_subscribers__), task.pid)
     end
   end
 

--- a/test/mob/device_test.exs
+++ b/test/mob/device_test.exs
@@ -17,7 +17,7 @@ defmodule Mob.DeviceTest do
       GenServer.start_link(Device, [], name: :"device_#{System.unique_integer([:positive])}")
 
     on_exit(fn ->
-      if Process.alive?(pid), do: GenServer.stop(pid)
+      Mob.Test.ProcessHelpers.stop_pid(pid)
     end)
 
     {:ok, dispatcher: pid}
@@ -197,22 +197,22 @@ defmodule Mob.DeviceTest do
     end
 
     test "multiple subscribers all receive matching events", %{dispatcher: d} do
-      task1 =
-        Task.async(fn ->
-          :ok = GenServer.call(d, {:subscribe, self(), [:app]})
-          assert_receive {:mob_device, :did_become_active}, 200
-          :got_it
-        end)
+      parent = self()
 
-      task2 =
-        Task.async(fn ->
-          :ok = GenServer.call(d, {:subscribe, self(), [:app]})
-          assert_receive {:mob_device, :did_become_active}, 200
-          :got_it
-        end)
+      subscriber = fn ->
+        :ok = GenServer.call(d, {:subscribe, self(), [:app]})
+        send(parent, :subscribed)
+        assert_receive {:mob_device, :did_become_active}, 200
+        :got_it
+      end
 
-      # Give both tasks time to subscribe.
-      Process.sleep(20)
+      task1 = Task.async(subscriber)
+      task2 = Task.async(subscriber)
+
+      # Both subscriptions must be registered before the event is sent. The
+      # tasks say when that is true; sleeping only guessed at it.
+      assert_receive :subscribed
+      assert_receive :subscribed
       send(d, {:mob_device, :did_become_active})
 
       assert Task.await(task1) == :got_it
@@ -234,11 +234,13 @@ defmodule Mob.DeviceTest do
         end)
 
       assert Task.await(task) == :done
-      # Wait for the :DOWN to be processed.
-      Process.sleep(50)
 
-      subs = GenServer.call(d, :__test_subscribers__)
-      refute Map.has_key?(subs, task.pid)
+      # The :DOWN comes from the monitor, not from this process, so a call here
+      # orders nothing. Poll until the server has actually pruned the entry.
+      Mob.Test.ProcessHelpers.eventually(fn ->
+        subs = GenServer.call(d, :__test_subscribers__)
+        not Map.has_key?(subs, task.pid)
+      end)
     end
 
     test "double-subscribe replaces categories rather than duplicating", %{dispatcher: d} do
@@ -292,10 +294,11 @@ defmodule Mob.DeviceTest do
         end)
 
       assert Task.await(task) == :done
-      Process.sleep(50)
 
-      subs = GenServer.call(Mob.Device.IOS, :__test_subscribers__)
-      refute Map.has_key?(subs, task.pid)
+      Mob.Test.ProcessHelpers.eventually(fn ->
+        subs = GenServer.call(Mob.Device.IOS, :__test_subscribers__)
+        not Map.has_key?(subs, task.pid)
+      end)
     end
   end
 

--- a/test/mob/event/integration_test.exs
+++ b/test/mob/event/integration_test.exs
@@ -123,7 +123,10 @@ defmodule Mob.Event.IntegrationTest do
       send(screen, {:tap, {:list, :items, :select, 0}})
       send(screen, {:tap, :stop})
 
-      Process.sleep(20)
+      # No sleep: `get_log/1` is a GenServer.call from the same process that
+      # sent the events above. Erlang guarantees message order between a pair
+      # of processes, so every send is already in the mailbox ahead of the
+      # call, and the screen handles them in order before replying.
       log = TestScreen.get_log(screen)
 
       assert log == [
@@ -141,7 +144,6 @@ defmodule Mob.Event.IntegrationTest do
       send(screen, {:not_an_event, :ignored})
       send(screen, {:tap, :b})
 
-      Process.sleep(20)
       log = TestScreen.get_log(screen)
 
       # Only the two recognised taps:
@@ -204,7 +206,6 @@ defmodule Mob.Event.IntegrationTest do
         )
       end
 
-      Process.sleep(20)
       log = TestScreen.get_log(screen)
 
       seqs =

--- a/test/mob/event/target_test.exs
+++ b/test/mob/event/target_test.exs
@@ -66,7 +66,7 @@ defmodule Mob.Event.TargetTest do
 
     test "dead pid errors" do
       pid = spawn(fn -> :ok end)
-      Process.sleep(10)
+      Mob.Test.ProcessHelpers.await_exit(pid)
       refute Process.alive?(pid)
       s = scope()
       assert Target.resolve(pid, s) == {:error, :dead_pid}

--- a/test/mob/event/trace_test.exs
+++ b/test/mob/event/trace_test.exs
@@ -26,15 +26,21 @@ defmodule Mob.Event.TraceTest do
     end
 
     test "multiple subscribers all see the event" do
+      parent = self()
+
       task =
         Task.async(fn ->
           Trace.subscribe()
+          # The dispatch below must not run until this subscription is in the
+          # table. Sleeping guessed at how long that takes across processes;
+          # the ready-message is the actual ordering constraint.
+          send(parent, :subscribed)
           assert_receive {:mob_trace, _, :tap, nil}, 200
           :got_it
         end)
 
       Trace.subscribe()
-      Process.sleep(20)
+      assert_receive :subscribed
 
       :ok = Event.dispatch(self(), addr(), :tap, nil)
 
@@ -95,12 +101,14 @@ defmodule Mob.Event.TraceTest do
           # Exit immediately
         end)
 
-      Process.sleep(10)
+      Mob.Test.ProcessHelpers.await_exit(pid)
       refute Process.alive?(pid)
 
       # Now dispatch — broadcast should silently skip the dead pid and clean up.
+      # `broadcast/3` folds over the table in the *calling* process, so the
+      # delete has already happened by the time dispatch returns :ok. There is
+      # nothing to wait for.
       :ok = Event.dispatch(self(), addr(), :tap, nil)
-      Process.sleep(10)
 
       # Verify the dead pid was removed.
       assert :ets.lookup(:mob_event_trace, pid) == []

--- a/test/mob/listener_test.exs
+++ b/test/mob/listener_test.exs
@@ -13,17 +13,8 @@ defmodule Mob.ListenerTest do
 
   defp start_listener do
     {:ok, pid} = Listener.start_link([])
-    on_exit(fn -> stop_safely(pid) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
     pid
-  end
-
-  # `if Process.alive?, do: GenServer.stop` races: the process can exit between
-  # the check and the stop, and the :noproc exit then fails the test from inside
-  # the on_exit runner.
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
   end
 
   describe "handler/1 without a listener" do
@@ -284,7 +275,9 @@ defmodule Mob.ListenerTest do
       assert :ok = Listener.ensure_started()
       # Registered before the assertions below, so a failure cannot leak a
       # listener into unrelated test files.
-      on_exit(fn -> if pid = Process.whereis(Listener), do: stop_safely(pid) end)
+      on_exit(fn ->
+        if pid = Process.whereis(Listener), do: Mob.Test.ProcessHelpers.stop_pid(pid)
+      end)
 
       assert Listener.running?()
       pid = Process.whereis(Listener)
@@ -304,7 +297,7 @@ defmodule Mob.ListenerTest do
 
       assert_receive :started
       listener = Process.whereis(Listener)
-      on_exit(fn -> stop_safely(listener) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(listener) end)
 
       ref = Process.monitor(caller)
       send(caller, :die)

--- a/test/mob/listener_test.exs
+++ b/test/mob/listener_test.exs
@@ -166,10 +166,7 @@ defmodule Mob.ListenerTest do
     end
 
     setup do
-      case Process.whereis(FakeNative) do
-        nil -> :ok
-        pid -> Agent.stop(pid)
-      end
+      Mob.Test.ProcessHelpers.stop_if_running(FakeNative)
 
       FakeNative.start()
       :ok

--- a/test/mob/native_component_examples_test.exs
+++ b/test/mob/native_component_examples_test.exs
@@ -748,7 +748,19 @@ defmodule Mob.NativeComponentExamplesTest do
                ])
 
       :rpc.call(@node, Process, :exit, [pid, :shutdown])
-      Process.sleep(50)
+
+      # The registry prunes on a :DOWN from its own monitor, which this test
+      # never sent — so nothing here orders against it. Poll until it lands.
+      Mob.Test.ProcessHelpers.eventually(fn ->
+        match?(
+          {:error, :not_found},
+          :rpc.call(@node, Mob.ComponentRegistry, :lookup, [
+            screen_pid,
+            :od_pdf_term,
+            PDFComponent
+          ])
+        )
+      end)
 
       assert {:error, :not_found} =
                :rpc.call(@node, Mob.ComponentRegistry, :lookup, [

--- a/test/mob/native_logger_test.exs
+++ b/test/mob/native_logger_test.exs
@@ -107,8 +107,9 @@ defmodule Mob.NativeLoggerTest do
 
     test "Logger.info/1 reaches the handler end-to-end", %{nif_pid: pid} do
       Logger.info("end-to-end test")
-      # Give the async logger handler a moment to flush
-      Process.sleep(50)
+      # `Logger.flush/0` blocks until the handlers have drained — the actual
+      # barrier the sleep was approximating.
+      Logger.flush()
       calls = MockNIF.calls(pid)
 
       assert Enum.any?(calls, fn {level, msg} ->
@@ -118,7 +119,7 @@ defmodule Mob.NativeLoggerTest do
 
     test "Logger.error/1 reaches the handler with :error level", %{nif_pid: pid} do
       Logger.error("something broke")
-      Process.sleep(50)
+      Logger.flush()
       calls = MockNIF.calls(pid)
 
       assert Enum.any?(calls, fn {level, msg} ->

--- a/test/mob/native_logger_test.exs
+++ b/test/mob/native_logger_test.exs
@@ -107,8 +107,11 @@ defmodule Mob.NativeLoggerTest do
 
     test "Logger.info/1 reaches the handler end-to-end", %{nif_pid: pid} do
       Logger.info("end-to-end test")
-      # `Logger.flush/0` blocks until the handlers have drained — the actual
-      # barrier the sleep was approximating.
+      # Not really a barrier: `Mob.NativeLogger` is a plain :logger handler, and
+      # :logger invokes handlers synchronously in the calling process, so the
+      # mock has already been written by the time Logger.info/1 returns. The
+      # sleep here was guarding against nothing. `flush/0` is kept as the honest
+      # way to say "and nothing is queued", at no cost, rather than a duration.
       Logger.flush()
       calls = MockNIF.calls(pid)
 

--- a/test/mob/nav/multi_stack_test.exs
+++ b/test/mob/nav/multi_stack_test.exs
@@ -129,21 +129,12 @@ defmodule Mob.Nav.MultiStackTest do
     Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, pid} = Mob.Nav.Registry.start_link(TabApp)
-    on_exit(fn -> stop_safely(pid) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
 
     {:ok, screen} = Mob.Screen.start_link(HomeScreen, %{})
-    on_exit(fn -> stop_safely(screen) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(screen) end)
 
     %{screen: screen}
-  end
-
-  # `if Process.alive?, do: GenServer.stop` races: the process can exit between
-  # the check and the stop, and the :noproc exit then fails the test from inside
-  # the on_exit runner. Screens and their owner die with the test process.
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
   end
 
   describe "switching stacks" do

--- a/test/mob/nav/registry_test.exs
+++ b/test/mob/nav/registry_test.exs
@@ -50,26 +50,26 @@ defmodule Mob.Nav.RegistryTest do
     test "starts the registry and seeds it from the app module" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
       assert is_pid(pid)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
     end
   end
 
   describe "lookup/1" do
     test "finds a registered screen" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
       assert {:ok, HomeScreen} = Mob.Nav.Registry.lookup(:home)
     end
 
     test "returns not_found for unknown atom" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
       assert {:error, :not_found} = Mob.Nav.Registry.lookup(:nonexistent)
     end
 
     test "seeds both platforms from tab_bar app" do
       {:ok, pid} = Mob.Nav.Registry.start_link(TabApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
       assert {:ok, HomeScreen} = Mob.Nav.Registry.lookup(:home)
       assert {:ok, ProfileScreen} = Mob.Nav.Registry.lookup(:profile)
       assert {:ok, SettingsScreen} = Mob.Nav.Registry.lookup(:settings)
@@ -79,14 +79,14 @@ defmodule Mob.Nav.RegistryTest do
   describe "register/2" do
     test "registers a name→module mapping at runtime" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
       :ok = Mob.Nav.Registry.register(:detail, ProfileScreen)
       assert {:ok, ProfileScreen} = Mob.Nav.Registry.lookup(:detail)
     end
 
     test "overwrites an existing mapping" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
       :ok = Mob.Nav.Registry.register(:home, ProfileScreen)
       assert {:ok, ProfileScreen} = Mob.Nav.Registry.lookup(:home)
     end
@@ -95,7 +95,7 @@ defmodule Mob.Nav.RegistryTest do
   describe "register/3 + lookup_route/1 (route-bound params)" do
     test "params registered with the route come back via lookup_route" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
 
       :ok = Mob.Nav.Registry.register(:"/ash/post/list", ProfileScreen, %{resource: Post})
 
@@ -108,7 +108,7 @@ defmodule Mob.Nav.RegistryTest do
 
     test "register/2 entries resolve with empty route params" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
 
       :ok = Mob.Nav.Registry.register(:detail, ProfileScreen)
       assert Mob.Nav.Registry.lookup_route(:detail) == {:ok, ProfileScreen, %{}}
@@ -116,7 +116,7 @@ defmodule Mob.Nav.RegistryTest do
 
     test "app-navigation seeded routes resolve with empty route params" do
       {:ok, pid} = Mob.Nav.Registry.start_link(SimpleApp)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
       assert {:ok, _module, %{}} = Mob.Nav.Registry.lookup_route(:home)
     end
   end

--- a/test/mob/nav/reset_all_test.exs
+++ b/test/mob/nav/reset_all_test.exs
@@ -153,10 +153,7 @@ defmodule Mob.Nav.ResetAllTest do
   end
 
   setup do
-    case Process.whereis(Mob.Nav.Registry) do
-      nil -> :ok
-      pid -> Mob.Test.ProcessHelpers.stop_pid(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, registry} = Mob.Nav.Registry.start_link(TabApp)
     on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(registry) end)

--- a/test/mob/nav/reset_all_test.exs
+++ b/test/mob/nav/reset_all_test.exs
@@ -155,14 +155,14 @@ defmodule Mob.Nav.ResetAllTest do
   setup do
     case Process.whereis(Mob.Nav.Registry) do
       nil -> :ok
-      pid -> stop_safely(pid)
+      pid -> Mob.Test.ProcessHelpers.stop_pid(pid)
     end
 
     {:ok, registry} = Mob.Nav.Registry.start_link(TabApp)
-    on_exit(fn -> stop_safely(registry) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(registry) end)
 
     {:ok, router} = Mob.Screen.start_link(LoginScreen, %{source: :initial})
-    on_exit(fn -> stop_safely(router) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(router) end)
 
     %{router: router}
   end
@@ -302,11 +302,5 @@ defmodule Mob.Nav.ResetAllTest do
 
     assert Mob.Router.reset_all_supported?(Mob.Screen.Server, Mob.ScreenState)
     refute :code.is_loaded(Mob.ScreenState) == false
-  end
-
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
   end
 end

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -157,22 +157,20 @@ defmodule Mob.Nav.ResetTransitionTest do
     # directly. Mob.Router brings up the Sender and Listener under their global
     # names; leaving them behind is what produces cross-file ordering flakes.
     on_exit(fn ->
-      Mob.Test.ProcessHelpers.stop_pid(components)
+      # One list, not a sequence of raising calls: stop_pid/2 raises on timeout,
+      # so a wedged `components` would otherwise leave Sender and Listener alive
+      # under their global names — the exact cross-file leak this is preventing.
+      Mob.Test.ProcessHelpers.stop_all([
+        components,
+        Process.whereis(Mob.Sender),
+        Process.whereis(Mob.Listener)
+      ])
 
-      for name <- [Mob.Sender, Mob.Listener], pid = Process.whereis(name) do
-        Mob.Test.ProcessHelpers.stop_pid(pid)
-      end
-
-      case Process.whereis(RecordingNif) do
-        nil -> :ok
-        pid -> Agent.stop(pid)
-      end
+      Mob.Test.ProcessHelpers.stop_if_running(RecordingNif)
     end)
 
-    case Process.whereis(RecordingNif) do
-      nil -> RecordingNif.start()
-      pid -> Agent.stop(pid) && RecordingNif.start()
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(RecordingNif)
+    RecordingNif.start()
 
     {:ok, registry} = Mob.Nav.Registry.start_link(DemoApp)
     on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(registry) end)

--- a/test/mob/nav/reset_transition_test.exs
+++ b/test/mob/nav/reset_transition_test.exs
@@ -103,12 +103,6 @@ defmodule Mob.Nav.ResetTransitionTest do
     end
   end
 
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
-  end
-
   # The transition for the frame the reset painted, ignoring the initial mount.
   defp last_transition do
     Mob.Sender.sync(:infinity)
@@ -153,7 +147,7 @@ defmodule Mob.Nav.ResetTransitionTest do
   setup do
     for name <- [Mob.Nav.Registry, Mob.Sender, Mob.Listener, Mob.ComponentRegistry],
         pid = Process.whereis(name) do
-      stop_safely(pid)
+      Mob.Test.ProcessHelpers.stop_pid(pid)
     end
 
     # The render path reconciles components, which needs the registry's table.
@@ -163,10 +157,10 @@ defmodule Mob.Nav.ResetTransitionTest do
     # directly. Mob.Router brings up the Sender and Listener under their global
     # names; leaving them behind is what produces cross-file ordering flakes.
     on_exit(fn ->
-      stop_safely(components)
+      Mob.Test.ProcessHelpers.stop_pid(components)
 
       for name <- [Mob.Sender, Mob.Listener], pid = Process.whereis(name) do
-        stop_safely(pid)
+        Mob.Test.ProcessHelpers.stop_pid(pid)
       end
 
       case Process.whereis(RecordingNif) do
@@ -181,10 +175,10 @@ defmodule Mob.Nav.ResetTransitionTest do
     end
 
     {:ok, registry} = Mob.Nav.Registry.start_link(DemoApp)
-    on_exit(fn -> stop_safely(registry) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(registry) end)
 
     {:ok, router} = Mob.Router.start_root(HomeScreen, %{}, nif: RecordingNif)
-    on_exit(fn -> stop_safely(router) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(router) end)
 
     RecordingNif.reset()
     %{router: router}

--- a/test/mob/nav/screen_nav_test.exs
+++ b/test/mob/nav/screen_nav_test.exs
@@ -3,15 +3,6 @@ defmodule Mob.Nav.ScreenNavTest do
 
   import ExUnit.CaptureLog
 
-  # `if Process.alive?, do: GenServer.stop` races: the router dies with the test
-  # process, so it can exit between the check and the stop and fail the test
-  # from inside the on_exit runner.
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
-  end
-
   # ── Screen fixtures ────────────────────────────────────────────────────────
   # Bare module names inside nested defmodule blocks don't auto-alias to siblings.
   # Use module attributes with fully qualified names for cross-screen references.
@@ -93,7 +84,7 @@ defmodule Mob.Nav.ScreenNavTest do
     Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, pid} = Mob.Nav.Registry.start_link(DemoApp)
-    on_exit(fn -> stop_safely(pid) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
     :ok
   end
 
@@ -194,7 +185,8 @@ defmodule Mob.Nav.ScreenNavTest do
       {:ok, pid} = Mob.Screen.start_link(HomeScreen, %{})
       # Send an info message that would trigger pop — default handle_info is noop
       send(pid, :pop_test)
-      Process.sleep(10)
+      # `get_current_module/1` is a call from this same process, so :pop_test is
+      # already handled by the time it replies — no sleep needed.
       assert Mob.Screen.get_current_module(pid) == HomeScreen
       GenServer.stop(pid)
     end
@@ -297,7 +289,7 @@ defmodule Mob.Nav.ScreenNavTest do
       # would take down every screen — over a typo in push_screen/2. It is
       # caught: navigation is left untouched and the app carries on.
       {:ok, pid} = Mob.Screen.start_link(UnknownNavScreen, %{})
-      on_exit(fn -> stop_safely(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
 
       log = capture_log(fn -> assert :ok = Mob.Screen.dispatch(pid, "bad_nav", %{}) end)
 

--- a/test/mob/nav/screen_nav_test.exs
+++ b/test/mob/nav/screen_nav_test.exs
@@ -185,8 +185,18 @@ defmodule Mob.Nav.ScreenNavTest do
       {:ok, pid} = Mob.Screen.start_link(HomeScreen, %{})
       # Send an info message that would trigger pop — default handle_info is noop
       send(pid, :pop_test)
-      # `get_current_module/1` is a call from this same process, so :pop_test is
-      # already handled by the time it replies — no sleep needed.
+
+      # `pid` is the owner. :pop_test travels owner -> screen, and if the screen
+      # produced a nav action, screen -> owner. The test is not party to either
+      # hop, so pairwise ordering against a test -> owner call proves nothing:
+      # an earlier version of this test deleted the wait on that reasoning and
+      # stopped catching the regression it exists for.
+      #
+      # Syncing with the *screen* is a real barrier. Once its handle_info has
+      # returned, any {:nav_action, ...} it sent is already sitting in the
+      # owner's mailbox, so the call below queues behind it.
+      pid |> Mob.Screen.get_screen_pid() |> :sys.get_state()
+
       assert Mob.Screen.get_current_module(pid) == HomeScreen
       GenServer.stop(pid)
     end

--- a/test/mob/nav/tab_transition_test.exs
+++ b/test/mob/nav/tab_transition_test.exs
@@ -115,10 +115,7 @@ defmodule Mob.Nav.TabTransitionTest do
     {:ok, router} = Mob.Router.start_root(HomeScreen, %{}, nif: RecordingNif)
 
     on_exit(fn ->
-      Mob.Test.ProcessHelpers.stop_pid(router)
-      Mob.Test.ProcessHelpers.stop_pid(registry)
-      Mob.Test.ProcessHelpers.stop_pid(components)
-      Mob.Test.ProcessHelpers.stop_pid(crash_control)
+      Mob.Test.ProcessHelpers.stop_all([router, registry, components, crash_control])
 
       for name <- [Mob.Sender, Mob.Listener], pid = Process.whereis(name) do
         Mob.Test.ProcessHelpers.stop_pid(pid)

--- a/test/mob/nav/tab_transition_test.exs
+++ b/test/mob/nav/tab_transition_test.exs
@@ -105,7 +105,7 @@ defmodule Mob.Nav.TabTransitionTest do
   setup do
     for name <- [Mob.Nav.Registry, Mob.Sender, Mob.Listener, Mob.ComponentRegistry],
         pid = Process.whereis(name) do
-      stop_safely(pid)
+      Mob.Test.ProcessHelpers.stop_pid(pid)
     end
 
     {:ok, components} = Mob.ComponentRegistry.start_link()
@@ -115,16 +115,16 @@ defmodule Mob.Nav.TabTransitionTest do
     {:ok, router} = Mob.Router.start_root(HomeScreen, %{}, nif: RecordingNif)
 
     on_exit(fn ->
-      stop_safely(router)
-      stop_safely(registry)
-      stop_safely(components)
-      stop_safely(crash_control)
+      Mob.Test.ProcessHelpers.stop_pid(router)
+      Mob.Test.ProcessHelpers.stop_pid(registry)
+      Mob.Test.ProcessHelpers.stop_pid(components)
+      Mob.Test.ProcessHelpers.stop_pid(crash_control)
 
       for name <- [Mob.Sender, Mob.Listener], pid = Process.whereis(name) do
-        stop_safely(pid)
+        Mob.Test.ProcessHelpers.stop_pid(pid)
       end
 
-      stop_safely(recording)
+      Mob.Test.ProcessHelpers.stop_pid(recording)
     end)
 
     # The router queues initial paint from its process. Dispatching through the
@@ -133,12 +133,6 @@ defmodule Mob.Nav.TabTransitionTest do
     Mob.Router.dispatch(router, "noop", %{})
     RecordingNif.reset()
     %{router: router}
-  end
-
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
   end
 
   defp transitions do

--- a/test/mob/plugins_test.exs
+++ b/test/mob/plugins_test.exs
@@ -291,7 +291,7 @@ defmodule Mob.PluginsTest do
   end
 
   defp write_manifest(contents) do
-    dir = Path.join(System.tmp_dir!(), "mob_plugins_test_#{System.unique_integer([:positive])}")
+    dir = Mob.Test.ProcessHelpers.tmp_path("mob_plugins_test")
     File.mkdir_p!(dir)
     path = Path.join(dir, "mob_plugins.exs")
     File.write!(path, contents)

--- a/test/mob/plugins_tier4_test.exs
+++ b/test/mob/plugins_tier4_test.exs
@@ -29,7 +29,7 @@ defmodule Mob.PluginsTier4Test do
 
   describe "settings" do
     setup do
-      tmp = Path.join(System.tmp_dir!(), "mob_set_#{System.unique_integer([:positive])}")
+      tmp = Mob.Test.ProcessHelpers.tmp_path("mob_set")
       File.mkdir_p!(tmp)
       System.put_env("MOB_DATA_DIR", tmp)
       start_supervised!(Mob.State)

--- a/test/mob/process_helpers_test.exs
+++ b/test/mob/process_helpers_test.exs
@@ -71,6 +71,108 @@ defmodule Mob.Test.ProcessHelpersTest do
     end
   end
 
+  defmodule TerminateCrasher do
+    @moduledoc false
+    use GenServer
+    def init(_), do: {:ok, %{}}
+    def terminate(_reason, _state), do: raise("boom in terminate")
+  end
+
+  describe "stop_pid/2 and crashes during terminate" do
+    test "a process that raises in terminate/2 is reported, not swallowed" do
+      # Swallowing this was the pre-existing behaviour and it hides real bugs:
+      # a screen whose terminate/2 fails to flush state looks like a clean stop.
+      {:ok, pid} = GenServer.start(TerminateCrasher, [])
+
+      assert_raise RuntimeError, "boom in terminate", fn ->
+        ProcessHelpers.stop_pid(pid)
+      end
+    end
+  end
+
+  describe "stop_all/2" do
+    test "stops every pid even when an earlier one refuses, then raises" do
+      # The whole point. If stop_all bailed at the first failure, the survivors
+      # would leak into the next file under their global names — the failure
+      # this module exists to prevent.
+
+      wedged =
+        spawn(fn ->
+          Process.flag(:trap_exit, true)
+          Process.sleep(:infinity)
+        end)
+
+      {:ok, a} = Agent.start(fn -> :a end)
+      {:ok, b} = Agent.start(fn -> :b end)
+
+      assert_raise RuntimeError, ~r/1 process\(es\) refused to stop/, fn ->
+        ProcessHelpers.stop_all([wedged, a, b], 50)
+      end
+
+      refute Process.alive?(a), "a was after the wedged pid and must still be stopped"
+      refute Process.alive?(b), "b was after the wedged pid and must still be stopped"
+
+      Process.exit(wedged, :kill)
+    end
+
+    test "ignores non-pids so an unregistered name is not a special case" do
+      {:ok, a} = Agent.start(fn -> :a end)
+      assert ProcessHelpers.stop_all([nil, a, Process.whereis(:definitely_not_registered)]) == :ok
+      refute Process.alive?(a)
+    end
+  end
+
+  describe "eventually/2" do
+    test "returns as soon as the condition holds, not after the full timeout" do
+      # The point of the helper over a fixed sleep: it pays the actual latency,
+      # not the worst case.
+      {us, :ok} =
+        :timer.tc(fn ->
+          ProcessHelpers.eventually(fn -> true end, 5_000)
+        end)
+
+      assert us < 100_000, "returned in #{us}us; should not wait out the deadline"
+    end
+
+    test "waits for a condition that becomes true later" do
+      ref = :counters.new(1, [])
+
+      spawn(fn ->
+        Process.sleep(20)
+        :counters.add(ref, 1, 1)
+      end)
+
+      assert ProcessHelpers.eventually(fn -> :counters.get(ref, 1) > 0 end) == :ok
+    end
+
+    test "raises, naming the timeout, when the condition never holds" do
+      # Without this, a helper that silently returned :ok would void every test
+      # that uses it as its only assertion.
+      assert_raise RuntimeError, ~r/still false after 50ms/, fn ->
+        ProcessHelpers.eventually(fn -> false end, 50)
+      end
+    end
+
+    test "treats nil and false as not-yet, anything else as satisfied" do
+      assert ProcessHelpers.eventually(fn -> :some_value end, 50) == :ok
+      assert_raise RuntimeError, fn -> ProcessHelpers.eventually(fn -> nil end, 50) end
+    end
+
+    test "lets an exception from the condition through instead of polling on it" do
+      # A condition that raises is a broken test, not a not-yet. Retrying it
+      # would turn a clear error into "condition still false after 1000ms".
+      assert_raise ArgumentError, fn ->
+        ProcessHelpers.eventually(fn -> raise ArgumentError end, 50)
+      end
+    end
+
+    test "lets an exit from the condition through" do
+      # e.g. calling a GenServer that has died: the :noproc should surface as
+      # itself, not be swallowed by the deadline.
+      assert catch_exit(ProcessHelpers.eventually(fn -> exit(:noproc) end, 50)) == :noproc
+    end
+  end
+
   describe "stop_if_running/2" do
     test "stops a named process and tolerates its absence" do
       # Unique per run, not a fixed atom. A test that documents the danger of

--- a/test/mob/process_helpers_test.exs
+++ b/test/mob/process_helpers_test.exs
@@ -1,0 +1,86 @@
+defmodule Mob.Test.ProcessHelpersTest do
+  @moduledoc """
+  The helpers exist to remove races from test setup and teardown, so they are
+  worth testing: a helper that silently does nothing would hide the very
+  failures it was written to prevent.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mob.Test.ProcessHelpers
+
+  describe "await_exit/2" do
+    test "returns once the process is gone" do
+      pid = spawn(fn -> :ok end)
+
+      assert ProcessHelpers.await_exit(pid) == :ok
+      refute Process.alive?(pid)
+    end
+
+    test "raises rather than continuing when the process outlives the timeout" do
+      # The failure mode that matters. Returning quietly here would let the
+      # caller assert against a process that is still running — exactly the
+      # situation a fixed Process.sleep leaves you in, just with a nicer name.
+      pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert_raise RuntimeError, ~r/still alive after/, fn ->
+        ProcessHelpers.await_exit(pid, 20)
+      end
+
+      Process.exit(pid, :kill)
+    end
+
+    test "an already-dead process returns immediately" do
+      pid = spawn(fn -> :ok end)
+      :ok = ProcessHelpers.await_exit(pid)
+
+      # Monitoring a dead pid delivers :DOWN straight away rather than hanging.
+      assert ProcessHelpers.await_exit(pid) == :ok
+    end
+  end
+
+  describe "stop_pid/2" do
+    test "stops a live process" do
+      {:ok, pid} = Agent.start(fn -> :state end)
+
+      assert ProcessHelpers.stop_pid(pid) == :ok
+      refute Process.alive?(pid)
+    end
+
+    test "tolerates a process that is already gone — the race it exists for" do
+      {:ok, pid} = Agent.start(fn -> :state end)
+      :ok = ProcessHelpers.stop_pid(pid)
+
+      assert ProcessHelpers.stop_pid(pid) == :ok
+    end
+
+    test "raises when the process ignores a :normal stop" do
+      # :timeout is the opposite of "already gone" — the process is alive and
+      # about to leak into the next test. Returning :ok here would hide the
+      # exact failure this module exists to prevent.
+      pid =
+        spawn(fn ->
+          Process.flag(:trap_exit, true)
+          Process.sleep(:infinity)
+        end)
+
+      assert_raise RuntimeError, ~r/still alive/, fn ->
+        ProcessHelpers.stop_pid(pid, 50)
+      end
+
+      Process.exit(pid, :kill)
+    end
+  end
+
+  describe "stop_if_running/2" do
+    test "stops a named process and tolerates its absence" do
+      # Unique per run, not a fixed atom. A test that documents the danger of
+      # shared global names should not register one: if this failed before its
+      # cleanup, the agent would outlive the run and break the next repeat.
+      name = :"helpers_probe_#{System.unique_integer([:positive])}"
+      {:ok, _} = Agent.start(fn -> :state end, name: name)
+
+      assert ProcessHelpers.stop_if_running(name) == :ok
+      assert ProcessHelpers.stop_if_running(name) == :ok
+    end
+  end
+end

--- a/test/mob/registry_test.exs
+++ b/test/mob/registry_test.exs
@@ -47,7 +47,7 @@ defmodule Mob.RegistryTest do
       # Use a unique name per test to avoid async collisions
       name = :"Mob.Registry.#{System.unique_integer([:positive])}"
       {:ok, pid} = Registry.start_link(name: name)
-      on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
       %{default_reg: name}
     end
 

--- a/test/mob/render_stats_test.exs
+++ b/test/mob/render_stats_test.exs
@@ -250,9 +250,9 @@ defmodule Mob.RenderStatsTest do
     end
 
     setup do
-      for name <- [Mob.Sender], pid = Process.whereis(name), do: GenServer.stop(pid)
+      Mob.Test.ProcessHelpers.stop_if_running(Mob.Sender)
       {:ok, sender} = Mob.Sender.start_link(active: :the_screen)
-      on_exit(fn -> if Process.alive?(sender), do: GenServer.stop(sender) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(sender) end)
 
       RenderStats.enable()
       RenderStats.reset()
@@ -338,7 +338,7 @@ defmodule Mob.RenderStatsTest do
 
     setup do
       services = [Mob.Sender, Mob.Listener, Mob.ComponentRegistry, Mob.Nav.Registry]
-      for name <- services, pid = Process.whereis(name), do: safe_stop(pid)
+      for name <- services, pid = Process.whereis(name), do: Mob.Test.ProcessHelpers.stop_pid(pid)
 
       {:ok, _} = Mob.ComponentRegistry.start_link()
       {:ok, _} = Mob.Nav.Registry.start_link(DemoApp)
@@ -349,17 +349,14 @@ defmodule Mob.RenderStatsTest do
       {:ok, router} = Mob.Router.start_root(CounterScreen, %{}, nif: RealNif)
 
       on_exit(fn ->
-        safe_stop(router)
-        for name <- services, pid = Process.whereis(name), do: safe_stop(pid)
+        Mob.Test.ProcessHelpers.stop_pid(router)
+
+        for name <- services,
+            pid = Process.whereis(name),
+            do: Mob.Test.ProcessHelpers.stop_pid(pid)
       end)
 
       %{router: router}
-    end
-
-    defp safe_stop(pid) do
-      GenServer.stop(pid)
-    catch
-      :exit, _ -> :ok
     end
 
     test "a real render records a complete frame", %{router: router} do

--- a/test/mob/router_hot_path_test.exs
+++ b/test/mob/router_hot_path_test.exs
@@ -64,20 +64,14 @@ defmodule Mob.RouterHotPathTest do
     def set_root(_json), do: :ok
   end
 
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
-  end
-
   setup do
     Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, registry} = Mob.Nav.Registry.start_link(DemoApp)
-    on_exit(fn -> stop_safely(registry) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(registry) end)
 
     {:ok, router} = Mob.Screen.start_link(HomeScreen, %{})
-    on_exit(fn -> stop_safely(router) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(router) end)
 
     screen = Mob.Screen.get_screen_pid(router)
     %{router: router, screen: screen}
@@ -152,15 +146,18 @@ defmodule Mob.RouterHotPathTest do
   describe "the render path does not reach it either" do
     setup do
       services = [Mob.Sender, Mob.Listener, Mob.ComponentRegistry]
-      for name <- services, pid = Process.whereis(name), do: stop_safely(pid)
+      for name <- services, pid = Process.whereis(name), do: Mob.Test.ProcessHelpers.stop_pid(pid)
 
       # The render path reconciles components, which needs the registry's table.
       {:ok, _} = Mob.ComponentRegistry.start_link()
       {:ok, router} = Mob.Router.start_root(HomeScreen, %{}, nif: StubNif)
 
       on_exit(fn ->
-        stop_safely(router)
-        for name <- services, pid = Process.whereis(name), do: stop_safely(pid)
+        Mob.Test.ProcessHelpers.stop_pid(router)
+
+        for name <- services,
+            pid = Process.whereis(name),
+            do: Mob.Test.ProcessHelpers.stop_pid(pid)
       end)
 
       %{rendering_router: router, rendering_screen: Mob.Screen.get_screen_pid(router)}

--- a/test/mob/router_hot_path_test.exs
+++ b/test/mob/router_hot_path_test.exs
@@ -153,11 +153,7 @@ defmodule Mob.RouterHotPathTest do
       {:ok, router} = Mob.Router.start_root(HomeScreen, %{}, nif: StubNif)
 
       on_exit(fn ->
-        Mob.Test.ProcessHelpers.stop_pid(router)
-
-        for name <- services,
-            pid = Process.whereis(name),
-            do: Mob.Test.ProcessHelpers.stop_pid(pid)
+        Mob.Test.ProcessHelpers.stop_all([router | Enum.map(services, &Process.whereis/1)])
       end)
 
       %{rendering_router: router, rendering_screen: Mob.Screen.get_screen_pid(router)}

--- a/test/mob/screen/isolation_test.exs
+++ b/test/mob/screen/isolation_test.exs
@@ -57,21 +57,12 @@ defmodule Mob.Screen.IsolationTest do
     Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, registry} = Mob.Nav.Registry.start_link(DemoApp)
-    on_exit(fn -> stop_safely(registry) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(registry) end)
 
     {:ok, owner} = Mob.Screen.start_link(HomeScreen, %{})
-    on_exit(fn -> stop_safely(owner) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(owner) end)
 
     %{owner: owner}
-  end
-
-  # `if Process.alive?, do: GenServer.stop` races: the process can exit between
-  # the check and the stop, and the :noproc exit then fails the test from inside
-  # the on_exit runner. Screens and their owner die with the test process.
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
   end
 
   describe "one process per screen" do

--- a/test/mob/screen/migration_test.exs
+++ b/test/mob/screen/migration_test.exs
@@ -82,17 +82,11 @@ defmodule Mob.Screen.MigrationTest do
     def navigation(_), do: tab_bar([stack(:home, root: @home), stack(:settings, root: @settings)])
   end
 
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
-  end
-
   # Screens dump in their own terminate/2, which runs after the router exits —
   # so the router being down does not mean the writes have landed.
   defp stop_and_await_screens(router) do
     refs = for pid <- live_screen_pids(router), do: {pid, Process.monitor(pid)}
-    stop_safely(router)
+    Mob.Test.ProcessHelpers.stop_pid(router)
 
     for {pid, ref} <- refs do
       receive do
@@ -137,24 +131,24 @@ defmodule Mob.Screen.MigrationTest do
   defp reset_services do
     for name <- [Mob.Sender, Mob.Listener, Mob.ComponentRegistry, Mob.Nav.Registry],
         pid = Process.whereis(name),
-        do: stop_safely(pid)
+        do: Mob.Test.ProcessHelpers.stop_pid(pid)
   end
 
   describe "hot reload reaches every live screen" do
     setup do
       reset_services()
 
-      if pid = Process.whereis(Renders), do: Agent.stop(pid)
+      Mob.Test.ProcessHelpers.stop_if_running(Renders)
       {:ok, renders} = Renders.start()
       # Globally named and unlinked, so it outlives the suite unless stopped.
-      on_exit(fn -> if Process.alive?(renders), do: Agent.stop(renders) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(renders) end)
 
       {:ok, _} = Mob.ComponentRegistry.start_link()
       {:ok, _} = Mob.Nav.Registry.start_link(TabApp)
       {:ok, router} = Mob.Router.start_root(HomeScreen, %{}, nif: StubNif)
 
       on_exit(fn ->
-        stop_safely(router)
+        Mob.Test.ProcessHelpers.stop_pid(router)
         reset_services()
       end)
 

--- a/test/mob/screen/restart_test.exs
+++ b/test/mob/screen/restart_test.exs
@@ -63,12 +63,6 @@ defmodule Mob.Screen.RestartTest do
     end
   end
 
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
-  end
-
   defp owner_state(owner), do: :sys.get_state(owner)
   defp history(owner), do: owner |> owner_state() |> Map.fetch!(:nav) |> Mob.Nav.history()
   defp parked(owner), do: owner |> owner_state() |> Map.fetch!(:nav) |> Map.fetch!(:parked)
@@ -93,10 +87,10 @@ defmodule Mob.Screen.RestartTest do
     Mob.Test.ProcessHelpers.stop_if_running(Mob.Nav.Registry)
 
     {:ok, registry} = Mob.Nav.Registry.start_link(TabApp)
-    on_exit(fn -> stop_safely(registry) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(registry) end)
 
     {:ok, owner} = Mob.Screen.start_link(HomeScreen, %{})
-    on_exit(fn -> stop_safely(owner) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(owner) end)
 
     %{owner: owner}
   end

--- a/test/mob/screen_collocation_test.exs
+++ b/test/mob/screen_collocation_test.exs
@@ -3,7 +3,7 @@ defmodule Mob.ScreenCollocationTest do
 
   test "use Mob.Screen compiles a sibling .mob.heex template into render/1" do
     dir =
-      Path.join(System.tmp_dir!(), "mob_screen_collocation_#{System.unique_integer([:positive])}")
+      Mob.Test.ProcessHelpers.tmp_path("mob_screen_collocation")
 
     File.mkdir_p!(dir)
     on_exit(fn -> File.rm_rf!(dir) end)

--- a/test/mob/screen_repaint_test.exs
+++ b/test/mob/screen_repaint_test.exs
@@ -88,25 +88,19 @@ defmodule Mob.ScreenRepaintTest do
     screen = Mob.Screen.get_screen_pid(router)
 
     on_exit(fn ->
-      stop_safely(router)
-      for pid <- started, do: stop_safely(pid)
+      Mob.Test.ProcessHelpers.stop_pid(router)
+      for pid <- started, do: Mob.Test.ProcessHelpers.stop_pid(pid)
       # Mob.Router.start_root starts Mob.Listener when render_mode is :render,
       # globally named and unlinked. Leaving it running makes Mob.Renderer route
       # every later tap through it, so other files see {listener_pid, {:mob_route,
       # ...}} where they assert {pid, tag}. Two renderer_test cases failed that
       # way, and only when the files happened to run in the wrong order.
-      if pid = Process.whereis(Mob.Listener), do: stop_safely(pid)
+      if pid = Process.whereis(Mob.Listener), do: Mob.Test.ProcessHelpers.stop_pid(pid)
       Mob.Theme.set(theme_before)
     end)
 
     settle(screen)
     %{screen: screen}
-  end
-
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
   end
 
   # Deterministic, not timing-based.

--- a/test/mob/screen_sender_wiring_test.exs
+++ b/test/mob/screen_sender_wiring_test.exs
@@ -86,22 +86,13 @@ defmodule Mob.ScreenSenderWiringTest do
     {:ok, registry} = Mob.Nav.Registry.start_link(TabApp)
 
     on_exit(fn ->
-      for pid <- [sender, registry], do: stop_safely(pid)
+      for pid <- [sender, registry], do: Mob.Test.ProcessHelpers.stop_pid(pid)
     end)
 
     {:ok, screen} = Mob.Screen.start_link(HomeScreen, %{})
-    on_exit(fn -> stop_safely(screen) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(screen) end)
 
     %{screen: screen}
-  end
-
-  # `if Process.alive?, do: GenServer.stop` races: the process can exit between
-  # the check and the stop, and the :noproc exit then fails the test from inside
-  # the on_exit runner. Screens and their owner die with the test process.
-  defp stop_safely(pid) do
-    GenServer.stop(pid)
-  catch
-    :exit, _ -> :ok
   end
 
   test "mounting a screen makes that screen active", %{screen: screen} do

--- a/test/mob/sender_test.exs
+++ b/test/mob/sender_test.exs
@@ -41,10 +41,7 @@ defmodule Mob.SenderTest do
     # flush queued, and it would record into the fresh recorder.
     Mob.Test.ProcessHelpers.stop_if_running(Sender)
 
-    case Process.whereis(RecordingNif) do
-      nil -> :ok
-      pid -> Agent.stop(pid)
-    end
+    Mob.Test.ProcessHelpers.stop_if_running(RecordingNif)
 
     RecordingNif.start()
     :ok

--- a/test/mob/sender_test.exs
+++ b/test/mob/sender_test.exs
@@ -52,7 +52,7 @@ defmodule Mob.SenderTest do
 
   defp start_sender(active) do
     {:ok, pid} = Sender.start_link(active: active)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
     pid
   end
 
@@ -469,7 +469,7 @@ defmodule Mob.SenderTest do
       refute Sender.running?()
       assert :ok = Sender.ensure_started()
       assert Sender.running?()
-      on_exit(fn -> if Sender.running?(), do: GenServer.stop(Sender) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_if_running(Sender) end)
     end
 
     test "is a no-op when one is already running" do
@@ -495,7 +495,7 @@ defmodule Mob.SenderTest do
       assert_receive {:DOWN, ^ref, :process, ^caller, _}
 
       assert Process.alive?(sender)
-      on_exit(fn -> if Sender.running?(), do: GenServer.stop(Sender) end)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_if_running(Sender) end)
     end
   end
 

--- a/test/mob/state_test.exs
+++ b/test/mob/state_test.exs
@@ -65,7 +65,7 @@ defmodule Mob.StateTest do
       Process.unlink(pid)
       # bypasses terminate/2, no dets.close
       Process.exit(pid, :kill)
-      Process.sleep(10)
+      Mob.Test.ProcessHelpers.await_exit(pid)
       {:ok, _} = Mob.State.start_link()
       assert Mob.State.get(:kill_survived) == :yes
     end

--- a/test/mob/state_test.exs
+++ b/test/mob/state_test.exs
@@ -3,7 +3,7 @@ defmodule Mob.StateTest do
 
   # Each test uses an isolated DETS file so tests don't share state.
   setup do
-    tmp = Path.join(System.tmp_dir!(), "mob_state_test_#{System.unique_integer([:positive])}")
+    tmp = Mob.Test.ProcessHelpers.tmp_path("mob_state_test")
     File.mkdir_p!(tmp)
     System.put_env("MOB_DATA_DIR", tmp)
 

--- a/test/mob/storage_test.exs
+++ b/test/mob/storage_test.exs
@@ -4,7 +4,7 @@ defmodule Mob.StorageTest do
   alias Mob.Storage
 
   setup do
-    dir = Path.join(System.tmp_dir!(), "mob_storage_#{:erlang.unique_integer([:positive])}")
+    dir = Mob.Test.ProcessHelpers.tmp_path("mob_storage")
     File.mkdir_p!(dir)
     on_exit(fn -> File.rm_rf!(dir) end)
     %{dir: dir}

--- a/test/mob/theme_host_test.exs
+++ b/test/mob/theme_host_test.exs
@@ -20,7 +20,7 @@ defmodule Mob.ThemeHostTest do
         Enum.each(tasks, &send(&1.pid, :go))
         results = Enum.map(tasks, &Task.await/1)
         true = Enum.all?(results, &(&1 in [:light, :ok]))
-        Process.sleep(100)
+        Logger.flush()
       end)
 
     1 = length(:binary.matches(log, "The on_load function for module mob_nif returned"))
@@ -69,7 +69,7 @@ defmodule Mob.ThemeHostTest do
       Code.compile_string(fake_nif)
       :dark = Mob.Theme.color_scheme()
       :available = :persistent_term.get(key)
-      Process.sleep(100)
+      Logger.flush()
     end)
 
     :persistent_term.erase(key)

--- a/test/support/process_helpers.ex
+++ b/test/support/process_helpers.ex
@@ -2,7 +2,7 @@ defmodule Mob.Test.ProcessHelpers do
   @moduledoc """
   Stopping a named process from test setup, without the race.
 
-  The idiom this replaces appeared in nine test files:
+  The idiom this replaces appeared six times across five test modules:
 
       case Process.whereis(Name) do
         nil -> :ok
@@ -33,15 +33,138 @@ defmodule Mob.Test.ProcessHelpers do
         :ok
 
       pid ->
-        try do
-          GenServer.stop(pid, :normal, timeout)
-        catch
-          # :noproc — it exited between the whereis and here, which is the race.
-          # :normal / :shutdown — it was already on its way down.
-          :exit, _ -> :ok
-        end
+        stop_pid(pid, timeout)
+    end
+  end
 
+  @doc """
+  Stop `pid` if it is running, tolerating it having already stopped.
+
+  The pid-shaped version of the same race, which appeared 19 times across
+  11 modules as:
+
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+  `Process.alive?/1` is a check-then-act just as `whereis` is. Since MOB-112
+  the screen owner is *linked to the test process*, and ExUnit exits that
+  process with `:shutdown` when the test ends — so the owner is dying
+  concurrently with the very callback trying to stop it. The window is
+  microseconds wide and CI is where it lands (MOB-123).
+
+  Thirteen test modules had each written this correctly in private, byte for byte
+  identically, which is a fair signal it belongs here instead.
+  """
+  @spec stop_pid(pid(), timeout()) :: :ok
+  def stop_pid(pid, timeout \\ 5_000) when is_pid(pid) do
+    GenServer.stop(pid, :normal, timeout)
+    :ok
+  catch
+    # Only one exit reason means "did not work": the process ignored a :normal
+    # stop and is still alive, about to leak into the next test. That is the
+    # failure this module exists to prevent, so it is the one thing that must
+    # not be swallowed. `GenServer.stop/3` reports it as
+    # `{:timeout, {GenServer, :stop, _}}`, not a bare atom.
+    :exit, {:timeout, _} ->
+      raise "#{inspect(pid)} ignored a :normal stop for #{timeout}ms and is still alive"
+
+    # Everything else means it was already on its way down, which is the state
+    # the caller wanted. Do not enumerate those shapes: they nest to varying
+    # depths depending on how far into shutdown the process got — a linked
+    # owner dying as ExUnit tears the test down arrives as
+    # `{{:shutdown, {:sys, :terminate, _}}, {GenServer, :stop, _}}`. An earlier
+    # version of this clause listed `{reason, _} when reason in [:normal,
+    # :shutdown]` and failed on exactly that, in three tests, only under a full
+    # concurrent run.
+    :exit, _ ->
+      :ok
+  end
+
+  @doc """
+  Block until `pid` has actually exited, or fail loudly.
+
+  Replaces the shape MOB-154 was opened for:
+
+      Process.exit(pid, :kill)
+      Process.sleep(10)
+      # ... assert something that requires the process to be gone
+
+  A fixed sleep is a bet on the scheduler. It wins on an idle laptop and loses
+  on a loaded CI box, so the failure lands on whoever pushed next and looks
+  unrelated to their change. A monitor is not a tighter bet — the `:DOWN`
+  cannot arrive before the process is gone, so there is nothing left to race.
+
+  Raises rather than returning on timeout: a test that continues after this
+  fails is asserting against a process that may still be alive, which is the
+  situation being avoided.
+  """
+  @spec await_exit(pid(), timeout()) :: :ok
+  def await_exit(pid, timeout \\ 1_000) when is_pid(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      timeout ->
+        Process.demonitor(ref, [:flush])
+        raise "#{inspect(pid)} was still alive after #{timeout}ms"
+    end
+  end
+
+  @doc """
+  Poll `fun` until it returns a truthy value, or fail after `timeout` ms.
+
+  For the narrow case where a process mutates its own state in response to a
+  message from *somewhere else* — a `:DOWN` from a monitor, say. A `call` from
+  the test process is an ordering barrier only for messages the test itself
+  sent; it says nothing about a `:DOWN` that arrived from a third party.
+
+  Prefer a ready-message or a monitor when the thing you are waiting for is
+  observable. Reach for this only when it genuinely is not: unlike a fixed
+  sleep it returns as soon as the condition holds, and it reports the failure
+  instead of letting the next assertion produce a confusing one.
+  """
+  @spec eventually((-> any()), non_neg_integer()) :: :ok
+  def eventually(fun, timeout \\ 1_000) when is_function(fun, 0) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_eventually(fun, deadline, timeout)
+  end
+
+  defp do_eventually(fun, deadline, timeout) do
+    cond do
+      fun.() ->
         :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        raise "condition still false after #{timeout}ms"
+
+      true ->
+        Process.sleep(5)
+        do_eventually(fun, deadline, timeout)
+    end
+  end
+
+  @doc """
+  Make sure `Mob.ComponentRegistry` is running, without any test owning it.
+
+  The registry is globally named and owns a named ETS table, and two
+  `async: true` modules use it. Under `start_supervised/1` whichever test won
+  the race OWNED it, and ExUnit tore it — and its table — down at that test's
+  end while the other module was still running (MOB-119).
+
+  `test_helper.exs` starts it for the run, which fixes that for one `mix test`.
+  It is not enough on its own: several sync modules deliberately stop it in
+  teardown and do not restart it, and `--repeat-until-failure` loops inside
+  `ExUnit.run/0` without re-running `test_helper.exs` — so on the second
+  iteration the async setups would find it absent and own it again, restoring
+  the exact race.
+
+  Starting it here, unlinked and unsupervised, means no test can ever own it.
+  """
+  @spec ensure_component_registry() :: :ok
+  def ensure_component_registry do
+    case GenServer.start(Mob.ComponentRegistry, [], name: Mob.ComponentRegistry) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
     end
   end
 end

--- a/test/support/process_helpers.ex
+++ b/test/support/process_helpers.ex
@@ -59,13 +59,21 @@ defmodule Mob.Test.ProcessHelpers do
     GenServer.stop(pid, :normal, timeout)
     :ok
   catch
-    # Only one exit reason means "did not work": the process ignored a :normal
+    # Two exit reasons mean "did not work". First: the process ignored a :normal
     # stop and is still alive, about to leak into the next test. That is the
     # failure this module exists to prevent, so it is the one thing that must
     # not be swallowed. `GenServer.stop/3` reports it as
     # `{:timeout, {GenServer, :stop, _}}`, not a bare atom.
     :exit, {:timeout, _} ->
       raise "#{inspect(pid)} ignored a :normal stop for #{timeout}ms and is still alive"
+
+    # A process that blew up in `terminate/2` exits with the exception itself in
+    # the reason. That is a real bug — screens in this repo flush state from
+    # terminate/2 — and reporting it as a clean stop would hide it. Identify it
+    # *positively*, by the exception struct, rather than by enumerating the
+    # shutdown shapes: enumerating is what broke this function last time.
+    :exit, {{%{__exception__: true} = exception, stack}, _} when is_list(stack) ->
+      reraise exception, stack
 
     # Everything else means it was already on its way down, which is the state
     # the caller wanted. Do not enumerate those shapes: they nest to varying
@@ -77,6 +85,62 @@ defmodule Mob.Test.ProcessHelpers do
     # concurrent run.
     :exit, _ ->
       :ok
+  end
+
+  @doc """
+  A temp path unique across concurrently running VMs, not just within one.
+
+  `System.unique_integer/1` is unique *per VM*. Two `mix test` runs at once —
+  a CI matrix on one box, a worktree A/B, a developer with a second terminal —
+  each start counting from their own zero, collide on the same directory, and
+  then delete each other's fixtures from `on_exit`. The symptom is a file that
+  vanishes mid-test: `Storage.delete/1` returning `{:error, :enoent}` for a file
+  the test just wrote. Observed exactly that way while measuring this PR.
+
+  The OS pid is what distinguishes the VMs.
+  """
+  @spec tmp_path(String.t()) :: String.t()
+  def tmp_path(prefix) do
+    Path.join(
+      System.tmp_dir!(),
+      "#{prefix}_#{System.pid()}_#{System.unique_integer([:positive])}"
+    )
+  end
+
+  @doc """
+  Stop every pid in `pids`, then raise if any of them refused.
+
+  `stop_pid/2` raises on timeout, which is correct on its own and wrong in the
+  middle of a teardown list: the first failure would skip every later stop, so
+  a single wedged process leaks all its siblings — under their global names —
+  into every file that runs after. That is precisely the failure this module
+  exists to prevent, so a teardown must stop everything first and report
+  afterwards.
+
+  Non-pids are ignored, so `stop_all([a, Process.whereis(B), c])` is safe when
+  a name is not registered.
+  """
+  @spec stop_all([pid() | nil], timeout()) :: :ok
+  def stop_all(pids, timeout \\ 5_000) when is_list(pids) do
+    failures =
+      pids
+      |> Enum.filter(&is_pid/1)
+      |> Enum.flat_map(fn pid ->
+        try do
+          stop_pid(pid, timeout)
+          []
+        rescue
+          e in RuntimeError -> [Exception.message(e)]
+        end
+      end)
+
+    case failures do
+      [] ->
+        :ok
+
+      msgs ->
+        raise "#{length(msgs)} process(es) refused to stop:\n  " <> Enum.join(msgs, "\n  ")
+    end
   end
 
   @doc """
@@ -163,8 +227,8 @@ defmodule Mob.Test.ProcessHelpers do
   @spec ensure_component_registry() :: :ok
   def ensure_component_registry do
     case GenServer.start(Mob.ComponentRegistry, [], name: Mob.ComponentRegistry) do
-      {:ok, _pid} -> :ok
-      {:error, {:already_started, _pid}} -> :ok
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
     end
   end
 end

--- a/test/support/process_helpers.ex
+++ b/test/support/process_helpers.ex
@@ -194,12 +194,18 @@ defmodule Mob.Test.ProcessHelpers do
   end
 
   defp do_eventually(fun, deadline, timeout) do
+    value = fun.()
+
     cond do
-      fun.() ->
+      value ->
         :ok
 
       System.monotonic_time(:millisecond) >= deadline ->
-        raise "condition still false after #{timeout}ms"
+        # Report what the condition last saw. Without it every failure reads
+        # "still false", which hides the difference between "the event did not
+        # happen" and "the check was wrong" — an `:rpc.call` answering
+        # `{:badrpc, _}`, say, is never going to match and is not a timeout.
+        raise "condition still false after #{timeout}ms; last saw: #{inspect(value)}"
 
       true ->
         Process.sleep(5)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,26 @@
+# `Mob.ComponentRegistry` is a globally-named singleton that owns a named ETS
+# table, and two `async: true` modules use it — `component_test.exs` and
+# `component_server_test.exs`. Both setups do:
+#
+#     case start_supervised({Mob.ComponentRegistry, []}) do
+#       {:ok, _pid} -> :ok
+#       {:error, {:already_started, _pid}} -> :ok
+#     end
+#
+# `start_supervised/1` ties the process to the *individual test*. So whichever
+# test wins the race OWNS the registry, and ExUnit tears it — and its ETS table
+# — down when that test ends, while a concurrent test in the other module is
+# still using it. The loser dies on `:ets.lookup` against a table that no
+# longer exists (MOB-119, and the mechanism behind MOB-154).
+#
+# Starting it here makes it owned by the RUN. Both setups then take the
+# `:already_started` branch, nobody owns it, and nobody can tear it down
+# mid-flight. Sharing is safe because every registry entry is keyed by a
+# per-test `screen_pid`, so no two tests can collide on a key.
+#
+# `router_hot_path_test.exs` deliberately stops and restarts it to prove the
+# hot path does not touch it. That is `async: false`, and ExUnit runs every
+# async module before any sync one, so it cannot race the two above.
+{:ok, _} = Mob.ComponentRegistry.start_link()
+
 ExUnit.start(exclude: [:onboarding, :on_device])


### PR DESCRIPTION
Closes MOB-154, MOB-119, MOB-123.

A 1-in-20 flake corrupted a mutation-testing verdict and, a day later, sent a bisect down the wrong path when it appeared in the same run as a real failure. The cost of a noisy suite is not the red build, it is the hours spent trusting it.

## Three mechanisms

**A globally-named singleton owned by whichever test started it.** `Mob.ComponentRegistry` is named and owns a named ETS table. Two `async: true` modules each called `start_supervised({Mob.ComponentRegistry, []})` and tolerated `{:error, {:already_started, _}}`. The winner owned it, and ExUnit tore the process and its table down when that test ended, while a concurrent test in the other module was still using it. It now starts in `test_helper.exs`, owned by the run.

**Check-then-act across a process boundary.** 19 `on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)` sites across 11 modules. Since MOB-112 the screen owner is linked to the test process, which ExUnit exits with `:shutdown` at test end, so the owner is dying concurrently with the callback trying to stop it. 13 further modules had each independently written the correct private helper, byte for byte identically.

**Fixed durations standing in for synchronisation.**

## Not every sleep is a bug

All 35 were classified. 12 are `Process.sleep(:infinity)` — a parked stub, not a wait. Of the 23 finite ones, **15 went and 8 remain**:

- **5 had nothing to wait for.** A `GenServer.call` from the same process that sent the earlier messages is already a barrier: Erlang orders messages pairwise, so every `send` is ahead of the `call`. And `Trace.broadcast/3` folds over the table *in the calling process*, so its cleanup is done before `dispatch/4` returns.
- **7 became the real barrier** — a ready-message, `Logger.flush/0`, a monitor.
- **3 became a bounded poll** (`eventually/2`), for the one shape where pairwise ordering genuinely does not help: a GenServer processing a `:DOWN` sent by a monitor, not by the test.
- **8 stay**: 3 are the subject under test in `render_stats_test.exs` (it measures elapsed time), 3 are the backoff inside a poll loop with its own deadline, 1 is a `@doc` example quoting the bad pattern, and 1 is a genuine bet (`router_hot_path_test.exs:206`) recorded rather than disguised.

## `mix mob.flake`

Runs the suite repeatedly and reports which tests are non-deterministic. Its **green** output says outright that 20 green runs miss a 1-in-17 flake about 30% of the time, because "I ran it 20 times" is the reasoning that let this persist.

## Honesty notes

- **The registry race is fixed by construction, not by demonstration.** It did not reproduce in 25 full-suite runs or 40 concentrated ones. The mechanism is provable by reading the code and was observed once here; that is weaker evidence than a reproduction and the record says so.
- **Tightening `stop_pid/2` broke 3 tests, and only under a full run.** Making the timeout raise meant replacing a blanket `:exit, _ -> :ok` with enumerated clauses, and the enumeration was wrong: a linked owner dying during teardown exits with `{{:shutdown, {:sys, :terminate, _}}, {GenServer, :stop, _}}`. Every file passed alone; the full run failed 3 tests, then 4. Fixed by inverting — special-case only the timeout, treat every other exit as "already gone". Enumerating the uninteresting set is a bet on having seen every shutdown shape, the same class of mistake as betting on a duration.
- The `Logger.flush/0` swaps are **not demonstrably load-bearing** — with the barrier deleted outright those tests still passed 8/8 here. `flush/0` is kept because it is the correct primitive and free when nothing is pending, whereas the sleep cost 300ms per run. That is a reason, not a measurement.

## Verification

- Full suite **5x green**: 1557 passed, 38 excluded (master: 1550).
- `mix credo --strict` clean, `mix format --check-formatted` clean.
- `mix mob.flake` verified against a deliberate 2-failure test: reports both, exits 1. Its first version silently dropped failures near the end of the output via `chunk_every(12, 1, :discard)`; now it splits on the failure-header regex.
- New `process_helpers_test.exs` (7 tests) pins the helper's own contract — including that `stop_pid/2` **raises** on timeout. That test caught a real bug in the first version of the catch clause, which matched a bare `:timeout` that `GenServer.stop/3` never emits.

Decision record: `decisions/2026-09-06-tests-wait-for-events-not-durations.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)