### PR TITLE
MOB-174: Present iOS alerts from an active app window

### DIFF
--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -7295,18 +7295,20 @@ static void mob_deliver_alert_action(const char *action) {
     enif_free_env(env);
 }
 
-// Returns the root UIViewController for presenting dialogs.
+// Returns the topmost presented UIViewController for presenting dialogs.
+//
+// The window has to be resolved through mob_root_vc, not by hand. Taking
+// `scene.windows.firstObject` and reading its rootViewController assumes the
+// app's window sorts first in the scene's window set; on iOS 26 it does not,
+// the property is nil, and every alert and action sheet is dropped with no
+// error anywhere. mob_root_vc tries `keyWindow` first and only then falls back
+// — which is why the scanner and camera plugins (scan_root_vc, cam_root_vc,
+// both copies of it) present fine while these two did not.
 static UIViewController *root_vc(void) {
-    for (UIWindowScene *scene in [UIApplication sharedApplication].connectedScenes) {
-        if (scene.activationState == UISceneActivationStateForegroundActive) {
-            UIWindow *win = scene.windows.firstObject;
-            UIViewController *vc = win.rootViewController;
-            while (vc.presentedViewController)
-                vc = vc.presentedViewController;
-            return vc;
-        }
-    }
-    return nil;
+    UIViewController *vc = mob_root_vc();
+    while (vc.presentedViewController)
+        vc = vc.presentedViewController;
+    return vc;
 }
 
 // ── NIF: alert_show/3 ────────────────────────────────────────────────────────

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -7295,20 +7295,33 @@ static void mob_deliver_alert_action(const char *action) {
     enif_free_env(env);
 }
 
-// Returns the topmost presented UIViewController for presenting dialogs.
-//
-// The window has to be resolved through mob_root_vc, not by hand. Taking
-// `scene.windows.firstObject` and reading its rootViewController assumes the
-// app's window sorts first in the scene's window set; on iOS 26 it does not,
-// the property is nil, and every alert and action sheet is dropped with no
-// error anywhere. mob_root_vc tries `keyWindow` first and only then falls back
-// — which is why the scanner and camera plugins (scan_root_vc, cam_root_vc,
-// both copies of it) present fine while these two did not.
+// Returns the topmost presented view controller in a foreground scene.
 static UIViewController *root_vc(void) {
-    UIViewController *vc = mob_root_vc();
-    while (vc.presentedViewController)
-        vc = vc.presentedViewController;
-    return vc;
+    for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]] ||
+            scene.activationState != UISceneActivationStateForegroundActive)
+            continue;
+
+        UIWindowScene *window_scene = (UIWindowScene *)scene;
+        UIViewController *vc = window_scene.keyWindow.rootViewController;
+
+        if (!vc) {
+            for (UIWindow *window in window_scene.windows) {
+                if (window.rootViewController) {
+                    vc = window.rootViewController;
+                    break;
+                }
+            }
+        }
+
+        if (!vc)
+            continue;
+
+        while (vc.presentedViewController)
+            vc = vc.presentedViewController;
+        return vc;
+    }
+    return nil;
 }
 
 // ── NIF: alert_show/3 ────────────────────────────────────────────────────────

--- a/test/mob/native_alert_window_test.exs
+++ b/test/mob/native_alert_window_test.exs
@@ -1,0 +1,29 @@
+# This source-contract test guards UIKit behavior that Elixir cannot execute.
+# credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+defmodule Mob.NativeAlertWindowTest do
+  use ExUnit.Case, async: true
+
+  alias Mob.Test.NativeSource
+
+  @source Path.expand("../../ios/mob_nif.m", __DIR__) |> File.read!()
+
+  @root_vc NativeSource.region(
+             @source,
+             "static UIViewController *root_vc(void) {",
+             "// ── NIF: alert_show/3"
+           )
+           |> NativeSource.code_only(:objc)
+           |> String.replace(~r/\s+/, " ")
+
+  test "iOS alerts choose a usable window from a foreground scene" do
+    assert @root_vc =~
+             "if (![scene isKindOfClass:[UIWindowScene class]] || " <>
+               "scene.activationState != UISceneActivationStateForegroundActive) continue; " <>
+               "UIWindowScene *window_scene = (UIWindowScene *)scene; " <>
+               "UIViewController *vc = window_scene.keyWindow.rootViewController; " <>
+               "if (!vc) { for (UIWindow *window in window_scene.windows) { " <>
+               "if (window.rootViewController) { vc = window.rootViewController; break; } } } " <>
+               "if (!vc) continue; while (vc.presentedViewController) " <>
+               "vc = vc.presentedViewController; return vc;"
+  end
+end


### PR DESCRIPTION
`Mob.Alert.alert/2` and `Mob.Alert.action_sheet/2` can fail to appear when the first window in an active iOS scene has no root view controller.

This change selects only foreground-active window scenes, prefers the scene's key window, falls back to another window with a root controller, and presents from the topmost already-presented controller.

Validation:

- Full `mix test` after updating from current `master`: 1556 passed, 38 excluded.
- Format, strict Credo, erlfmt, clang-format, and SwiftLint completed successfully. SwiftLint reports the two existing warnings in `MobRootView.swift`.
- The regression test passes here and fails on `master`.
- Focused UIKit checks passed the key-window, fallback-window, inactive-scene, presentation, and exact 189-character delivery cases for both alert styles on an iPad simulator and connected iPhone.
- `mix mob.deploy --native --ios` completed a signed build, install, and restart on the connected iPhone.

Tracked by MOB-174.
