### PR TITLE
MOB-53: Keep iOS alert action values valid until delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,13 +294,11 @@ These are the things we've burned ourselves on. Following them isn't optional.
     *the platform API didn't complain*. See
     `decisions/2026-08-09-tap-xy-reports-observed-effect.md`.
 
-15. **Never capture `[nsstring UTF8String]` in a block that outlives the
-    scope.** The pointer belongs to the NSString (and is autorelease-scoped
-    besides), so a `const char *` captured for a callback — a `UIAlertAction`
-    handler, a completion block, anything the run loop calls back later — is
-    reading freed memory by the time it fires. Capture the object and convert
-    inside the block. Both alert NIFs did this, and it is invisible in testing
-    because freed bytes usually still spell the old string.
+15. **Never capture `[nsstring UTF8String]` in a block that can outlive the
+    scope.** The pointer belongs to the NSString and may become invalid before
+    a delayed callback runs. Capture the object and convert inside the block.
+    Both alert NIFs previously relied on the pointer remaining valid; short
+    action names often masked the problem.
 
 ## Where to look
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,14 @@ These are the things we've burned ourselves on. Following them isn't optional.
     *the platform API didn't complain*. See
     `decisions/2026-08-09-tap-xy-reports-observed-effect.md`.
 
+15. **Never capture `[nsstring UTF8String]` in a block that outlives the
+    scope.** The pointer belongs to the NSString (and is autorelease-scoped
+    besides), so a `const char *` captured for a callback — a `UIAlertAction`
+    handler, a completion block, anything the run loop calls back later — is
+    reading freed memory by the time it fires. Capture the object and convert
+    inside the block. Both alert NIFs did this, and it is invisible in testing
+    because freed bytes usually still spell the old string.
+
 ## Where to look
 
 | Question | File |

--- a/decisions/2026-09-09-ios-alert-actions-retain-strings.md
+++ b/decisions/2026-09-09-ios-alert-actions-retain-strings.md
@@ -1,0 +1,34 @@
+# iOS alert callbacks retain action strings
+
+Date: 2026-09-09
+Status: accepted
+Ticket: MOB-53
+
+## Context
+
+The iOS alert and action-sheet NIFs decode each button action into an
+`NSString`, then create a `UIAlertAction` whose handler runs later. The old code
+stored `[action UTF8String]` in a `const char *` outside the handler and captured
+that pointer. Those bytes belong to the string and are not guaranteed to remain
+valid until the user selects the action. Short action names often appeared to
+work, which made the error easy to miss.
+
+## Decision
+
+Each `UIAlertAction` handler captures its `NSString` action. The handler obtains
+the UTF-8 pointer when it runs and passes it directly to
+`mob_deliver_alert_action`. That function constructs the Erlang term before it
+returns, so the pointer is used only while the captured string is still alive.
+
+Apply the same rule to any delayed Objective-C callback: retain the object whose
+value is needed, then obtain temporary C pointers inside the callback that
+consumes them.
+
+## Consequences
+
+- Alert and action-sheet callbacks deliver the action value decoded for their
+  own button, even after the presenting NIF has returned.
+- The native regression test checks both handlers and ignores commented source,
+  so restoring the earlier pointer capture fails the suite.
+- A future delivery helper that stores the pointer after returning would require
+  copying the bytes; the current synchronous helper does not.

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -7350,11 +7350,16 @@ static ERL_NIF_TERM nif_alert_show(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
               as = UIAlertActionStyleCancel;
           if ([style isEqualToString:@"destructive"])
               as = UIAlertActionStyleDestructive;
-          const char *act_c = [action UTF8String];
+          // Capture the NSString, not [action UTF8String]. The C pointer aims
+          // into a string owned by `buttons`, a local ARC releases the moment
+          // this block returns — long before anyone taps — so the handler read
+          // freed memory and enif_make_atom built the action atom out of
+          // whatever was there. Capturing the object retains it for the life
+          // of the handler.
           [ac addAction:[UIAlertAction actionWithTitle:label
                                                  style:as
                                                handler:^(UIAlertAction *_) {
-                                                 mob_deliver_alert_action(act_c);
+                                                 mob_deliver_alert_action([action UTF8String]);
                                                }]];
       }
       UIViewController *vc = root_vc();
@@ -7399,11 +7404,10 @@ static ERL_NIF_TERM nif_action_sheet_show(ErlNifEnv *env, int argc, const ERL_NI
               as = UIAlertActionStyleCancel;
           if ([style isEqualToString:@"destructive"])
               as = UIAlertActionStyleDestructive;
-          const char *act_c = [action UTF8String];
           [ac addAction:[UIAlertAction actionWithTitle:label
                                                  style:as
                                                handler:^(UIAlertAction *_) {
-                                                 mob_deliver_alert_action(act_c);
+                                                 mob_deliver_alert_action([action UTF8String]);
                                                }]];
       }
       UIViewController *vc = root_vc();

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -7350,12 +7350,9 @@ static ERL_NIF_TERM nif_alert_show(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
               as = UIAlertActionStyleCancel;
           if ([style isEqualToString:@"destructive"])
               as = UIAlertActionStyleDestructive;
-          // Capture the NSString, not [action UTF8String]. The C pointer aims
-          // into a string owned by `buttons`, a local ARC releases the moment
-          // this block returns — long before anyone taps — so the handler read
-          // freed memory and enif_make_atom built the action atom out of
-          // whatever was there. Capturing the object retains it for the life
-          // of the handler.
+          // Capture the NSString, not its UTF8String pointer. The block can
+          // outlive the temporary buffer; retaining the object and converting
+          // inside the handler keeps the bytes valid for synchronous delivery.
           [ac addAction:[UIAlertAction actionWithTitle:label
                                                  style:as
                                                handler:^(UIAlertAction *_) {

--- a/test/mob/native_alert_action_test.exs
+++ b/test/mob/native_alert_action_test.exs
@@ -1,0 +1,31 @@
+# This source-contract test guards UIKit behavior that Elixir cannot execute.
+# credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+defmodule Mob.NativeAlertActionTest do
+  use ExUnit.Case, async: true
+
+  alias Mob.Test.NativeSource
+
+  @source Path.expand("../../ios/mob_nif.m", __DIR__) |> File.read!()
+
+  @alert NativeSource.region(
+           @source,
+           "static ERL_NIF_TERM nif_alert_show",
+           "nif_action_sheet_show"
+         )
+         |> NativeSource.code_only(:objc)
+
+  @action_sheet NativeSource.region(
+                  @source,
+                  "static ERL_NIF_TERM nif_action_sheet_show",
+                  "// ── NIF: toast_show/2"
+                )
+                |> NativeSource.code_only(:objc)
+
+  test "iOS alert handlers convert retained action strings at delivery time" do
+    refute @alert =~ "const char *act_c = [action UTF8String]"
+    refute @action_sheet =~ "const char *act_c = [action UTF8String]"
+
+    assert @alert =~ "mob_deliver_alert_action([action UTF8String]);"
+    assert @action_sheet =~ "mob_deliver_alert_action([action UTF8String]);"
+  end
+end


### PR DESCRIPTION
iOS alert and action-sheet handlers previously saved temporary UTF-8 bytes before their delayed callbacks ran. Longer action values could therefore arrive incorrectly.

Each handler now retains its `NSString` action and converts it to UTF-8 when the callback runs, immediately before synchronous Erlang term construction. Both alert styles use the corrected path, with the rationale recorded in `decisions/2026-09-09-ios-alert-actions-retain-strings.md`.

Validation:

- Full `mix test`: 1555 passed, 38 excluded.
- Format, strict Credo, erlfmt, clang-format, and SwiftLint completed successfully. SwiftLint reports the two existing warnings in `MobRootView.swift`.
- The regression test passes here and fails on `master`.
- Focused UIKit checks delivered exact 189-character action values for alerts and action sheets on an iPad simulator and connected iPhone.
- `mix mob.deploy --native --ios` completed a signed build, install, and restart on the connected iPhone.

Tracked by MOB-53.
