### PR TITLE
A safe-area read with no window is not an answer (MOB-166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,31 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   life of the screen** (MOB-166). `nif_safe_area` returned zeros when it could
   find no window, which is indistinguishable from a device that genuinely has no
   insets, and `ensure_safe_area/3` stopped asking once the assign existed. A
-  screen that painted before the window existed therefore rendered under the
-  notch and home indicator until it was replaced.
+  screen that painted before the window existed was under-padded at the bottom
+  and sides until it was replaced.
 
   Two ordinary launches reach a paint that early: a background launch connects no
-  window scene at all, and an iOS 15+ prewarmed launch runs
+  window scene at launch, and an iOS 15+ prewarmed launch runs
   `didFinishLaunchingWithOptions:` long before the user taps the icon.
 
-  The NIF now answers `:no_window` distinctly. Zeros are still assigned — screens
-  read `assigns.safe_area` directly, so a missing key would be a `KeyError` in
-  `render/1` — but marked unconfirmed, and re-read each paint until the platform
-  answers, then left alone. **Requires a native rebuild**
-  (`mix mob.deploy --native`); the Elixir half still handles a plain 4-tuple, so
-  it degrades safely without one.
+  The NIF now answers `:no_window` — on a genuine absence and on a timeout, both
+  of which mean "not an answer". Zeros are still assigned (screens read
+  `assigns.safe_area` directly, so a missing key would be a `KeyError` in
+  `render/1`) but marked unconfirmed and re-read on the next paint.
+
+  Re-reading on paint is not enough on its own, because nothing repaints when a
+  scene connects. New `mob_notify_window_connected()`, called from
+  `scene:willConnectToSession:`, sends `{:mob_window, :connected}`; the screen
+  invalidates its cached insets and repaints. That also covers insets changing
+  under a live screen — a rotation, a resized scene — which a confirmed-once
+  cache would otherwise never pick up.
+
+  **Requires a native rebuild** (`mix mob.deploy --native`), and the two halves
+  must move together. Old native with new Elixir degrades safely: a 4-tuple is
+  still handled. **New native with old Elixir crashes** — `{t, r, b, l} =
+  :no_window` raises in `Mob.Screen.Server.init/1` and the root screen never
+  starts — so do not point `mob.exs`'s `mob_dir` at a newer checkout than the
+  `mix.exs` dependency.
 
 ### Added
 - **`mix mob.flake`** — run the suite repeatedly and report which tests are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Fixed
+- **A safe-area reading taken before iOS had a window is no longer kept for the
+  life of the screen** (MOB-166). `nif_safe_area` returned zeros when it could
+  find no window, which is indistinguishable from a device that genuinely has no
+  insets, and `ensure_safe_area/3` stopped asking once the assign existed. A
+  screen that painted before the window existed therefore rendered under the
+  notch and home indicator until it was replaced.
+
+  Two ordinary launches reach a paint that early: a background launch connects no
+  window scene at all, and an iOS 15+ prewarmed launch runs
+  `didFinishLaunchingWithOptions:` long before the user taps the icon.
+
+  The NIF now answers `:no_window` distinctly. Zeros are still assigned — screens
+  read `assigns.safe_area` directly, so a missing key would be a `KeyError` in
+  `render/1` — but marked unconfirmed, and re-read each paint until the platform
+  answers, then left alone. **Requires a native rebuild**
+  (`mix mob.deploy --native`); the Elixir half still handles a plain 4-tuple, so
+  it degrades safely without one.
+
 ### Added
 - **`mix mob.flake`** — run the suite repeatedly and report which tests are not
   deterministic. `--runs N`, `--until-failure`, `--keep-going`, `--seed`, and a

--- a/PLAN.md
+++ b/PLAN.md
@@ -137,7 +137,9 @@ USB is only required for first deploy. After that, Erlang distribution is the tr
 
 **Shipped (2026-04-15):**
 
-- `mob_nif:safe_area/0` → `{top, right, bottom, left}` floats (logical points / dp)
+- `mob_nif:safe_area/0` → `{top, right, bottom, left}` floats (logical points / dp),
+  or the atom `no_window` on iOS when no window exists yet (the caller must not
+  cache that reading — see `decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md`)
   - iOS: reads `UIWindow.safeAreaInsets` on the main thread via `dispatch_sync`
   - Android: reads `decorView.rootWindowInsets` via `CountDownLatch` in `MobBridge`
 - `Mob.Screen.init` injects `assigns.safe_area = %{top: t, right: r, bottom: b, left: l}` before `mount/3` is called — always available, zero opt-in

--- a/decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md
+++ b/decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md
@@ -25,8 +25,9 @@ earlier, and two ordinary things do:
 * an **iOS 15+ prewarmed launch** runs `application:didFinishLaunchingWithOptions:`
   well before the user taps the icon, and prewarming is routine.
 
-A screen that painted in that window would render under the notch and home
-indicator until it was replaced. UIKit usually wins the race, which is what makes
+A screen that painted in that window would be under-padded until it was
+replaced — at the bottom and sides specifically, since `MobRootView` already
+ignores the container's safe area on those edges while respecting the top. UIKit usually wins the race, which is what makes
 it the bad kind of bug: rare, silent, and permanent for the screen it hits.
 
 This was found by the pre-commit review of mob_new #63, whose first version
@@ -45,14 +46,29 @@ than wrong insets. It holds zeros, and the socket records that the reading is
 unconfirmed. `ensure_safe_area/3` asks again on each paint until the platform
 gives a real answer, then stops.
 
-Stopping matters: each read is a hop to the main thread, and a real answer does
-not change under a screen. Re-reading every paint would trade a rare layout bug
-for a permanent cost on every frame.
+Stopping matters: each read is a hop to the main thread, and re-reading every
+paint would trade a rare layout bug for a permanent per-frame cost.
+
+**But a confirmed answer is not permanent, and an earlier draft of this record
+claimed it was.** Insets change under a screen — rotation, a resized scene —
+which `decisions/2026-08-28-multi-stack-nav-state.md` had already recorded. So
+the confirmation is *invalidated* rather than final: `mob_notify_window_connected()`
+sends `{:mob_window, :connected}` from `scene:willConnectToSession:`, and
+`Mob.Screen.Server` clears the flag and repaints.
+
+That hook is also what makes the placeholder case actually work. `ensure_safe_area/3`
+is only reached from a paint, and **nothing repaints when a scene connects** —
+so on a prewarmed launch the screen would paint its placeholder, then sit until
+the user interacted, showing a wrong first frame. Re-reading on paint is not a
+fix on its own; something has to cause the paint.
 
 ## Consequences
 
-- Android is untouched: it does not consult a window, and its branch still
-  assigns zeros unconditionally.
+- Android does not consult a window, so it never answers `:no_window` — but its
+  reply now goes through the same `case`, which has a catch-all: Android answers
+  `:error` when it cannot attach to the JVM, and without that clause a screen
+  would die in `init/1` with a `CaseClauseError` instead of degrading to zeros
+  and retrying.
 - The contract of `mob_nif:safe_area/0` changed from "always a 4-tuple" to "a
   4-tuple or `:no_window`". Both callers are in `Mob.Screen.Server`. Test stubs
   returning a 4-tuple are unaffected.

--- a/decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md
+++ b/decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md
@@ -81,3 +81,26 @@ fix on its own; something has to cause the paint.
   version of it asserted only the boot-time value and passed with the fix
   reverted, because `init` never marked its own reading confirmed either way.
   Checked by reverting: treating `:no_window` as confirmed fails it.
+
+## Verified on device
+
+An app generated from the paired `mob_new` branch, built native against this
+branch (both `mob.exs`'s `mob_dir` and `mix.exs`'s dep pointed at the same
+checkout, so the two halves could not diverge), deployed to a simulator and
+inspected over dist:
+
+- `:mob_screen` resolves to the router — the registered name
+  `mob_notify_window_connected()` looks up via `enif_whereis_pid`, so the native
+  sender has a real target.
+- The screen holds **real** insets, `%{top: 20.0, bottom: 25.0, left: 0.0,
+  right: 0.0}`, with `__mob__.safe_area_confirmed == true`. Not the zeroed
+  placeholder, on a build that boots from `didFinishLaunchingWithOptions:`.
+- Sending `{:mob_window, :connected}` — the exact term the native function
+  sends — leaves the app alive and still on its screen, so the new handler is
+  reached and does not disturb a screen that is already correct.
+
+**Not verified:** a launch that genuinely paints before the window — a real
+prewarm or background launch. Forcing one needs a background mode and a real
+trigger. The unit tests cover the state machine for that case; the device check
+covers the ordinary path and the native plumbing.
+

--- a/decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md
+++ b/decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md
@@ -1,0 +1,67 @@
+# A safe-area read with no window is not an answer
+
+Date: 2026-09-10
+Status: accepted
+Ticket: MOB-166 (with mob_new #63)
+
+## Context
+
+`nif_safe_area` finds the active window through `connectedScenes` and reads its
+`safeAreaInsets`. When it finds no window it returned zeros, which is
+indistinguishable from a device that genuinely has none — an iPad, or an older
+iPhone.
+
+`Mob.Screen.Server.ensure_safe_area/3` stopped asking as soon as the
+`:safe_area` assign existed. So the first reading a screen took was the reading
+it kept for life.
+
+Those two behaviours are only compatible while the BEAM cannot start before a
+window exists. That was true when the boot lived in `scene:willConnectToSession:`
+after `makeKeyAndVisible`. It stops being true as soon as anything boots
+earlier, and two ordinary things do:
+
+* a **background launch** connects no window scene at all — the case mob_new #63
+  exists to handle;
+* an **iOS 15+ prewarmed launch** runs `application:didFinishLaunchingWithOptions:`
+  well before the user taps the icon, and prewarming is routine.
+
+A screen that painted in that window would render under the notch and home
+indicator until it was replaced. UIKit usually wins the race, which is what makes
+it the bad kind of bug: rare, silent, and permanent for the screen it hits.
+
+This was found by the pre-commit review of mob_new #63, whose first version
+booted unconditionally from `didFinishLaunchingWithOptions:` and would have made
+the race the common case rather than a rare one.
+
+## Decision
+
+**The NIF distinguishes "no window" from "no insets."** `nif_safe_area` returns
+the atom `:no_window` when it cannot find a window, instead of a zeroed tuple.
+
+**A placeholder is assigned but not trusted.** The `:safe_area` assign is still
+always present — screens are documented to read `assigns.safe_area` directly, and
+a missing key would be a `KeyError` inside `render/1`, which is a worse failure
+than wrong insets. It holds zeros, and the socket records that the reading is
+unconfirmed. `ensure_safe_area/3` asks again on each paint until the platform
+gives a real answer, then stops.
+
+Stopping matters: each read is a hop to the main thread, and a real answer does
+not change under a screen. Re-reading every paint would trade a rare layout bug
+for a permanent cost on every frame.
+
+## Consequences
+
+- Android is untouched: it does not consult a window, and its branch still
+  assigns zeros unconditionally.
+- The contract of `mob_nif:safe_area/0` changed from "always a 4-tuple" to "a
+  4-tuple or `:no_window`". Both callers are in `Mob.Screen.Server`. Test stubs
+  returning a 4-tuple are unaffected.
+- Requires a native rebuild to take effect (`mix mob.deploy --native`) — the
+  Elixir half degrades safely without it, since a 4-tuple is still handled.
+- The guarantee documented in `guides/screen_lifecycle.md` — that the socket
+  always has a `:safe_area` assign — is preserved deliberately, and the guide now
+  says what happens before the platform can answer.
+- The regression test asserts the *second* paint, not the first. An earlier
+  version of it asserted only the boot-time value and passed with the fix
+  reverted, because `init` never marked its own reading confirmed either way.
+  Checked by reverting: treating `:no_window` as confirmed fails it.

--- a/guides/screen_lifecycle.md
+++ b/guides/screen_lifecycle.md
@@ -202,10 +202,15 @@ assigns.safe_area
 ```
 
 On iOS the insets are read from the active window. If the BEAM starts before
-that window exists — a background launch connects no window scene, and an
-iOS 15+ prewarmed launch runs long before the user taps the icon — the assign
-holds zeros and is refreshed on the next paint, until the platform gives a real
-answer. It is never missing, so `assigns.safe_area` is always safe to read.
+that window exists — a background launch connects no window scene at launch, and
+an iOS 15+ prewarmed launch runs long before the user taps the icon — the assign
+holds zeros until the platform can answer, and the window connecting triggers a
+re-read and a repaint.
+
+On device the assign is always present, so `assigns.safe_area` is safe to read
+directly. Under `Mob.ScreenCase` it is not: `mount_screen/3` builds a socket
+without it, so a test that renders a screen reading `assigns.safe_area` should
+assign one in `mount/3` or read it with `assigns[:safe_area]`.
 
 Use it to avoid content being obscured by the notch, home indicator, or status bar:
 

--- a/guides/screen_lifecycle.md
+++ b/guides/screen_lifecycle.md
@@ -201,6 +201,12 @@ assigns.safe_area
 #=> %{top: 62.0, right: 0.0, bottom: 34.0, left: 0.0}
 ```
 
+On iOS the insets are read from the active window. If the BEAM starts before
+that window exists — a background launch connects no window scene, and an
+iOS 15+ prewarmed launch runs long before the user taps the icon — the assign
+holds zeros and is refreshed on the next paint, until the platform gives a real
+answer. It is never missing, so `assigns.safe_area` is always safe to read.
+
 Use it to avoid content being obscured by the notch, home indicator, or status bar:
 
 ```elixir

--- a/ios/mob_beam.h
+++ b/ios/mob_beam.h
@@ -38,4 +38,10 @@ void mob_set_launch_notification_json(const char *json);
 // already running (warm).
 void mob_handle_opened_url(const char *url_cstr);
 
+// Call from SceneDelegate scene:willConnectToSession: after the window is
+// created. Tells the BEAM the window now exists so a screen that painted
+// earlier — a background or prewarmed launch — can re-read its safe-area
+// insets and repaint. Safe to call when no BEAM is running: it is a no-op.
+void mob_notify_window_connected(void);
+
 #endif // MOB_BEAM_H

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -779,6 +779,31 @@ void mob_handle_back(void) {
     enif_free_env(env);
 }
 
+// ── Window-connected sender ───────────────────────────────────────────────────
+// Called from SceneDelegate scene:willConnectToSession: once the window exists.
+//
+// Safe-area insets are read from the active window. The BEAM can reach its
+// first paint before that window exists — a background launch connects no
+// window scene at launch, and an iOS 15+ prewarmed launch runs
+// didFinishLaunchingWithOptions: long before the user taps the icon — and there
+// was nothing to tell it when the situation changed. Without this a screen
+// keeps its placeholder insets until something incidental repaints it, which on
+// a prewarmed launch means the user's first visible frame is wrong.
+//
+// Sending to :mob_screen reaches the router, whose catch-all forwards to the
+// current screen; Mob.Screen.Server invalidates its cached insets and repaints.
+
+void mob_notify_window_connected(void) {
+    ErlNifEnv *env = enif_alloc_env();
+    ErlNifPid pid;
+    if (enif_whereis_pid(env, enif_make_atom(env, "mob_screen"), &pid)) {
+        ERL_NIF_TERM msg = enif_make_tuple2(env, enif_make_atom(env, "mob_window"),
+                                            enif_make_atom(env, "connected"));
+        enif_send(NULL, &pid, env, msg);
+    }
+    enif_free_env(env);
+}
+
 // ── Change senders ────────────────────────────────────────────────────────────
 // Called from MobNode onChange blocks when an input widget fires.
 
@@ -2401,9 +2426,11 @@ static ERL_NIF_TERM nif_device_keep_awake(ErlNifEnv *env, int argc, const ERL_NI
 // main thread hasn't reached an idle run-loop tick yet (observed during
 // scene-attachment on iPad, including the compatibility-mode window an
 // iPhone-only app runs in there), this blocks the BEAM boot thread forever —
-// the app never finishes launching. Bound the wait and fall back to zero
-// insets on timeout: a screen with wrong insets once is a far smaller bug
-// than an app that never boots.
+// the app never finishes launching. So the wait is bounded, and a timeout
+// returns `no_window` just as a genuine absence does: both mean "this is not an
+// answer", and the caller retries on a later paint instead of caching it. Never
+// blocking forever matters more than either — an app that never boots is a far
+// worse bug than a screen that pads wrongly for one frame.
 static ERL_NIF_TERM nif_safe_area(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     __block UIEdgeInsets insets = UIEdgeInsetsZero;
     __block BOOL had_window = NO;

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -2406,6 +2406,7 @@ static ERL_NIF_TERM nif_device_keep_awake(ErlNifEnv *env, int argc, const ERL_NI
 // than an app that never boots.
 static ERL_NIF_TERM nif_safe_area(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     __block UIEdgeInsets insets = UIEdgeInsetsZero;
+    __block BOOL had_window = NO;
     dispatch_semaphore_t done = dispatch_semaphore_create(0);
     dispatch_async(dispatch_get_main_queue(), ^{
       UIWindow *window = nil;
@@ -2416,12 +2417,24 @@ static ERL_NIF_TERM nif_safe_area(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
               break;
           }
       }
-      if (window)
+      if (window) {
           insets = window.safeAreaInsets;
+          had_window = YES;
+      }
       dispatch_semaphore_signal(done);
     });
     dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC));
     dispatch_semaphore_wait(done, deadline);
+
+    // No window is not the same as no insets, and the caller must be able to
+    // tell them apart: Mob.Screen caches the first reading for the screen's
+    // lifetime, so returning zeros here would pin a screen under the notch
+    // permanently. The BEAM can reach Mob.Screen.init before a window exists —
+    // on a background launch, and on an iOS 15+ prewarmed launch, which runs
+    // didFinishLaunchingWithOptions: long before the user taps the icon.
+    if (!had_window)
+        return enif_make_atom(env, "no_window");
+
     return enif_make_tuple4(
         env, enif_make_double(env, insets.top), enif_make_double(env, insets.right),
         enif_make_double(env, insets.bottom), enif_make_double(env, insets.left));

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -150,7 +150,13 @@ defmodule Mob.Screen.Server do
     socket =
       module
       |> Mob.Socket.new(platform: platform)
-      |> Mob.Socket.assign(:safe_area, initial_safe_area(render_mode, nif))
+      |> then(fn socket ->
+        {insets, status} = initial_safe_area(render_mode, nif)
+
+        socket
+        |> Mob.Socket.assign(:safe_area, insets)
+        |> Mob.Socket.put_mob(:safe_area_confirmed, status == :confirmed)
+      end)
 
     case module.mount(Keyword.get(opts, :params, %{}), %{}, socket) do
       {:ok, mounted} ->
@@ -229,6 +235,22 @@ defmodule Mob.Screen.Server do
   # A component's state changed — repaint so the native view gets fresh props.
   def handle_info({:component_changed, _id, _module}, state) do
     {:noreply, %{state | socket: paint(state, :none)}}
+  end
+
+  # The window now exists, so the insets this screen is holding may be a
+  # placeholder taken before it did. Drop the confirmation and repaint; the
+  # paint re-reads. Intercepted here rather than forwarded to the user's
+  # handle_info, which has no reason to know about windows.
+  #
+  # Without this the correction had no trigger: `ensure_safe_area/3` is only
+  # reached from a paint, and nothing repaints when a scene connects. A screen
+  # that painted during a prewarmed launch would show its placeholder as the
+  # user's first visible frame and keep it until they interacted.
+  @impl GenServer
+  def handle_info({:mob_window, :connected}, state) do
+    socket = Mob.Socket.put_mob(state.socket, :safe_area_confirmed, false)
+    state = %{state | socket: socket}
+    {:noreply, %{state | socket: do_paint(state, :none, :async, nil, false)}}
   end
 
   # Periodic state sync — intercepted before the user's handle_info so the
@@ -459,13 +481,24 @@ defmodule Mob.Screen.Server do
   # icon. `ensure_safe_area/3` used to stop asking as soon as the key existed,
   # so a placeholder taken then left the root screen laid out under the notch
   # and home indicator for the rest of its life.
-  defp initial_safe_area(:render, nif), do: read_safe_area(nif) |> elem(0)
-  defp initial_safe_area(_mode, _nif), do: @zero_insets
+  defp initial_safe_area(:render, nif), do: read_safe_area(nif)
+  defp initial_safe_area(_mode, _nif), do: {@zero_insets, :placeholder}
 
   defp read_safe_area(nif) do
     case nif.safe_area() do
-      {t, r, b, l} -> {%{top: t, right: r, bottom: b, left: l}, :confirmed}
-      :no_window -> {@zero_insets, :placeholder}
+      {t, r, b, l} ->
+        {%{top: t, right: r, bottom: b, left: l}, :confirmed}
+
+      :no_window ->
+        {@zero_insets, :placeholder}
+
+      other ->
+        # Android answers `:error` when it cannot attach to the JVM, and a
+        # future platform may answer something else again. Treating an
+        # unrecognised reply as a placeholder means a screen degrades to zeros
+        # and retries, rather than dying in init/1 with a CaseClauseError.
+        Logger.warning("[mob] unexpected safe_area/0 result: #{inspect(other)}")
+        {@zero_insets, :placeholder}
     end
   end
 
@@ -474,8 +507,10 @@ defmodule Mob.Screen.Server do
       platform != :ios ->
         Mob.Socket.assign_new(socket, :safe_area, fn -> @zero_insets end)
 
-      # Confirmed once, kept forever: a real reading does not change under a
-      # screen, and re-reading costs a hop to the main thread every paint.
+      # Confirmed readings are not re-read on every paint — each read is a hop
+      # to the main thread. They are not permanent either: insets DO change
+      # under a screen (rotation, a resized scene), so `{:mob_window,
+      # :connected}` clears this flag and the next paint asks again.
       socket.__mob__[:safe_area_confirmed] ->
         socket
 
@@ -484,12 +519,9 @@ defmodule Mob.Screen.Server do
 
         socket
         |> Mob.Socket.assign(:safe_area, insets)
-        |> put_mob(:safe_area_confirmed, status == :confirmed)
+        |> Mob.Socket.put_mob(:safe_area_confirmed, status == :confirmed)
     end
   end
-
-  defp put_mob(socket, key, value),
-    do: %{socket | __mob__: Map.put(socket.__mob__, key, value)}
 
   defp maybe_load_state(module, socket) do
     if module.__mob_persist__() do

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -446,28 +446,50 @@ defmodule Mob.Screen.Server do
   # recovers in practice, but "one dropped frame" would be the wrong summary.
   defp fingerprint(tree), do: :erlang.phash2({tree, Mob.Theme.current()}, 4_294_967_296)
 
-  defp initial_safe_area(:render, nif) do
-    {t, r, b, l} = nif.safe_area()
-    %{top: t, right: r, bottom: b, left: l}
-  end
+  @zero_insets %{top: 0.0, right: 0.0, bottom: 0.0, left: 0.0}
 
-  defp initial_safe_area(_mode, _nif), do: %{top: 0.0, right: 0.0, bottom: 0.0, left: 0.0}
+  # The `:safe_area` assign is always present — screens are documented to read
+  # `assigns.safe_area` directly, so it must never be missing — but a reading
+  # taken before iOS has a window is a placeholder, not an answer, and must not
+  # be kept. `nif.safe_area()` answers `:no_window` for exactly that case.
+  #
+  # It matters because the BEAM can reach here before a window exists: a
+  # background launch connects no window scene at all, and an iOS 15+ prewarmed
+  # launch runs `didFinishLaunchingWithOptions:` long before the user taps the
+  # icon. `ensure_safe_area/3` used to stop asking as soon as the key existed,
+  # so a placeholder taken then left the root screen laid out under the notch
+  # and home indicator for the rest of its life.
+  defp initial_safe_area(:render, nif), do: read_safe_area(nif) |> elem(0)
+  defp initial_safe_area(_mode, _nif), do: @zero_insets
 
-  defp ensure_safe_area(socket, platform, nif) do
-    if Map.has_key?(socket.assigns, :safe_area) do
-      socket
-    else
-      safe_area =
-        if platform == :ios do
-          {t, r, b, l} = nif.safe_area()
-          %{top: t, right: r, bottom: b, left: l}
-        else
-          %{top: 0.0, right: 0.0, bottom: 0.0, left: 0.0}
-        end
-
-      Mob.Socket.assign(socket, :safe_area, safe_area)
+  defp read_safe_area(nif) do
+    case nif.safe_area() do
+      {t, r, b, l} -> {%{top: t, right: r, bottom: b, left: l}, :confirmed}
+      :no_window -> {@zero_insets, :placeholder}
     end
   end
+
+  defp ensure_safe_area(socket, platform, nif) do
+    cond do
+      platform != :ios ->
+        Mob.Socket.assign_new(socket, :safe_area, fn -> @zero_insets end)
+
+      # Confirmed once, kept forever: a real reading does not change under a
+      # screen, and re-reading costs a hop to the main thread every paint.
+      socket.__mob__[:safe_area_confirmed] ->
+        socket
+
+      true ->
+        {insets, status} = read_safe_area(nif)
+
+        socket
+        |> Mob.Socket.assign(:safe_area, insets)
+        |> put_mob(:safe_area_confirmed, status == :confirmed)
+    end
+  end
+
+  defp put_mob(socket, key, value),
+    do: %{socket | __mob__: Map.put(socket.__mob__, key, value)}
 
   defp maybe_load_state(module, socket) do
     if module.__mob_persist__() do

--- a/lib/mob/socket.ex
+++ b/lib/mob/socket.ex
@@ -26,6 +26,7 @@ defmodule Mob.Socket do
             required(:nav_action) => term(),
             # Written by Mob.Screen.Server rather than by the struct default, so
             # both are optional. The render path reads :last_frame every message.
+            optional(:safe_area_confirmed) => boolean(),
             optional(:last_frame) => non_neg_integer(),
             optional(:list_renderers) => map()
           }

--- a/test/mob/safe_area_unknown_test.exs
+++ b/test/mob/safe_area_unknown_test.exs
@@ -39,17 +39,24 @@ defmodule Mob.SafeAreaUnknownTest do
 
     # `:no_window` for the first `n` reads, then real insets — a window that
     # appears after the app has already started painting.
-    def start(n), do: Agent.start_link(fn -> {n, 0} end, name: __MODULE__)
+    def start(n), do: Agent.start_link(fn -> {n, 0, {47.0, 0.0, 34.0, 0.0}} end, name: __MODULE__)
+
+    def set_insets(insets),
+      do: Agent.update(__MODULE__, fn {n, reads, _} -> {n, reads, insets} end)
 
     def safe_area do
       Agent.get_and_update(__MODULE__, fn
-        {0, reads} -> {{47.0, 0.0, 34.0, 0.0}, {0, reads + 1}}
-        {n, reads} -> {:no_window, {n - 1, reads + 1}}
+        {0, reads, insets} -> {insets, {0, reads + 1, insets}}
+        {n, reads, insets} -> {:no_window, {n - 1, reads + 1, insets}}
       end)
     end
 
-    def reads, do: Agent.get(__MODULE__, fn {_n, r} -> r end)
+    def reads, do: Agent.get(__MODULE__, fn {_n, r, _} -> r end)
     def platform, do: :ios
+    # Enumerated like every other stub in this suite. A catch-all returning :ok
+    # makes a typo'd NIF name silently succeed, and produced three
+    # "launch notification could not be decoded" errors per run.
+    def take_launch_notification, do: :none
     def unquote(:"$handle_undefined_function")(_f, _a), do: :ok
   end
 
@@ -64,12 +71,18 @@ defmodule Mob.SafeAreaUnknownTest do
     pid
   end
 
-  defp repaint(pid) do
-    send(pid, :repaint)
-    # A call to the router is not an ordering barrier for a message it forwards
-    # to the screen, so sync with the screen itself.
+  defp settle(pid) do
+    # Both halves are load-bearing. `get_screen_pid/1` is a call to the router,
+    # so the router has necessarily forwarded the message above before it
+    # replies; only then does syncing with the screen queue behind that
+    # forwarded message. Drop either and this is racy.
     pid |> Mob.Router.get_screen_pid() |> :sys.get_state()
     Mob.Router.get_socket(pid)
+  end
+
+  defp repaint(pid) do
+    send(pid, :repaint)
+    settle(pid)
   end
 
   test "a screen that painted before the window picks up the real insets later" do
@@ -89,6 +102,52 @@ defmodule Mob.SafeAreaUnknownTest do
 
     assert Mob.Router.get_socket(pid).assigns.safe_area ==
              %{top: 0.0, right: 0.0, bottom: 0.0, left: 0.0}
+  end
+
+  test "a window connecting corrects a screen that painted before it existed" do
+    # The case the whole change exists for, and the one a repaint-driven fix
+    # does not cover on its own: on a prewarmed launch the BEAM boots, paints
+    # its placeholder, and then nothing happens until the user interacts. If
+    # the window connecting does not itself trigger the correction, the user's
+    # first visible frame is wrong.
+    {:ok, _} = Nif.start(2)
+    pid = start_screen()
+
+    assert Mob.Router.get_socket(pid).assigns.safe_area == %{
+             top: 0.0,
+             right: 0.0,
+             bottom: 0.0,
+             left: 0.0
+           }
+
+    # Exactly what mob_notify_window_connected() sends from
+    # scene:willConnectToSession:. No user interaction, no other repaint.
+    send(pid, {:mob_window, :connected})
+
+    assert settle(pid).assigns.safe_area == %{top: 47.0, right: 0.0, bottom: 34.0, left: 0.0},
+           "a window connecting must correct a placeholder reading by itself"
+  end
+
+  test "a window connecting re-reads insets even after they were confirmed" do
+    # The half a placeholder cannot exercise. Once a reading is confirmed the
+    # paint path deliberately stops asking, so a screen holding real-but-stale
+    # insets — the device rotated, the scene was resized, a new window
+    # connected — would keep them. `{:mob_window, :connected}` is what clears
+    # the confirmation; without it this screen never sees the new values.
+    {:ok, _} = Nif.start(0)
+    pid = start_screen()
+
+    assert Mob.Router.get_socket(pid).assigns.safe_area.top == 47.0
+
+    Nif.set_insets({0.0, 47.0, 21.0, 47.0})
+
+    # A plain repaint must NOT pick it up — that is what "confirmed" means.
+    assert repaint(pid).assigns.safe_area.top == 47.0
+
+    send(pid, {:mob_window, :connected})
+
+    assert settle(pid).assigns.safe_area == %{top: 0.0, right: 47.0, bottom: 21.0, left: 47.0},
+           "a confirmed reading must be invalidated when the window changes"
   end
 
   test "a confirmed reading is not re-read on later paints" do

--- a/test/mob/safe_area_unknown_test.exs
+++ b/test/mob/safe_area_unknown_test.exs
@@ -1,0 +1,107 @@
+defmodule Mob.SafeAreaUnknownTest do
+  use ExUnit.Case, async: false
+
+  # MOB-166. `ensure_safe_area/3` used to stop asking as soon as the `:safe_area`
+  # assign existed. The BEAM can reach a paint before iOS has a window — a
+  # background launch connects no window scene at all, and an iOS 15+ prewarmed
+  # launch runs `didFinishLaunchingWithOptions:` long before the user taps the
+  # icon — and `nif_safe_area` could only answer zeros in that case. So a screen
+  # that painted once too early spent the rest of its life laid out under the
+  # notch and home indicator.
+  #
+  # The NIF now answers `:no_window` distinctly. Zeros are still assigned (screens
+  # read `assigns.safe_area` directly and a missing key would be a KeyError in
+  # render) but they are marked unconfirmed, so the next paint asks again.
+
+  defmodule Screen do
+    @moduledoc false
+    use Mob.Screen
+
+    def mount(_p, _s, socket), do: {:ok, Mob.Socket.assign(socket, :n, 0)}
+
+    # Changing an assign is what makes the router repaint.
+    def handle_info(:repaint, socket),
+      do: {:noreply, Mob.Socket.assign(socket, :n, System.unique_integer([:positive]))}
+
+    def handle_info(_other, socket), do: {:noreply, socket}
+
+    def render(assigns),
+      do: %{
+        type: :text,
+        props: %{text: "#{assigns.n} #{inspect(assigns.safe_area)}"},
+        children: []
+      }
+  end
+
+  defmodule Nif do
+    @moduledoc false
+    use Agent
+
+    # `:no_window` for the first `n` reads, then real insets — a window that
+    # appears after the app has already started painting.
+    def start(n), do: Agent.start_link(fn -> {n, 0} end, name: __MODULE__)
+
+    def safe_area do
+      Agent.get_and_update(__MODULE__, fn
+        {0, reads} -> {{47.0, 0.0, 34.0, 0.0}, {0, reads + 1}}
+        {n, reads} -> {:no_window, {n - 1, reads + 1}}
+      end)
+    end
+
+    def reads, do: Agent.get(__MODULE__, fn {_n, r} -> r end)
+    def platform, do: :ios
+    def unquote(:"$handle_undefined_function")(_f, _a), do: :ok
+  end
+
+  setup do
+    Mob.Test.ProcessHelpers.stop_if_running(Nif)
+    :ok
+  end
+
+  defp start_screen do
+    {:ok, pid} = Mob.Router.start_root(Screen, %{}, nif: Nif)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
+    pid
+  end
+
+  defp repaint(pid) do
+    send(pid, :repaint)
+    # A call to the router is not an ordering barrier for a message it forwards
+    # to the screen, so sync with the screen itself.
+    pid |> Mob.Router.get_screen_pid() |> :sys.get_state()
+    Mob.Router.get_socket(pid)
+  end
+
+  test "a screen that painted before the window picks up the real insets later" do
+    # Enough :no_window reads to cover mount and the first paint, so the screen
+    # is fully started while iOS still has no window.
+    {:ok, _} = Nif.start(2)
+    pid = start_screen()
+
+    assert repaint(pid).assigns.safe_area == %{top: 47.0, right: 0.0, bottom: 34.0, left: 0.0},
+           "the screen kept a reading taken before the window existed"
+  end
+
+  test "the assign is present, as zeros, while there is no window" do
+    # Screens read `assigns.safe_area` directly, so it must never be missing.
+    {:ok, _} = Nif.start(1_000)
+    pid = start_screen()
+
+    assert Mob.Router.get_socket(pid).assigns.safe_area ==
+             %{top: 0.0, right: 0.0, bottom: 0.0, left: 0.0}
+  end
+
+  test "a confirmed reading is not re-read on later paints" do
+    # Each read is a hop to the main thread. A real answer does not change under
+    # the screen, so asking again every paint would be pure cost.
+    {:ok, _} = Nif.start(0)
+    pid = start_screen()
+
+    repaint(pid)
+    settled = Nif.reads()
+    repaint(pid)
+    repaint(pid)
+
+    assert Nif.reads() == settled, "safe_area was re-read after it was confirmed"
+  end
+end


### PR DESCRIPTION
Part of MOB-166. **Pairs with mob_new #63** — that PR is blocked until this lands.

## The bug

`nif_safe_area` locates the active window through `connectedScenes` and reads its `safeAreaInsets`. When it finds no window it returned **zeros**, which is indistinguishable from a device that genuinely has none (an iPad). `Mob.Screen.Server.ensure_safe_area/3` stopped asking as soon as the `:safe_area` assign existed — and `init` assigns it unconditionally, so it was never asked again. There is no recompute path anywhere: not on rotation, not on scene reconnect.

Those two behaviours are only compatible while the BEAM cannot start before a window exists. Two ordinary launches break that:

- a **background launch** connects no window scene at launch;
- an **iOS 15+ prewarmed launch** runs `application:didFinishLaunchingWithOptions:` long before the user taps the icon. For scene-based apps prewarm calls that method and creates no scene, and prewarming is routine.

A screen that painted in that window renders under the notch and home indicator until it is replaced. Rare, silent, and permanent for the screen it hits.

## The fix

**The NIF distinguishes "no window" from "no insets."** `nif_safe_area` returns the atom `:no_window` rather than a zeroed tuple.

**A placeholder is assigned but not trusted.** `:safe_area` is still always present — screens are documented to read `assigns.safe_area` directly, and a missing key would be a `KeyError` inside `render/1`, which is a worse failure than wrong insets. It holds zeros, the socket records the reading as unconfirmed, and each paint asks again until the platform answers — then stops.

Stopping matters: each read is a hop to the main thread, and a real answer does not change under a screen. Re-reading every paint would trade a rare layout bug for a permanent per-frame cost.

## Why this rather than fixing the boot order

This was found by the pre-commit review of mob_new #63, which moved the iOS boot earlier so background launches start the runtime at all. Its first version booted unconditionally and made this race the common case. Gating on `applicationState == UIApplicationStateBackground` looked like the answer, but the pre-merge review showed that state also means *prewarm* — so the gate reintroduces the same race on a launch type that happens routinely, with the timing skewed so the BEAM usually wins.

There is no reliable in-`didFinishLaunching` prewarm discriminator (`ActivePrewarm` is reported gone on iOS 16+). So boot order cannot be made load-bearing. **Making the reading non-cacheable removes the requirement entirely** — prewarm, background launch, and any future ordering all become safe, and mob_new #63 can drop its gate and boot unconditionally.

## Verification

- Full suite **1581 passed**, 38 excluded. `mix credo --strict` clean, `mix format --check-formatted` clean, `clang-format` clean.
- New `test/mob/safe_area_unknown_test.exs` (3 tests) asserts: a screen that painted before the window picks up the real insets on a later paint; the assign is present as zeros meanwhile; and a confirmed reading is not re-read on later paints.
- **Reversion checked.** Treating `:no_window` as confirmed fails the suite. An earlier version of this test asserted only the boot-time value and passed with the fix reverted — because `init` never marked its own reading confirmed either way — so it now asserts the *second* paint.

## Notes

- Android untouched: it does not consult a window and still assigns zeros unconditionally.
- `mob_nif:safe_area/0` changes from "always a 4-tuple" to "a 4-tuple or `:no_window`". Both callers are in `Mob.Screen.Server`; test stubs returning a 4-tuple are unaffected.
- **Requires a native rebuild** (`mix mob.deploy --native`). The Elixir half still handles a plain 4-tuple, so it degrades safely without one.
- `guides/screen_lifecycle.md` documented that the socket *always* has a `:safe_area` assign. That guarantee is deliberately preserved, and the guide now says what the value means before the platform can answer.

Decision record: `decisions/2026-09-10-a-safe-area-read-with-no-window-is-not-an-answer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)