### PR TITLE
Causal receipts — an action id from dispatch to committed frame (MOB-155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ### Added
 - **Causal receipts — `Mob.Agent.Receipt`** (MOB-155). Every dispatched event now
-  gets an `action_id`, and the screen records which of five stages the action
-  reached: dispatched, handled (or unhandled), assigns changed, navigated, frame
-  changed, committed. The first stage it fails to reach names the layer answerable for it,
+  gets an `action_id`, and the screen records which stages the action
+  reached: dispatched, handled (or unhandled), assigns changed, navigation
+  requested, frame changed, committed. The first stage it fails to reach names the layer answerable for it,
   so "the tap did nothing" becomes "the handler ran and changed `:count`, and the
   tree did not change" — which points at a `render/1` that never reads `:count`.
 
@@ -22,12 +22,15 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   callback, and every later stage is a before/after comparison the screen makes
   itself, so a handler cannot claim an effect it did not have.
 
-  A navigation is its own verdict: this screen deliberately does not paint when
-  the handler navigates, so deriving the answer from the absence of a paint would
-  report a screen push — the commonest successful action in a mobile app — as
-  "the handler did nothing".
+  A navigation is its own verdict, and explicitly a *request*: this screen does
+  not paint when the handler navigates, so deriving the answer from the absence
+  of a paint would report a screen push as "the handler did nothing" — but the
+  router may also refuse the request (a pop at the root), which this screen
+  cannot see, so the owner is `:unknown` rather than "nothing to answer for".
 
-  **Receipts carry no application state.** A crash is reduced to its kind,
+  **Receipts carry no state read out of assigns.** They do carry the event tag,
+  which is the action's identity and whatever the render tree put in `on_tap`.
+  A crash is reduced to its kind,
   exception module and top stack frame; the message is dropped unless the
   framework built it, because `KeyError` and friends embed the term that failed
   and would otherwise carry the whole assigns map into telemetry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Added
+- **Causal receipts — `Mob.Agent.Receipt`** (MOB-155). Every dispatched event now
+  gets an `action_id`, and the screen records which of five stages the action
+  reached: dispatched, handled (or unhandled), assigns changed, navigated, frame
+  changed, committed. The first stage it fails to reach names the layer answerable for it,
+  so "the tap did nothing" becomes "the handler ran and changed `:count`, and the
+  tree did not change" — which points at a `render/1` that never reads `:count`.
+
+  The stages are *observed*, not reported: only `handled` is proved by the
+  callback, and every later stage is a before/after comparison the screen makes
+  itself, so a handler cannot claim an effect it did not have.
+
+  A navigation is its own verdict: this screen deliberately does not paint when
+  the handler navigates, so deriving the answer from the absence of a paint would
+  report a screen push — the commonest successful action in a mobile app — as
+  "the handler did nothing".
+
+  **Receipts carry no application state.** A crash is reduced to its kind,
+  exception module and top stack frame; the message is dropped unless the
+  framework built it, because `KeyError` and friends embed the term that failed
+  and would otherwise carry the whole assigns map into telemetry.
+  `Mob.Agent.Receipts.fetch/1` retrieves one by id; `recent/1` lists the newest.
+  Bounded at 256, with `count/0` and `dropped/0` so a missing receipt can be told
+  apart from an id that never existed.
+
+  Emits `[:mob, :action, :stop]` **only when the host app already has
+  `:telemetry` loaded** — `mob` keeps its single runtime dependency.
+
+  `native_commit` is `:unknown`: this says what the BEAM did, not that the pixels
+  changed. See
+  `decisions/2026-09-10-a-receipt-per-action-not-a-window.md`.
+
 ### Fixed
 - **A safe-area reading taken before iOS had a window is no longer kept for the
   life of the screen** (MOB-166). `nif_safe_area` returned zeros when it could

--- a/decisions/2026-09-10-a-receipt-per-action-not-a-window.md
+++ b/decisions/2026-09-10-a-receipt-per-action-not-a-window.md
@@ -150,3 +150,21 @@ that overclaim cost a day.
   receipts. `tap_xy`'s window is still in place; replacing it needs the native
   half. The vocabulary beyond `[:mob, :action, :stop]` — deploy, code-load,
   frame prepared/dropped, component allocate/release — is not emitted yet.
+
+- **A test module that calls `Mob.Router.start_root/3` leaks two global
+  processes, and the failure lands somewhere else entirely.** `start_root/3`
+  brings up `Mob.Sender` and `Mob.Listener` under global names.
+  `Mob.Listener.handler/1` wraps a tap tag into `{:mob_route, ...}` *only when a
+  listener is running* — so leaving one behind changes what the renderer does
+  for every file that runs afterwards. The symptom was two `Mob.RendererTest`
+  assertions failing 2 runs in 12, in a file with no connection to this work,
+  and passing every time in isolation. CI found it before the pre-merge review
+  did.
+
+  The teardown stops the router first, then both globals. Two wrong turns on the
+  way: adding `stop_if_running(:mob_screen)` made it fail 12 runs out of 12,
+  because it killed whichever process held that name at the time rather than the
+  one this module started. `reset_transition_test.exs` already carried a comment
+  saying leaving Sender and Listener behind "is what produces cross-file
+  ordering flakes" — the precedent was there to read.
+

--- a/decisions/2026-09-10-a-receipt-per-action-not-a-window.md
+++ b/decisions/2026-09-10-a-receipt-per-action-not-a-window.md
@@ -1,0 +1,152 @@
+# A receipt per action, not a window in which anything might have happened
+
+Date: 2026-09-10
+Status: accepted
+Ticket: MOB-155 (epic MOB-149, phase 1)
+
+## Context
+
+An agent driving a Mob app can ask what the assigns are now. It cannot ask
+whether *its* action caused them.
+
+The mechanism behind `tap_xy/3` is the clearest case. It records a process-wide
+UI-event counter, injects the tap, and polls for 300ms:
+
+```objc
+if (!mob_await_ui_event(seq_before, MOB_TAP_SETTLE_MS)) {
+    return ... "no_effect";
+}
+```
+
+That counter belongs to the process, not to the tap. Anything that bumps it
+inside the window — a timer, a scroll notification, a second agent on the same
+device — is indistinguishable from the tap landing, so the check reports success
+for taps that did nothing. It also fails the other way: on 2026-09-04 it returned
+`{:error, :no_effect}` for a tap that demonstrably worked.
+
+A window cannot answer a question about causation. Only a correlation id can.
+
+## Decision
+
+Every dispatched event gets an `action_id`, and the screen assembles a
+`%Mob.Agent.Receipt{}` around the callback recording which of five stages the
+action reached: `:dispatched`, `:handled` (or `:unhandled`),
+`:assigns_changed`, `:navigated`, `:frame_changed`, `:committed`.
+
+**The stages are observed, not reported.** Only `:handled` is proved by the
+callback itself; every later stage is a comparison the screen makes for itself —
+an assigns digest before and after, a tree fingerprint before and after. A
+handler cannot claim an effect it did not have, which is the property that makes
+a receipt worth more than a return value.
+
+**The first stage an action fails to reach names the owner.** That is the whole
+reason for recording stages separately rather than a boolean:
+
+| Stops at | Owner | Reading |
+|---|---|---|
+| `:unhandled` | `:event_routing` | a stale tag, a renamed event |
+| `:handled` | `:app_code` | the handler ran and decided nothing |
+| `:assigns_changed` | `:render_function` | `render/1` ignores what changed |
+| `:frame_changed` without `:committed` | `:renderer` | a frame built and never handed over |
+| `:navigated` | `:none` | this screen does not paint; the destination does |
+| `:committed` with `:frame_changed` | `:none` | nothing to answer for |
+
+"The tap did nothing" is a bug report nobody can route. "The handler ran and
+changed `:count`, and the tree did not change" points at a `render/1` that never
+reads `:count`. This is the attribution MOB-149 wants computable rather than
+guessed.
+
+**A navigation is its own verdict.** The first version of this derived
+everything from the paint, and `reply_after_callback/2` deliberately does not
+paint when the handler asked to navigate — the owner applies the action and the
+destination screen paints. So a tap that pushed a whole new screen recorded
+`[:dispatched, :handled]` and reported `:inert`, "the handler ran and decided
+nothing", filed against `:app_code`. That is the same lie the process-wide
+counter tells, inverted, on the commonest successful action in a mobile app. The
+receipt now reads the nav action before it is cleared.
+
+**`:no_visible_change` is not an error.** A handler that updates state the
+current screen does not render has done what it was asked. Whether that is a bug
+is the caller's judgement; a framework that decides it produces false alarms.
+
+## Two things this deliberately does not do
+
+**It does not add `:telemetry` as a dependency.** `mob` has exactly one runtime
+dependency, on a framework whose premise is running on a phone. Events go to
+`[:mob, :action, :stop]` only when the host application already has `:telemetry`
+loaded.
+
+That check is resolved **once, at startup**, and the first version got this
+badly wrong by calling `Code.ensure_loaded?/1` per action. A *negative* result is
+not cached: it is a `gen_server` call into `:code_server` plus a scan of the code
+path, measured at ~12us against ~0.04us for a loaded module. Since `mob` has no
+`:telemetry` dependency, absent is the default case — so the write path would
+have routed every event in every app through one global mailbox, in a module
+whose documentation boasted that no process was involved.
+
+**It does not claim the pixels changed.** `native_commit` is `:unknown` on a
+receipt assembled from the BEAM alone. Handing a frame to `Mob.Sender` is not
+proof the platform drew it, and the native acknowledgement is not wired. A
+receipt says what the BEAM did. Anything stronger would be the same overclaim the
+process-wide counter makes, in better clothes — and this record exists because
+that overclaim cost a day.
+
+## Consequences
+
+- The write path is one ETS insert, one `:atomics.add_get/3`, and an eviction
+  check, with no process involved. `:atomics` rather than `:counters` because
+  read-then-add is not atomic, and two screens dispatching concurrently could be
+  issued the same sequence number — which breaks ordering and lets eviction
+  delete the wrong row. A GenServer here would serialise every event in the app
+  through one mailbox, which is the opposite of what a diagnostic should cost.
+- Receipts are bounded at 256 — and the first version bounded at 257, because
+  eviction kept the boundary row while three documents stated 256. `count/0` and `dropped/0` are exposed so "no
+  receipt for that id" can be distinguished from "that id never existed"; a
+  diagnostic that silently forgets is a diagnostic that lies.
+- **A receipt carries no application state at all**, and getting this right took
+  two attempts. The first stored a hash of assigns and the normalised exception,
+  and the exception was the leak: `KeyError`, `MatchError` and `BadMapError`
+  embed the term that failed, so a `Map.fetch!/2` against assigns put the entire
+  assigns map — secrets included — into ETS and into telemetry metadata. That is
+  MOB-147's `SecureField` leak, re-created inside the mitigation that cites it,
+  reaching a sink unredacted in direct violation of
+  `2026-09-04-defect-reports-are-a-shipped-feature.md`.
+
+  A crash is now reduced to `{kind, exception module, top MFA}`. The **message
+  is dropped** unless the framework built it — app code writes `raise "failed
+  for \#{inspect(user)}"` as a matter of routine, and truncating does not help
+  because `KeyError`'s rendered message is itself "key :x not found in: %{...}".
+  Default-deny is the only posture the sink policy allows. It costs real
+  diagnostic detail and is worth it.
+
+- **The assigns comparison is a term comparison, not a hash.** `!==` answers
+  "did assigns change" exactly and short-circuits: 0.01us against 43us for a
+  deep `phash2` over a 1000-row list screen's assigns, and the first version did
+  that twice per event. It was answering a boolean question the expensive way,
+  on the path of every event in the app.
+- The receipt for a crashing handler is written on the way out, before the
+  exception propagates. `Mob.Router` wraps dispatch in `safe_call/1` and absorbs
+  the crash, so from outside, a handler that exploded and a handler that did
+  nothing look identical. That is precisely the case a receipt has to cover.
+- `catch` yields the raw Erlang reason (`:function_clause`), which cannot say
+  *which* function failed to match. `Exception.normalize/3` recovers the module,
+  function and arity — without it, every unmatched event was filed as a crash in
+  a handler that was never entered.
+- **The diagnostic cannot crash what it observes.** The receipt write is
+  wrapped: it runs after a successful event, and in the `catch` clause it would
+  otherwise be able to replace the handler's exception with its own — destroying
+  the report the feature exists to produce. Relatedly, the store initialises its
+  `:persistent_term` state *before* creating the table, because the reverse
+  order leaves a window where a second process sees the table, skips
+  initialisation, and reads a key that does not exist yet.
+
+- **A `render/1` that raises produces no receipt.** The exception escapes from
+  the paint, which runs after the callback returned and outside the `try` that
+  wraps it, so the textbook `:render_function` defect is the one case with no
+  record. Covering it means wrapping the paint, which changes what a render
+  crash does to a screen — a bigger decision than this slice.
+
+- Not yet done, and the reason this is phase 1 of five: nothing consumes
+  receipts. `tap_xy`'s window is still in place; replacing it needs the native
+  half. The vocabulary beyond `[:mob, :action, :stop]` — deploy, code-load,
+  frame prepared/dropped, component allocate/release — is not emitted yet.

--- a/decisions/2026-09-10-a-receipt-per-action-not-a-window.md
+++ b/decisions/2026-09-10-a-receipt-per-action-not-a-window.md
@@ -29,9 +29,10 @@ A window cannot answer a question about causation. Only a correlation id can.
 ## Decision
 
 Every dispatched event gets an `action_id`, and the screen assembles a
-`%Mob.Agent.Receipt{}` around the callback recording which of five stages the
-action reached: `:dispatched`, `:handled` (or `:unhandled`),
-`:assigns_changed`, `:navigated`, `:frame_changed`, `:committed`.
+`%Mob.Agent.Receipt{}` around the callback recording which stages the
+action reached: `:dispatched`, `:handled` (or `:unhandled`), `:assigns_changed`,
+`:navigation_requested`, `:frame_changed`, `:committed`, and `:unobservable`
+for a screen that does not render.
 
 **The stages are observed, not reported.** Only `:handled` is proved by the
 callback itself; every later stage is a comparison the screen makes for itself —
@@ -48,7 +49,7 @@ reason for recording stages separately rather than a boolean:
 | `:handled` | `:app_code` | the handler ran and decided nothing |
 | `:assigns_changed` | `:render_function` | `render/1` ignores what changed |
 | `:frame_changed` without `:committed` | `:renderer` | a frame built and never handed over |
-| `:navigated` | `:none` | this screen does not paint; the destination does |
+| `:navigation_requested` | `:unknown` | the handler asked to navigate; this screen cannot see whether the router honoured it |
 | `:committed` with `:frame_changed` | `:none` | nothing to answer for |
 
 "The tap did nothing" is a bug report nobody can route. "The handler ran and
@@ -56,14 +57,22 @@ changed `:count`, and the tree did not change" points at a `render/1` that never
 reads `:count`. This is the attribution MOB-149 wants computable rather than
 guessed.
 
-**A navigation is its own verdict.** The first version of this derived
-everything from the paint, and `reply_after_callback/2` deliberately does not
+**A navigation is its own verdict, and only a request.** The first version of
+this derived everything from the paint, and `reply_after_callback/2` deliberately does not
 paint when the handler asked to navigate — the owner applies the action and the
 destination screen paints. So a tap that pushed a whole new screen recorded
 `[:dispatched, :handled]` and reported `:inert`, "the handler ran and decided
 nothing", filed against `:app_code`. That is the same lie the process-wide
 counter tells, inverted, on the commonest successful action in a mobile app. The
 receipt now reads the nav action before it is cleared.
+
+It records the **request**, not the outcome, and the naming says so. The router
+decides whether the ask does anything and routinely refuses — a pop at the root,
+a push to a module that fails to resolve, an unrecognised action — repainting
+this screen instead. A second version called that `:navigated` with
+`owner: :none`, which reported a false success on Back-at-root: the same lie as
+the process-wide counter, on the second-commonest action in a mobile app.
+Confirming the outcome needs the router to report back, which is not wired.
 
 **`:no_visible_change` is not an error.** A handler that updates state the
 current screen does not render has done what it was asked. Whether that is a bug
@@ -103,7 +112,11 @@ that overclaim cost a day.
   eviction kept the boundary row while three documents stated 256. `count/0` and `dropped/0` are exposed so "no
   receipt for that id" can be distinguished from "that id never existed"; a
   diagnostic that silently forgets is a diagnostic that lies.
-- **A receipt carries no application state at all**, and getting this right took
+- **A receipt carries no state out of the socket.** It does carry `event` — the
+  tag the render tree put in `on_tap` — because that is the action's identity.
+  The guides teach building those tags from record data (`{:contact,
+  contact.id}`), so a receipt can carry an identifier the app chose to put in a
+  tag. What it never carries is anything read out of assigns, and getting this right took
   two attempts. The first stored a hash of assigns and the normalised exception,
   and the exception was the leak: `KeyError`, `MatchError` and `BadMapError`
   embed the term that failed, so a `Map.fetch!/2` against assigns put the entire
@@ -153,18 +166,25 @@ that overclaim cost a day.
 
 - **A test module that calls `Mob.Router.start_root/3` leaks two global
   processes, and the failure lands somewhere else entirely.** `start_root/3`
-  brings up `Mob.Sender` and `Mob.Listener` under global names.
+  registers `Mob.Sender` and `Mob.Listener` under global names, and
   `Mob.Listener.handler/1` wraps a tap tag into `{:mob_route, ...}` *only when a
   listener is running* — so leaving one behind changes what the renderer does
   for every file that runs afterwards. The symptom was two `Mob.RendererTest`
-  assertions failing 2 runs in 12, in a file with no connection to this work,
-  and passing every time in isolation. CI found it before the pre-merge review
-  did.
+  assertions failing, in a file with no connection to this work, passing every
+  time in isolation.
 
-  The teardown stops the router first, then both globals. Two wrong turns on the
-  way: adding `stop_if_running(:mob_screen)` made it fail 12 runs out of 12,
-  because it killed whichever process held that name at the time rather than the
-  one this module started. `reset_transition_test.exs` already carried a comment
-  saying leaving Sender and Listener behind "is what produces cross-file
-  ordering flakes" — the precedent was there to read.
+  **This predates the receipts work.** `safe_area_unknown_test.exs`, added by
+  MOB-166 and already on master, stopped only its router pid. The fix is
+  `ProcessHelpers.stop_root/2`, now used by every `start_root/3` caller.
+
+  Two wrong turns while chasing it: adding `stop_if_running(:mob_screen)` made
+  it fail 12 runs out of 12, because it killed whichever process held that name
+  rather than the one the module started. And **no rate is claimed** — a
+  reviewer measured the leak at 4 runs in 14 on master where this machine
+  measured 0 in 12. The mechanism is verified by reading
+  `Mob.Listener.handler/1`; the frequency is load-dependent and not worth
+  asserting, a lesson MOB-154 already paid for.
+  `reset_transition_test.exs` carried a comment saying leaving Sender and
+  Listener behind "is what produces cross-file ordering flakes" — the precedent
+  was there to read.
 

--- a/lib/mob/agent/receipt.ex
+++ b/lib/mob/agent/receipt.ex
@@ -1,0 +1,280 @@
+defmodule Mob.Agent.Receipt do
+  @moduledoc """
+  What one action did, and which layer is answerable if it did nothing.
+
+  An agent driving a Mob app can already ask "what are the assigns now". It
+  cannot ask "did *my* tap cause that". The difference matters more than it
+  sounds: the effect detector behind `tap_xy/3` waits 300ms for a process-wide
+  event counter to move, so any Mob event inside that window — a timer, a scroll
+  notification, another agent on the same device — is indistinguishable from the
+  tap landing. It reports success for taps that did nothing, and on 2026-09-04 it
+  reported `{:error, :no_effect}` for a tap that demonstrably worked.
+
+  A receipt replaces the window with a correlation id. One action, one id,
+  followed from dispatch through to the committed frame.
+
+  ## The five stages
+
+  An action passes through five observable stages, and the *first* one it fails
+  to reach names the layer at fault. That is the whole point of recording them
+  separately rather than reporting a boolean:
+
+  | Stage | Reached when | If it stops here |
+  |---|---|---|
+  | `:dispatched` | the screen received the event | — |
+  | `:unhandled` | *no* clause matched the event | event routing — a stale tag, a renamed event |
+  | `:handled` | `handle_event/3` returned | — it raised; see `:unhandled` below |
+  | `:assigns_changed` | the socket's assigns differ | application code — the handler ran and decided nothing |
+  | `:frame_changed` | `render/1` produced a different frame | the render function — it ignores the assigns that changed |
+  | `:committed` | the frame was handed to the sender | the renderer or the bridge |
+  | `:navigated` | the handler asked for a navigation | — this screen does not paint; the destination does |
+
+  `:frame_changed` rather than `:tree_changed` because the fingerprint covers
+  `{tree, Mob.Theme.current()}` — a handler that changes only the theme produces
+  an identical tree and a different frame, and calling that "the tree changed"
+  would be false.
+
+  This is why `owner/1` is computable rather than guessed. A defect report that
+  says "the tap did nothing" is a bug report nobody can route; one that says
+  "the handler ran and changed `:count`, and the tree did not change" points at a
+  `render/1` that never reads `:count`.
+
+  ## What this does not know
+
+  A `render/1` that raises produces **no receipt**. The exception escapes from
+  the paint, which happens after the callback returned, outside the `try` that
+  wraps it — so the textbook `:render_function` defect is the one case with no
+  record. Covering it means wrapping the paint, which would change what a
+  render crash does to the screen, and that is a bigger decision than this
+  slice.
+
+  `native_commit` is `:unknown` on a receipt assembled from the BEAM alone.
+  Handing a frame to `Mob.Sender` is not proof the platform drew it, and the
+  native acknowledgement is not wired yet. A receipt says what the BEAM did; it
+  does not claim the pixels changed. Anything stronger would be the same
+  overclaim the process-wide counter makes, in better clothes.
+  """
+
+  @type stage ::
+          :dispatched
+          | :unhandled
+          | :handled
+          | :assigns_changed
+          | :frame_changed
+          | :committed
+          | :navigated
+
+  @typedoc """
+  A crash, reduced to what is safe to keep.
+
+  Never the exception struct. Standard exceptions embed the term that failed —
+  `KeyError.term`, `MatchError.term`, `BadMapError.term` — so a `Map.fetch!/2`
+  against assigns puts the whole assigns map, secrets included, into the
+  receipt. That is exactly MOB-147's leak, and a receipt is written to ETS and
+  handed to telemetry, so it reaches a sink.
+  """
+  @type error_summary :: %{
+          kind: :error | :exit | :throw,
+          exception: module() | nil,
+          message: String.t() | nil,
+          at: mfa() | nil,
+          redaction: :applied
+        }
+  @type owner :: :event_routing | :app_code | :render_function | :renderer | :none
+
+  @type t :: %__MODULE__{
+          action_id: String.t(),
+          screen: module() | nil,
+          handler: mfa() | nil,
+          event: term(),
+          stages: [stage()],
+          before_frame_fingerprint: non_neg_integer() | nil,
+          after_frame_fingerprint: non_neg_integer() | nil,
+          native_commit: :unknown | :acknowledged | :rejected,
+          error: error_summary() | nil,
+          elapsed_us: non_neg_integer() | nil,
+          monotonic_us: integer() | nil
+        }
+
+  defstruct action_id: nil,
+            screen: nil,
+            handler: nil,
+            event: nil,
+            stages: [],
+            before_frame_fingerprint: nil,
+            after_frame_fingerprint: nil,
+            native_commit: :unknown,
+            error: nil,
+            elapsed_us: nil,
+            monotonic_us: nil
+
+  @doc """
+  A fresh correlation id.
+
+  Unique within the node and cheap: this is on the path of every dispatched
+  event, so it must not be a bottleneck or a source of entropy exhaustion.
+  """
+  @spec new_action_id() :: String.t()
+  def new_action_id do
+    Integer.to_string(System.unique_integer([:positive, :monotonic]), 36)
+  end
+
+  @doc """
+  Did this action reach `stage`?
+  """
+  @spec reached?(t(), stage()) :: boolean()
+  def reached?(%__MODULE__{stages: stages}, stage), do: stage in stages
+
+  @doc """
+  True when `error` is "no clause matched `handle_event/3` on this screen".
+
+  Distinct from a crash *inside* a handler, and the distinction is the whole
+  reason `:event_routing` and `:app_code` are separate owners. An event that
+  reached the screen and matched nothing is a routing problem — a tag that no
+  longer exists, a renamed event — and sending someone to read the handler body
+  wastes their time. `use Mob.Screen` supplies no catch-all, so this arrives as
+  a `FunctionClauseError` naming the function it failed to match.
+  """
+  @spec unmatched_event?(term(), module()) :: boolean()
+  def unmatched_event?({:error, %Mob.Screen.UnhandledEventError{}}, _screen), do: true
+
+  def unmatched_event?({:error, %FunctionClauseError{} = e}, screen) do
+    e.module == screen and e.function == :handle_event and e.arity == 3
+  end
+
+  def unmatched_event?(_error, _screen), do: false
+
+  # Exceptions whose message is built from framework-controlled values only.
+  # Everything else is assumed to embed application state, because most standard
+  # exceptions do — and not only in a struct field: `KeyError`'s *message* is
+  # "key :x not found in: %{...}", so truncating the rendered message does not
+  # help. Default-deny is the only posture consistent with the sink policy in
+  # `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`, which
+  # excludes assigns by default and allows `redaction: "none"` only for a report
+  # that provably contains no application state.
+  @safe_message_exceptions [Mob.Screen.UnhandledEventError]
+
+  @doc """
+  Reduce a raised exception to a summary that cannot carry application state.
+
+  Keeps the kind, the exception module, and the top stack frame — enough to
+  route a defect ("a `KeyError` in `MyScreen.handle_event/3`") without carrying
+  a single value out of the socket.
+
+  The **message is dropped** unless the exception is one whose message the
+  framework builds itself. This is deliberate and costs real diagnostic detail:
+  a `RuntimeError`'s message is usually the most useful line in the report. But
+  app code writes `raise "failed for \#{inspect(user)}"` as a matter of routine,
+  and a receipt is written to ETS and handed to telemetry — a sink. Carrying it
+  would re-create MOB-147's `SecureField` leak in the mitigation named after it.
+  """
+  @spec summarize_error(:error | :exit | :throw, term(), Exception.stacktrace()) ::
+          error_summary()
+  def summarize_error(kind, reason, stacktrace) do
+    exception = if is_exception(reason), do: reason.__struct__
+
+    %{
+      kind: kind,
+      exception: exception,
+      message: safe_message(exception, reason),
+      at: top_mfa(stacktrace),
+      redaction: :applied
+    }
+  end
+
+  defp safe_message(exception, reason) when exception in @safe_message_exceptions,
+    do: reason |> Exception.message() |> String.slice(0, 512)
+
+  defp safe_message(_exception, _reason), do: nil
+
+  defp top_mfa([{m, f, a, _loc} | _]) when is_integer(a), do: {m, f, a}
+  defp top_mfa([{m, f, a, _loc} | _]) when is_list(a), do: {m, f, length(a)}
+  defp top_mfa(_), do: nil
+
+  @doc """
+  The layer answerable for this action producing no visible change.
+
+  `:none` when the action committed a changed frame — nothing to answer for.
+
+  A raise is attributed to `:app_code` — a crash in a callback is the
+  application's, and the stage list would otherwise blame whichever layer
+  happened to come next — unless it is the "no clause matched" raise, which is
+  routing.
+  """
+  @spec owner(t()) :: owner()
+  def owner(%__MODULE__{error: error, stages: stages}) when not is_nil(error) do
+    if :unhandled in stages, do: :event_routing, else: :app_code
+  end
+
+  def owner(%__MODULE__{stages: stages}) do
+    cond do
+      # A handler that navigated did the most visible thing an action can do.
+      # The destination screen paints; this one deliberately does not.
+      :navigated in stages -> :none
+      :frame_changed in stages and :committed in stages -> :none
+      :frame_changed in stages -> :renderer
+      :assigns_changed in stages -> :render_function
+      :handled in stages -> :app_code
+      true -> :event_routing
+    end
+  end
+
+  @doc """
+  The verdict an agent asked "did my action do anything" wants.
+
+  * `:verified` — a changed frame was committed.
+  * `:navigated` — the handler asked for a navigation. The most visible thing an
+    action can do, and it is reported separately because this screen
+    deliberately does not paint: the owner applies the action and the
+    destination paints. Reporting it from the absence of a paint would call the
+    commonest successful action in a mobile app "inert", which is the same lie
+    the process-wide counter tells, in the other direction.
+  * `:no_visible_change` — the handler ran and the frame came out identical.
+  * `:not_committed` — a new frame was built and never handed to the sender.
+  * `:inert` — the handler ran and changed nothing.
+  * `:unhandled` — no clause matched the event.
+  * `:error` — the handler raised.
+
+  `:no_visible_change` is deliberately not an error. A handler that toggles a
+  value the current screen does not render has done exactly what it was asked;
+  whether that is a bug is the caller's judgement, and a framework that decides
+  it for them produces false failures.
+  """
+  @spec effect(t()) ::
+          :verified
+          | :navigated
+          | :no_visible_change
+          | :not_committed
+          | :inert
+          | :unhandled
+          | :error
+  def effect(%__MODULE__{error: error, stages: stages}) when not is_nil(error) do
+    if :unhandled in stages, do: :unhandled, else: :error
+  end
+
+  def effect(%__MODULE__{stages: stages}) do
+    cond do
+      :navigated in stages -> :navigated
+      :frame_changed in stages and :committed in stages -> :verified
+      :frame_changed in stages -> :not_committed
+      :assigns_changed in stages -> :no_visible_change
+      :handled in stages -> :inert
+      true -> :unhandled
+    end
+  end
+
+  @doc """
+  A one-line summary for a human reading a triage log.
+  """
+  @spec describe(t()) :: String.t()
+  def describe(%__MODULE__{} = receipt) do
+    handler =
+      case receipt.handler do
+        {m, f, a} -> "#{inspect(m)}.#{f}/#{a}"
+        nil -> "(no handler)"
+      end
+
+    "#{receipt.action_id} #{inspect(receipt.event)} → #{handler} " <>
+      "= #{effect(receipt)} (owner: #{owner(receipt)}, #{receipt.elapsed_us || 0}us)"
+  end
+end

--- a/lib/mob/agent/receipt.ex
+++ b/lib/mob/agent/receipt.ex
@@ -13,10 +13,10 @@ defmodule Mob.Agent.Receipt do
   A receipt replaces the window with a correlation id. One action, one id,
   followed from dispatch through to the committed frame.
 
-  ## The five stages
+  ## The stages
 
-  An action passes through five observable stages, and the *first* one it fails
-  to reach names the layer at fault. That is the whole point of recording them
+  An action passes through the stages below, and the *first* one it fails to
+  reach names the layer at fault. That is the whole point of recording them
   separately rather than reporting a boolean:
 
   | Stage | Reached when | If it stops here |
@@ -27,7 +27,7 @@ defmodule Mob.Agent.Receipt do
   | `:assigns_changed` | the socket's assigns differ | application code — the handler ran and decided nothing |
   | `:frame_changed` | `render/1` produced a different frame | the render function — it ignores the assigns that changed |
   | `:committed` | the frame was handed to the sender | the renderer or the bridge |
-  | `:navigated` | the handler asked for a navigation | — this screen does not paint; the destination does |
+  | `:navigation_requested` | the handler asked to navigate | `:unknown` — this screen cannot see whether the router honoured it |
 
   `:frame_changed` rather than `:tree_changed` because the fingerprint covers
   `{tree, Mob.Theme.current()}` — a handler that changes only the theme produces
@@ -57,12 +57,13 @@ defmodule Mob.Agent.Receipt do
 
   @type stage ::
           :dispatched
+          | :unobservable
           | :unhandled
           | :handled
           | :assigns_changed
           | :frame_changed
           | :committed
-          | :navigated
+          | :navigation_requested
 
   @typedoc """
   A crash, reduced to what is safe to keep.
@@ -80,7 +81,8 @@ defmodule Mob.Agent.Receipt do
           at: mfa() | nil,
           redaction: :applied
         }
-  @type owner :: :event_routing | :app_code | :render_function | :renderer | :none
+  @type owner ::
+          :event_routing | :app_code | :render_function | :renderer | :unknown | :none
 
   @type t :: %__MODULE__{
           action_id: String.t(),
@@ -132,8 +134,10 @@ defmodule Mob.Agent.Receipt do
   reason `:event_routing` and `:app_code` are separate owners. An event that
   reached the screen and matched nothing is a routing problem — a tag that no
   longer exists, a renamed event — and sending someone to read the handler body
-  wastes their time. `use Mob.Screen` supplies no catch-all, so this arrives as
-  a `FunctionClauseError` naming the function it failed to match.
+  wastes their time. A screen with its own `handle_event/3` clauses overrides
+  the catch-all `use Mob.Screen` injects, so an unmatched event arrives as a
+  `FunctionClauseError`; a screen with no clauses of its own raises
+  `Mob.Screen.UnhandledEventError` from that catch-all. Both are routing.
   """
   @spec unmatched_event?(term(), module()) :: boolean()
   def unmatched_event?({:error, %Mob.Screen.UnhandledEventError{}}, _screen), do: true
@@ -208,9 +212,14 @@ defmodule Mob.Agent.Receipt do
 
   def owner(%__MODULE__{stages: stages}) do
     cond do
-      # A handler that navigated did the most visible thing an action can do.
-      # The destination screen paints; this one deliberately does not.
-      :navigated in stages -> :none
+      :unobservable in stages -> :unknown
+      # The one stage this screen cannot verify: it records that the handler
+      # ASKED to navigate, and the router decides whether the ask does anything.
+      # It routinely refuses — a pop at the root, a push to a module that fails
+      # to resolve, an unrecognised action — and repaints this screen instead.
+      # Reporting :none there would be a false "nothing to answer for" on Back,
+      # which is the same lie the process-wide counter tells.
+      :navigation_requested in stages -> :unknown
       :frame_changed in stages and :committed in stages -> :none
       :frame_changed in stages -> :renderer
       :assigns_changed in stages -> :render_function
@@ -223,16 +232,19 @@ defmodule Mob.Agent.Receipt do
   The verdict an agent asked "did my action do anything" wants.
 
   * `:verified` — a changed frame was committed.
-  * `:navigated` — the handler asked for a navigation. The most visible thing an
-    action can do, and it is reported separately because this screen
-    deliberately does not paint: the owner applies the action and the
-    destination paints. Reporting it from the absence of a paint would call the
-    commonest successful action in a mobile app "inert", which is the same lie
-    the process-wide counter tells, in the other direction.
+  * `:navigation_requested` — the handler asked to navigate. Reported separately
+    because this screen deliberately does not paint for it: the owner applies
+    the action and the destination paints, so deriving a verdict from the
+    absence of a paint would call a screen push "inert". **It is a request, not
+    an outcome** — the router may refuse it (a pop at the root, a push that
+    fails to resolve) and simply repaint this screen. The receipt says what was
+    asked; confirming what happened needs the router, which is not wired yet.
   * `:no_visible_change` — the handler ran and the frame came out identical.
   * `:not_committed` — a new frame was built and never handed to the sender.
   * `:inert` — the handler ran and changed nothing.
   * `:unhandled` — no clause matched the event.
+  * `:unobservable` — the screen is in `:no_render` mode, so no frame stage can
+    be reached and no conclusion about the view is available.
   * `:error` — the handler raised.
 
   `:no_visible_change` is deliberately not an error. A handler that toggles a
@@ -242,11 +254,12 @@ defmodule Mob.Agent.Receipt do
   """
   @spec effect(t()) ::
           :verified
-          | :navigated
+          | :navigation_requested
           | :no_visible_change
           | :not_committed
           | :inert
           | :unhandled
+          | :unobservable
           | :error
   def effect(%__MODULE__{error: error, stages: stages}) when not is_nil(error) do
     if :unhandled in stages, do: :unhandled, else: :error
@@ -254,7 +267,11 @@ defmodule Mob.Agent.Receipt do
 
   def effect(%__MODULE__{stages: stages}) do
     cond do
-      :navigated in stages -> :navigated
+      # No paint happens in :no_render mode, so no frame stage can ever be
+      # reached. Falling through to :no_visible_change would blame a render
+      # function that is not running.
+      :unobservable in stages -> :unobservable
+      :navigation_requested in stages -> :navigation_requested
       :frame_changed in stages and :committed in stages -> :verified
       :frame_changed in stages -> :not_committed
       :assigns_changed in stages -> :no_visible_change

--- a/lib/mob/agent/receipts.ex
+++ b/lib/mob/agent/receipts.ex
@@ -1,0 +1,186 @@
+defmodule Mob.Agent.Receipts do
+  @moduledoc """
+  A bounded record of recent action receipts, and the telemetry bridge.
+
+  Receipts are written on the path of every dispatched event, so this is
+  deliberately cheap: one ETS insert into a `:set`, plus a counter, plus an
+  eviction every `@keep` writes. No process is involved on the write path — a
+  GenServer here would serialise every event in the app through one mailbox,
+  which is the opposite of what a diagnostic should cost.
+
+  ## Bounded, and honest about it
+
+  The table keeps the most recent 256 receipts. An agent
+  that drives an action and reads its receipt immediately will always find it;
+  one that drives ten thousand actions and then goes looking for the first will
+  not. `count/0` reports how many are held and `dropped/0` how many were evicted,
+  so "no receipt for that id" can be distinguished from "that id never existed" —
+  a diagnostic that silently forgets is a diagnostic that lies.
+
+  ## Telemetry without a dependency
+
+  `mob` has exactly one runtime dependency. Adding `:telemetry` for this would
+  double that, on a framework whose whole premise is running on a phone, so
+  events are emitted only when the host application already has it loaded.
+  Apps with telemetry (most Phoenix-adjacent ones) get:
+
+      [:mob, :action, :stop]
+
+  with measurements `%{duration_us: ..., }` and metadata carrying the receipt.
+  Apps without it pay one `Code.ensure_loaded?/1` per action, cached by the code
+  server after the first call.
+  """
+
+  @table :mob_agent_receipts
+  @state :mob_agent_receipts_state
+  @keep 256
+
+  @doc false
+  @spec start() :: :ok
+  def start do
+    if :ets.whereis(@table) == :undefined do
+      # State BEFORE the table, and the table is the flag. The reverse order has
+      # a window in which a second process sees the table, skips
+      # initialisation, and then reads a `:persistent_term` key that does not
+      # exist yet — which raises, on the event path, inside the very `catch`
+      # clause that is trying to record a crash report. A state entry with no
+      # table is harmless; a table with no state is not.
+      :persistent_term.put(@state, %{
+        seq: :atomics.new(2, signed: false),
+        telemetry?: telemetry_available?()
+      })
+
+      :ets.new(@table, [:set, :public, :named_table, {:write_concurrency, true}])
+    end
+
+    :ok
+  rescue
+    # Two processes racing to create the same named table: whichever lost is
+    # looking at a table the winner already made, which is the desired state.
+    ArgumentError -> :ok
+  end
+
+  # Resolved once, at startup, and never again. `Code.ensure_loaded?/1` for an
+  # ABSENT module is not cached: it is a `gen_server` call into `:code_server`
+  # plus a scan of the code path, measured here at ~12us against ~0.04us for a
+  # loaded module. `mob` has no `:telemetry` dependency, so absent is the
+  # default case — calling it per action would put every event in every app
+  # through one global mailbox, which is exactly what this module's docs claim
+  # it avoids.
+  defp telemetry_available? do
+    mod = emitter()
+    Code.ensure_loaded?(mod) and function_exported?(mod, :execute, 3)
+  end
+
+  # Configurable so the emission path is testable. `mob` has no `:telemetry`
+  # dependency, so with the real module the `emit/2` body can never execute
+  # under `mix test` — an advertised event shape that nothing verifies.
+  defp emitter, do: Application.get_env(:mob, :telemetry_module, :telemetry)
+
+  @doc """
+  Record `receipt`, evicting the oldest when the table is full.
+
+  Returns the receipt, so this can sit at the end of a pipeline.
+  """
+  @spec record(Mob.Agent.Receipt.t()) :: Mob.Agent.Receipt.t()
+  def record(%Mob.Agent.Receipt{} = receipt) do
+    start()
+    state = state()
+    # `:atomics.add_get/3` in one step. `:counters.get` followed by
+    # `:counters.add` is not atomic, so two screens dispatching concurrently
+    # could be issued the same sequence number — which breaks `recent/1`'s
+    # ordering and lets eviction delete the wrong row.
+    seq = :atomics.add_get(state.seq, 1, 1)
+    :ets.insert(@table, {receipt.action_id, seq, receipt})
+    evict_beyond_keep(state, seq)
+    emit(state, receipt)
+    receipt
+  end
+
+  @doc "The receipt for `action_id`, or `:error` if it is not held."
+  @spec fetch(String.t()) :: {:ok, Mob.Agent.Receipt.t()} | :error
+  def fetch(action_id) do
+    start()
+
+    case :ets.lookup(@table, action_id) do
+      [{^action_id, _seq, receipt}] -> {:ok, receipt}
+      [] -> :error
+    end
+  end
+
+  @doc "The most recent receipts, newest first."
+  @spec recent(pos_integer()) :: [Mob.Agent.Receipt.t()]
+  def recent(limit \\ 20) do
+    start()
+
+    @table
+    |> :ets.tab2list()
+    |> Enum.sort_by(fn {_id, seq, _r} -> -seq end)
+    |> Enum.take(limit)
+    |> Enum.map(fn {_id, _seq, receipt} -> receipt end)
+  end
+
+  @doc "How many receipts are currently held."
+  @spec count() :: non_neg_integer()
+  def count do
+    start()
+    :ets.info(@table, :size)
+  end
+
+  @doc """
+  How many receipts have been evicted since the table was created.
+
+  Non-zero means `fetch/1` returning `:error` is ambiguous for old ids.
+  """
+  @spec dropped() :: non_neg_integer()
+  def dropped do
+    start()
+    :atomics.get(state().seq, 2)
+  end
+
+  @doc false
+  @spec reset() :: :ok
+  def reset do
+    start()
+    :ets.delete_all_objects(@table)
+    state = state()
+    :atomics.put(state.seq, 1, 0)
+    :atomics.put(state.seq, 2, 0)
+    :ok
+  end
+
+  defp state, do: :persistent_term.get(@state)
+
+  defp evict_beyond_keep(state, seq) do
+    if :ets.info(@table, :size) > @keep do
+      # `seq - @keep + 1`: the row at exactly `seq - @keep` is the @keep'th
+      # newest and must survive. Without the +1 the table settles at @keep + 1.
+      cutoff = seq - @keep + 1
+      removed = :ets.select_delete(@table, [{{:_, :"$1", :_}, [{:<, :"$1", cutoff}], [true]}])
+      :atomics.add(state.seq, 2, removed)
+    end
+  end
+
+  # `:telemetry` is not a dependency of mob — see the moduledoc. Emitting only
+  # when the host app has it keeps mob's runtime dependency count at one.
+  # Resolved at startup, not per call — see `telemetry_available?/0`.
+  defp emit(%{telemetry?: false}, _receipt), do: :ok
+
+  defp emit(%{telemetry?: true}, receipt) do
+    emitter().execute(
+      [:mob, :action, :stop],
+      %{duration_us: receipt.elapsed_us || 0},
+      %{
+        action_id: receipt.action_id,
+        screen: receipt.screen,
+        handler: receipt.handler,
+        event: receipt.event,
+        effect: Mob.Agent.Receipt.effect(receipt),
+        owner: Mob.Agent.Receipt.owner(receipt),
+        receipt: receipt
+      }
+    )
+
+    :ok
+  end
+end

--- a/lib/mob/agent/receipts.ex
+++ b/lib/mob/agent/receipts.ex
@@ -38,44 +38,9 @@ defmodule Mob.Agent.Receipts do
   @doc false
   @spec start() :: :ok
   def start do
-    if :ets.whereis(@table) == :undefined do
-      # State BEFORE the table, and the table is the flag. The reverse order has
-      # a window in which a second process sees the table, skips
-      # initialisation, and then reads a `:persistent_term` key that does not
-      # exist yet — which raises, on the event path, inside the very `catch`
-      # clause that is trying to record a crash report. A state entry with no
-      # table is harmless; a table with no state is not.
-      :persistent_term.put(@state, %{
-        seq: :atomics.new(2, signed: false),
-        telemetry?: telemetry_available?()
-      })
-
-      :ets.new(@table, [:set, :public, :named_table, {:write_concurrency, true}])
-    end
-
+    if :ets.whereis(@table) == :undefined, do: Mob.Agent.Receipts.Owner.start()
     :ok
-  rescue
-    # Two processes racing to create the same named table: whichever lost is
-    # looking at a table the winner already made, which is the desired state.
-    ArgumentError -> :ok
   end
-
-  # Resolved once, at startup, and never again. `Code.ensure_loaded?/1` for an
-  # ABSENT module is not cached: it is a `gen_server` call into `:code_server`
-  # plus a scan of the code path, measured here at ~12us against ~0.04us for a
-  # loaded module. `mob` has no `:telemetry` dependency, so absent is the
-  # default case — calling it per action would put every event in every app
-  # through one global mailbox, which is exactly what this module's docs claim
-  # it avoids.
-  defp telemetry_available? do
-    mod = emitter()
-    Code.ensure_loaded?(mod) and function_exported?(mod, :execute, 3)
-  end
-
-  # Configurable so the emission path is testable. `mob` has no `:telemetry`
-  # dependency, so with the real module the `emit/2` body can never execute
-  # under `mix test` — an advertised event shape that nothing verifies.
-  defp emitter, do: Application.get_env(:mob, :telemetry_module, :telemetry)
 
   @doc """
   Record `receipt`, evicting the oldest when the table is full.
@@ -141,7 +106,7 @@ defmodule Mob.Agent.Receipts do
   @doc false
   @spec reset() :: :ok
   def reset do
-    start()
+    Mob.Agent.Receipts.Owner.reload()
     :ets.delete_all_objects(@table)
     state = state()
     :atomics.put(state.seq, 1, 0)
@@ -167,7 +132,11 @@ defmodule Mob.Agent.Receipts do
   defp emit(%{telemetry?: false}, _receipt), do: :ok
 
   defp emit(%{telemetry?: true}, receipt) do
-    emitter().execute(
+    # Same lookup the owner used to resolve `telemetry?`, so a test that swaps
+    # the module and restarts the owner gets a consistent pair.
+    emitter = Application.get_env(:mob, :telemetry_module, :telemetry)
+
+    emitter.execute(
       [:mob, :action, :stop],
       %{duration_us: receipt.elapsed_us || 0},
       %{

--- a/lib/mob/agent/receipts.ex
+++ b/lib/mob/agent/receipts.ex
@@ -3,10 +3,12 @@ defmodule Mob.Agent.Receipts do
   A bounded record of recent action receipts, and the telemetry bridge.
 
   Receipts are written on the path of every dispatched event, so this is
-  deliberately cheap: one ETS insert into a `:set`, plus a counter, plus an
-  eviction every `@keep` writes. No process is involved on the write path — a
-  GenServer here would serialise every event in the app through one mailbox,
-  which is the opposite of what a diagnostic should cost.
+  deliberately cheap: one ETS insert into a `:set`, one `:atomics.add_get/3`,
+  and an eviction check. **No process is involved on the write path** — a
+  GenServer in front of the table would serialise every event in the app
+  through one mailbox, which is the opposite of what a diagnostic should cost.
+  `Mob.Agent.Receipts.Owner` exists only to own the table so it outlives the
+  screens that write to it; nothing routes through it.
 
   ## Bounded, and honest about it
 
@@ -27,8 +29,11 @@ defmodule Mob.Agent.Receipts do
       [:mob, :action, :stop]
 
   with measurements `%{duration_us: ..., }` and metadata carrying the receipt.
-  Apps without it pay one `Code.ensure_loaded?/1` per action, cached by the code
-  server after the first call.
+  The check runs once, in `Mob.Agent.Receipts.Owner`, and the result is read
+  from `:persistent_term` thereafter. Doing it per action would be far worse
+  than it looks: a *negative* `Code.ensure_loaded?/1` is not cached, so every
+  event in every app would make a `gen_server` call into `:code_server` and scan
+  the code path.
   """
 
   @table :mob_agent_receipts

--- a/lib/mob/agent/receipts/owner.ex
+++ b/lib/mob/agent/receipts/owner.ex
@@ -1,0 +1,92 @@
+defmodule Mob.Agent.Receipts.Owner do
+  @moduledoc """
+  Owns the receipts ETS table, and does nothing else.
+
+  An ETS table dies with the process that created it. The first version created
+  it lazily from `record/1`, which runs inside `Mob.Screen.Server.handle_call` —
+  so the owner was whichever screen happened to dispatch the first event of the
+  app's life, and every held receipt was destroyed when that screen was popped.
+  Not at 256, at zero, with `dropped/0` still reporting 0 — exactly the
+  "no receipt for that id" ambiguity `Mob.Agent.Receipts` says it eliminates.
+
+  Worse in the case that matters most: if the screen owning the table is the one
+  whose handler raises, the crash receipt written on the way out is destroyed
+  microseconds later by the same crash.
+
+  Started with `GenServer.start/3` rather than `start_link/3`, and never linked:
+  a diagnostic must not take a screen down with it, and must not die when one
+  dies. `mob` has no supervision tree of its own — it is a library inside
+  someone else's app — so `Mob.Agent.Receipts.start/0` starts this on demand and
+  tolerates `{:error, {:already_started, _}}`, the same shape
+  `Mob.Test.ProcessHelpers.ensure_component_registry/0` uses for the same reason.
+  """
+
+  use GenServer
+
+  @table :mob_agent_receipts
+  @state :mob_agent_receipts_state
+
+  @doc false
+  @spec start() :: {:ok, pid()}
+  def start do
+    case GenServer.start(__MODULE__, [], name: __MODULE__) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+    end
+  end
+
+  @doc """
+  Re-run initialisation: re-resolve the telemetry module and recreate the table
+  if it is missing.
+
+  For tests that change `:telemetry_module`, and as self-healing if anything
+  deletes the table out from under the owner. Not on any hot path.
+  """
+  @spec reload() :: :ok
+  def reload do
+    {:ok, pid} = start()
+    GenServer.call(pid, :reload)
+  end
+
+  @impl GenServer
+  def handle_call(:reload, _from, state) do
+    setup()
+    {:reply, :ok, state}
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    setup()
+    {:ok, %{}}
+  end
+
+  defp setup do
+    # State before the table, and the table is the flag: the reverse order
+    # leaves a window in which another process sees the table, skips
+    # initialisation, and reads a `:persistent_term` key that does not exist —
+    # which raises on the event path, inside the very `catch` clause recording a
+    # crash. A state entry with no table is harmless; a table with no state is
+    # not.
+    :persistent_term.put(@state, %{
+      seq: :atomics.new(2, signed: false),
+      telemetry?: telemetry_available?()
+    })
+
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:set, :public, :named_table, {:write_concurrency, true}])
+    end
+
+    :ok
+  end
+
+  # Resolved once, here, and never again. `Code.ensure_loaded?/1` for an ABSENT
+  # module is not cached: it is a `gen_server` call into `:code_server` plus a
+  # scan of the code path, measured at ~6-12us against ~0.03us for a loaded one.
+  # `mob` has no `:telemetry` dependency, so absent is the default case, and
+  # calling it per action would put every event in every app through one global
+  # mailbox — which is what `Mob.Agent.Receipts` documents itself as avoiding.
+  defp telemetry_available? do
+    mod = Application.get_env(:mob, :telemetry_module, :telemetry)
+    Code.ensure_loaded?(mod) and function_exported?(mod, :execute, 3)
+  end
+end

--- a/lib/mob/screen.ex
+++ b/lib/mob/screen.ex
@@ -124,8 +124,7 @@ defmodule Mob.Screen do
       def terminate(_reason, _socket), do: :ok
 
       def handle_event(event, _params, _socket) do
-        raise "unhandled event #{inspect(event)} in #{inspect(__MODULE__)}. " <>
-                "Add a handle_event/3 clause to handle it."
+        raise Mob.Screen.UnhandledEventError, event: event, screen: __MODULE__
       end
 
       @before_compile Mob.Screen

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -187,9 +187,53 @@ defmodule Mob.Screen.Server do
 
   @impl GenServer
   def handle_call({:event, event, params}, _from, state) do
-    case state.module.handle_event(event, params, state.socket) do
-      {:noreply, socket} -> reply_after_callback(socket, state)
-      {:reply, _payload, socket} -> reply_after_callback(socket, state)
+    # MOB-155. The receipt is assembled around the callback rather than inside
+    # it, so the stages are observed rather than reported: a handler cannot
+    # claim it changed something it did not.
+    started = System.monotonic_time(:microsecond)
+    # The term itself, not a hash of it. `!==` answers "did assigns change"
+    # exactly, and short-circuits: 0.01us against 43us for a deep phash2 over a
+    # 1000-row list screen's assigns, twice per event. The hash was answering a
+    # boolean question the expensive way, on the path of every event in the app.
+    before_assigns = state.socket.assigns
+    before_tree = Map.get(state.socket.__mob__, :last_frame)
+
+    receipt = %Mob.Agent.Receipt{
+      action_id: Mob.Agent.Receipt.new_action_id(),
+      screen: state.module,
+      event: event,
+      stages: [:dispatched],
+      before_frame_fingerprint: before_tree,
+      monotonic_us: started
+    }
+
+    try do
+      state.module.handle_event(event, params, state.socket)
+    catch
+      kind, reason ->
+        # `catch` hands back the raw Erlang reason — `:function_clause`, not a
+        # `%FunctionClauseError{}` — and the raw atom cannot say *which*
+        # function failed to match. Normalising recovers the module, function
+        # and arity, which is what separates "no clause for this event" from
+        # "the handler crashed".
+        # `catch` hands back the raw Erlang reason, and the raw atom cannot say
+        # *which* function failed to match, so normalise first — for `:error`
+        # only; `Exception.normalize/3` returns `:throw` and `:exit` reasons
+        # unchanged, which is fine because neither can be an unmatched event.
+        normalized = Exception.normalize(kind, reason, __STACKTRACE__)
+
+        record_receipt(receipt, state, before_assigns, before_tree, started,
+          error: {kind, normalized},
+          stacktrace: __STACKTRACE__
+        )
+
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    else
+      {:noreply, socket} ->
+        finish_event(socket, state, receipt, before_assigns, before_tree, started)
+
+      {:reply, _payload, socket} ->
+        finish_event(socket, state, receipt, before_assigns, before_tree, started)
     end
   end
 
@@ -211,6 +255,81 @@ defmodule Mob.Screen.Server do
   def handle_call({:render_sync, transition, activation_token}, _from, state) do
     {:reply, :ok, %{state | socket: paint(state, transition, :sync, activation_token)}}
   end
+
+  defp finish_event(socket, state, receipt, before_assigns, before_tree, started) do
+    # Read before `reply_after_callback/2` clears it. A handler that navigated
+    # is the reason this screen does not paint, so without this the receipt
+    # infers "nothing happened" from an absence the framework created on
+    # purpose — and calls a screen push `:inert`.
+    navigated? = not is_nil(socket.__mob__.nav_action)
+
+    {:reply, reply, new_state} = reply_after_callback(socket, state)
+
+    record_receipt(receipt, new_state, before_assigns, before_tree, started,
+      navigated: navigated?
+    )
+
+    {:reply, reply, new_state}
+  end
+
+  # Stages are derived from what actually changed, not from what ran. `handled`
+  # is the only one the callback itself proves; every later stage is a
+  # comparison the screen makes for itself.
+  #
+  # Wrapped: this runs after a successful event, and a diagnostic that can crash
+  # the screen it is observing is worse than no diagnostic. In the `catch`
+  # clause it would be worse still — it would replace the handler's exception
+  # with its own and destroy the report the feature exists to produce.
+  defp record_receipt(receipt, state, before_assigns, before_tree, started, opts) do
+    build_receipt(receipt, state, before_assigns, before_tree, started, opts)
+    |> Mob.Agent.Receipts.record()
+  rescue
+    _ -> receipt
+  catch
+    _, _ -> receipt
+  end
+
+  defp build_receipt(receipt, state, before_assigns, before_tree, started, opts) do
+    error = Keyword.get(opts, :error)
+    navigated? = Keyword.get(opts, :navigated, false)
+    observable? = state.render_mode == :render
+    after_assigns = state.socket.assigns
+    after_frame = Map.get(state.socket.__mob__, :last_frame)
+
+    unmatched? = Mob.Agent.Receipt.unmatched_event?(error, state.module)
+
+    stages =
+      [:dispatched]
+      |> add_if(unmatched?, :unhandled)
+      |> add_if(is_nil(error), :handled)
+      |> add_if(is_nil(error) and after_assigns !== before_assigns, :assigns_changed)
+      |> add_if(is_nil(error) and navigated?, :navigated)
+      # A frame is only observable in :render mode — `do_paint/5`'s :no_render
+      # clause never touches :last_frame, so comparing it there would report
+      # "the render function ignored your assigns" for every action.
+      |> add_if(is_nil(error) and observable? and after_frame != before_tree, :frame_changed)
+      # Every event paint runs with skippable: false, so a paint that happened
+      # always handed a frame over. `navigated?` is exactly the case where no
+      # paint happened.
+      |> add_if(is_nil(error) and observable? and not navigated?, :committed)
+
+    %{
+      receipt
+      | stages: stages,
+        handler: {state.module, :handle_event, 3},
+        after_frame_fingerprint: after_frame,
+        error: summarize(error, Keyword.get(opts, :stacktrace, [])),
+        elapsed_us: System.monotonic_time(:microsecond) - started
+    }
+  end
+
+  defp add_if(list, true, stage), do: list ++ [stage]
+  defp add_if(list, false, _stage), do: list
+
+  defp summarize(nil, _stacktrace), do: nil
+
+  defp summarize({kind, reason}, stacktrace),
+    do: Mob.Agent.Receipt.summarize_error(kind, reason, stacktrace)
 
   @impl GenServer
   def handle_cast({:render, transition}, state) do

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -257,6 +257,12 @@ defmodule Mob.Screen.Server do
   end
 
   defp finish_event(socket, state, receipt, before_assigns, before_tree, started) do
+    # The handler's own assigns, captured before the paint. `do_paint/5` runs
+    # `ensure_safe_area/3`, which writes `:safe_area` the first time insets
+    # resolve and on rotation — reading assigns afterwards reported
+    # `:assigns_changed` for an inert handler and blamed `render/1` for a
+    # framework-written assign.
+    handler_assigns = socket.assigns
     # Read before `reply_after_callback/2` clears it. A handler that navigated
     # is the reason this screen does not paint, so without this the receipt
     # infers "nothing happened" from an absence the framework created on
@@ -270,7 +276,8 @@ defmodule Mob.Screen.Server do
     {:reply, reply, new_state} = reply_after_callback(socket, state)
 
     record_receipt(receipt, new_state, before_assigns, before_tree, started,
-      navigated: navigated?
+      navigated: navigated?,
+      after_assigns: handler_assigns
     )
 
     {:reply, reply, new_state}
@@ -297,7 +304,7 @@ defmodule Mob.Screen.Server do
     error = Keyword.get(opts, :error)
     navigated? = Keyword.get(opts, :navigated, false)
     observable? = state.render_mode == :render
-    after_assigns = state.socket.assigns
+    after_assigns = Keyword.get(opts, :after_assigns, state.socket.assigns)
     after_frame = Map.get(state.socket.__mob__, :last_frame)
 
     unmatched? = Mob.Agent.Receipt.unmatched_event?(error, state.module)
@@ -321,7 +328,7 @@ defmodule Mob.Screen.Server do
     %{
       receipt
       | stages: stages,
-        handler: {state.module, :handle_event, 3},
+        handler: if(unmatched?, do: nil, else: {state.module, :handle_event, 3}),
         after_frame_fingerprint: after_frame,
         error: summarize(error, Keyword.get(opts, :stacktrace, [])),
         elapsed_us: System.monotonic_time(:microsecond) - started

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -261,6 +261,10 @@ defmodule Mob.Screen.Server do
     # is the reason this screen does not paint, so without this the receipt
     # infers "nothing happened" from an absence the framework created on
     # purpose — and calls a screen push `:inert`.
+    #
+    # This records the *request*. Whether the router honours it is not
+    # observable from here, which is why the stage and its verdict are named
+    # for the ask rather than the outcome.
     navigated? = not is_nil(socket.__mob__.nav_action)
 
     {:reply, reply, new_state} = reply_after_callback(socket, state)
@@ -301,9 +305,10 @@ defmodule Mob.Screen.Server do
     stages =
       [:dispatched]
       |> add_if(unmatched?, :unhandled)
+      |> add_if(is_nil(error) and not observable?, :unobservable)
       |> add_if(is_nil(error), :handled)
       |> add_if(is_nil(error) and after_assigns !== before_assigns, :assigns_changed)
-      |> add_if(is_nil(error) and navigated?, :navigated)
+      |> add_if(is_nil(error) and navigated?, :navigation_requested)
       # A frame is only observable in :render mode — `do_paint/5`'s :no_render
       # clause never touches :last_frame, so comparing it there would report
       # "the render function ignored your assigns" for every action.

--- a/lib/mob/screen/unhandled_event_error.ex
+++ b/lib/mob/screen/unhandled_event_error.ex
@@ -1,0 +1,20 @@
+defmodule Mob.Screen.UnhandledEventError do
+  @moduledoc """
+  Raised by the `handle_event/3` `use Mob.Screen` injects when a screen defines
+  no clause for an event.
+
+  A distinct exception rather than a `RuntimeError` with a recognisable message,
+  because `Mob.Agent.Receipt` has to tell "this event matched nothing" apart
+  from "the handler crashed" in order to attribute the first to event routing
+  and the second to application code. Matching on message text would break the
+  moment the wording changed.
+  """
+
+  defexception [:event, :screen]
+
+  @impl Exception
+  def message(%__MODULE__{event: event, screen: screen}) do
+    "unhandled event #{inspect(event)} in #{inspect(screen)}. " <>
+      "Add a handle_event/3 clause to handle it."
+  end
+end

--- a/test/mob/agent/receipt_test.exs
+++ b/test/mob/agent/receipt_test.exs
@@ -66,9 +66,9 @@ defmodule Mob.Agent.ReceiptTest do
       # The commonest successful action in a mobile app. This screen does not
       # paint for it — the destination does — so deriving the verdict from the
       # absence of a paint reports a screen push as "the handler did nothing".
-      nav = [:dispatched, :handled, :assigns_changed, :navigated]
-      assert Receipt.effect(receipt(nav)) == :navigated
-      assert Receipt.owner(receipt(nav)) == :none
+      nav = [:dispatched, :handled, :assigns_changed, :navigation_requested]
+      assert Receipt.effect(receipt(nav)) == :navigation_requested
+      assert Receipt.owner(receipt(nav)) == :unknown
     end
 
     test "a frame built but never handed over is not_committed" do

--- a/test/mob/agent/receipt_test.exs
+++ b/test/mob/agent/receipt_test.exs
@@ -1,0 +1,133 @@
+defmodule Mob.Agent.ReceiptTest do
+  use ExUnit.Case, async: true
+
+  alias Mob.Agent.Receipt
+
+  defp receipt(stages, opts \\ []) do
+    %Receipt{
+      action_id: "a1",
+      stages: stages,
+      error: Keyword.get(opts, :error)
+    }
+  end
+
+  describe "owner/1 — which layer is answerable" do
+    # The table in the moduledoc is the contract. Each row is a distinct place
+    # to look, and getting the mapping wrong sends someone to the wrong file.
+
+    test "no handler ran — the event never reached a clause" do
+      assert Receipt.owner(receipt([:dispatched])) == :event_routing
+    end
+
+    test "handler ran and changed nothing — the application decided not to" do
+      assert Receipt.owner(receipt([:dispatched, :handled])) == :app_code
+    end
+
+    test "assigns changed but the frame did not — render/1 ignores them" do
+      assert Receipt.owner(receipt([:dispatched, :handled, :assigns_changed])) ==
+               :render_function
+    end
+
+    test "a frame was built and never handed over — the renderer or the bridge" do
+      assert Receipt.owner(receipt([:dispatched, :handled, :assigns_changed, :frame_changed])) ==
+               :renderer
+    end
+
+    test "a committed changed frame has no owner to answer for it" do
+      full = [:dispatched, :handled, :assigns_changed, :frame_changed, :committed]
+      assert Receipt.owner(receipt(full)) == :none
+    end
+
+    test "an unchanged frame that was committed still blames the render function" do
+      # A paint happened and handed a frame over, but it was the same frame.
+      # `:committed` alone must not read as success, or every no-op repaint
+      # would report as a verified effect.
+      committed_same = [:dispatched, :handled, :assigns_changed, :committed]
+      assert Receipt.owner(receipt(committed_same)) == :render_function
+      assert Receipt.effect(receipt(committed_same)) == :no_visible_change
+    end
+
+    test "a raised handler is the application's, however far the action got" do
+      # Without this clause the stage list would blame whatever layer came next,
+      # which is how a crash in app code gets filed against the framework.
+      full = [:dispatched, :handled, :assigns_changed, :frame_changed, :committed]
+      assert Receipt.owner(receipt(full, error: {:error, %RuntimeError{}})) == :app_code
+      assert Receipt.owner(receipt([:dispatched], error: {:error, %RuntimeError{}})) == :app_code
+    end
+  end
+
+  describe "effect/1 — the verdict an agent asked for" do
+    test "a changed frame that was committed is verified" do
+      full = [:dispatched, :handled, :assigns_changed, :frame_changed, :committed]
+      assert Receipt.effect(receipt(full)) == :verified
+    end
+
+    test "a navigation is its own verdict, not inert" do
+      # The commonest successful action in a mobile app. This screen does not
+      # paint for it — the destination does — so deriving the verdict from the
+      # absence of a paint reports a screen push as "the handler did nothing".
+      nav = [:dispatched, :handled, :assigns_changed, :navigated]
+      assert Receipt.effect(receipt(nav)) == :navigated
+      assert Receipt.owner(receipt(nav)) == :none
+    end
+
+    test "a frame built but never handed over is not_committed" do
+      built = [:dispatched, :handled, :assigns_changed, :frame_changed]
+      assert Receipt.effect(receipt(built)) == :not_committed
+    end
+
+    test "assigns changed but no new tree is not an error" do
+      # A handler that updates state this screen does not render has done what
+      # it was asked. Calling that a failure produces false alarms.
+      assert Receipt.effect(receipt([:dispatched, :handled, :assigns_changed])) ==
+               :no_visible_change
+    end
+
+    test "handler ran and changed nothing is inert" do
+      assert Receipt.effect(receipt([:dispatched, :handled])) == :inert
+    end
+
+    test "no handler is unhandled, not inert" do
+      # The distinction is the whole point: :inert means the app chose to do
+      # nothing, :unhandled means the event never arrived anywhere.
+      assert Receipt.effect(receipt([:dispatched])) == :unhandled
+    end
+
+    test "a raise is reported as an error rather than as its stages" do
+      assert Receipt.effect(receipt([:dispatched, :handled], error: {:error, :boom})) == :error
+    end
+  end
+
+  describe "new_action_id/0" do
+    test "is unique across calls" do
+      ids = for _ <- 1..1_000, do: Receipt.new_action_id()
+      assert length(Enum.uniq(ids)) == 1_000
+    end
+  end
+
+  describe "reached?/2 and describe/1" do
+    test "reached?/2 reports stage membership" do
+      r = receipt([:dispatched, :handled])
+      assert Receipt.reached?(r, :handled)
+      refute Receipt.reached?(r, :committed)
+    end
+
+    test "describe/1 names the effect and the owner in one line" do
+      line =
+        %Receipt{
+          action_id: "abc",
+          event: "increment",
+          handler: {My.Screen, :handle_event, 3},
+          stages: [:dispatched, :handled],
+          elapsed_us: 42
+        }
+        |> Receipt.describe()
+
+      assert line =~ "abc"
+      assert line =~ "increment"
+      assert line =~ "My.Screen.handle_event/3"
+      assert line =~ "inert"
+      assert line =~ "app_code"
+    end
+  end
+end

--- a/test/mob/agent/receipts_integration_test.exs
+++ b/test/mob/agent/receipts_integration_test.exs
@@ -1,0 +1,227 @@
+defmodule Mob.Agent.ReceiptsIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias Mob.Agent.{Receipt, Receipts}
+
+  # MOB-155. The point of a receipt is that it is assembled from what the screen
+  # observed, not from what a handler claimed. These drive a real screen through
+  # `Mob.Screen.dispatch/3` and read the receipt back, so a handler that lies —
+  # or a stage the framework forgets to record — shows up here.
+
+  defmodule Screen do
+    @moduledoc false
+    use Mob.Screen
+
+    def mount(_p, _s, socket),
+      do: {:ok, Mob.Socket.assign(socket, %{count: 0, hidden: 0, password: "hunter2"})}
+
+    # Changes an assign the tree renders — a visible effect.
+    def handle_event("increment", _p, socket),
+      do: {:noreply, Mob.Socket.assign(socket, :count, socket.assigns.count + 1)}
+
+    # Changes an assign render/1 never reads — the render-function case.
+    def handle_event("bump_hidden", _p, socket),
+      do: {:noreply, Mob.Socket.assign(socket, :hidden, socket.assigns.hidden + 1)}
+
+    # Runs and decides nothing — the app-code case.
+    def handle_event("noop", _p, socket), do: {:noreply, socket}
+
+    def handle_event("boom", _p, _socket), do: raise("handler exploded")
+
+    def handle_event("go", _p, socket),
+      do: {:noreply, Mob.Socket.push_screen(socket, Mob.Agent.ReceiptsIntegrationTest.Dest)}
+
+    # Reads a key that is not there, so the raised KeyError embeds the whole
+    # assigns map — the shape that leaked a secret before summarize_error/3.
+    def handle_event("leak", _p, socket),
+      do: {:noreply, Map.fetch!(socket.assigns, :no_such_key)}
+
+    def render(assigns),
+      do: %{type: :text, props: %{text: "count=#{assigns.count}"}, children: []}
+  end
+
+  defmodule Dest do
+    @moduledoc false
+    use Mob.Screen
+    def mount(_p, _s, socket), do: {:ok, socket}
+    def render(_a), do: %{type: :text, props: %{text: "dest"}, children: []}
+  end
+
+  # A screen with no handle_event/3 of its own, so `use Mob.Screen`'s injected
+  # catch-all survives — the real "stale tag / renamed event" shape.
+  defmodule NoHandlers do
+    @moduledoc false
+    use Mob.Screen
+    def mount(_p, _s, socket), do: {:ok, socket}
+    def render(_a), do: %{type: :text, props: %{text: "x"}, children: []}
+  end
+
+  defmodule Nif do
+    @moduledoc false
+    def safe_area, do: {0.0, 0.0, 0.0, 0.0}
+    def platform, do: :ios
+    def take_launch_notification, do: :none
+    def unquote(:"$handle_undefined_function")(_f, _a), do: :ok
+  end
+
+  setup do
+    Receipts.reset()
+    {:ok, pid} = Mob.Router.start_root(Screen, %{}, nif: Nif)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
+    %{pid: pid}
+  end
+
+  defp dispatch_and_fetch(pid, event) do
+    Mob.Screen.dispatch(pid, event, %{})
+    [receipt] = Receipts.recent(1)
+    receipt
+  end
+
+  test "an event that changes what is rendered is verified", %{pid: pid} do
+    receipt = dispatch_and_fetch(pid, "increment")
+
+    assert Receipt.effect(receipt) == :verified
+    assert Receipt.owner(receipt) == :none
+    assert Receipt.reached?(receipt, :committed)
+
+    assert Receipt.reached?(receipt, :frame_changed),
+           "the stage the whole attribution turns on must be produced by a real dispatch"
+
+    assert receipt.before_frame_fingerprint != receipt.after_frame_fingerprint
+    assert receipt.handler == {Screen, :handle_event, 3}
+    assert receipt.event == "increment"
+    assert Receipt.reached?(receipt, :assigns_changed)
+  end
+
+  test "an assign the render function ignores is attributed to it", %{pid: pid} do
+    # This is the case a boolean cannot express and the one that saves the most
+    # time: the handler ran, the state changed, and nothing appeared on screen.
+    receipt = dispatch_and_fetch(pid, "bump_hidden")
+
+    assert Receipt.effect(receipt) == :no_visible_change
+    assert Receipt.owner(receipt) == :render_function
+    assert Receipt.reached?(receipt, :assigns_changed)
+    refute Receipt.reached?(receipt, :frame_changed)
+  end
+
+  test "a handler that changes nothing is inert, and blames the app", %{pid: pid} do
+    receipt = dispatch_and_fetch(pid, "noop")
+
+    assert Receipt.effect(receipt) == :inert
+    assert Receipt.owner(receipt) == :app_code
+    refute Receipt.reached?(receipt, :assigns_changed)
+  end
+
+  test "an unmatched event is unhandled, not inert", %{pid: pid} do
+    # `use Mob.Screen` supplies no catch-all, so an unknown event arrives as a
+    # FunctionClauseError. Lumping that in with "the handler crashed" would send
+    # someone to read a handler body that was never entered; it is a routing
+    # problem — a stale tag, a renamed event.
+    receipt = dispatch_and_fetch(pid, "no_such_event")
+
+    assert Receipt.effect(receipt) == :unhandled
+    assert Receipt.owner(receipt) == :event_routing
+    refute Receipt.reached?(receipt, :committed)
+  end
+
+  test "a raising handler is still recorded, on the way out", %{pid: pid} do
+    # The screen dies here, so the receipt has to be written before the
+    # exception propagates. Losing it would mean the crash a defect report most
+    # wants to explain is the one action with no receipt.
+    #
+    # The exit does not reach this test: Mob.Router wraps the dispatch in
+    # safe_call/1, so it absorbs the screen's crash. That is exactly why the
+    # receipt matters — from the outside, a handler that exploded and a handler
+    # that did nothing look the same.
+    Process.flag(:trap_exit, true)
+    Mob.Screen.dispatch(pid, "boom", %{})
+
+    [receipt] = Receipts.recent(1)
+
+    assert Receipt.effect(receipt) == :error
+    assert Receipt.owner(receipt) == :app_code
+    # No message: a RuntimeError's message is app-authored and routinely
+    # interpolates state. The module and the frame are enough to route it.
+    assert %{kind: :error, exception: RuntimeError, message: nil, redaction: :applied} =
+             receipt.error
+
+    assert {Screen, :handle_event, 3} = receipt.error.at
+    assert receipt.event == "boom"
+  end
+
+  test "each dispatch gets its own id, so two actions cannot be confused", %{pid: pid} do
+    # The reason receipts exist: the old effect detector waited on a
+    # process-wide counter, so a second action inside the window was
+    # indistinguishable from the first one landing.
+    Mob.Screen.dispatch(pid, "increment", %{})
+    Mob.Screen.dispatch(pid, "noop", %{})
+
+    [newest, older] = Receipts.recent(2)
+
+    assert newest.action_id != older.action_id
+    assert {newest.event, older.event} == {"noop", "increment"}
+    assert Receipt.effect(older) == :verified
+    assert Receipt.effect(newest) == :inert
+  end
+
+  test "a handler that navigates is not reported as inert", %{pid: pid} do
+    # The headline case. This screen deliberately does not paint for a
+    # navigation — the owner applies the action and the destination paints — so
+    # deriving the verdict from the absence of a paint reports a screen push,
+    # the commonest successful action in a mobile app, as "the handler did
+    # nothing". That is the same lie as the process-wide counter, inverted.
+    receipt = dispatch_and_fetch(pid, "go")
+
+    assert Receipt.effect(receipt) == :navigated
+    assert Receipt.owner(receipt) == :none
+    assert Receipt.reached?(receipt, :navigated)
+    refute Receipt.effect(receipt) == :inert
+  end
+
+  test "a screen with no handle_event clauses is routing, not a crash", %{pid: running} do
+    # The setup's router owns the global :mob_screen name; stop it first.
+    Mob.Test.ProcessHelpers.stop_pid(running)
+
+    # `use Mob.Screen` injects a catch-all that raises, so this does NOT arrive
+    # as a FunctionClauseError. Filing it as :app_code sends the reader to a
+    # handler body that was never written.
+    Receipts.reset()
+    Process.flag(:trap_exit, true)
+    {:ok, pid} = Mob.Router.start_root(NoHandlers, %{}, nif: Nif)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
+    Mob.Screen.dispatch(pid, "anything", %{})
+    [receipt] = Receipts.recent(1)
+
+    assert Receipt.effect(receipt) == :unhandled
+    assert Receipt.owner(receipt) == :event_routing
+  end
+
+  test "a crash never carries assigns into the receipt", %{pid: pid} do
+    # KeyError embeds the map it was searching, so the unsummarised exception
+    # put the entire assigns — secrets included — into ETS and into telemetry
+    # metadata. That is MOB-147's leak, re-created by the mitigation that cites
+    # it, and it reaches a sink unredacted.
+    Process.flag(:trap_exit, true)
+    Mob.Screen.dispatch(pid, "leak", %{})
+    [receipt] = Receipts.recent(1)
+
+    assert receipt.error.exception == KeyError
+
+    refute inspect(receipt) =~ "hunter2",
+           "the receipt carried a value out of assigns"
+  end
+
+  test "a receipt is retrievable by its id", %{pid: pid} do
+    receipt = dispatch_and_fetch(pid, "increment")
+
+    assert {:ok, ^receipt} = Receipts.fetch(receipt.action_id)
+    assert Receipts.fetch("never-issued") == :error
+  end
+
+  test "elapsed_us is recorded", %{pid: pid} do
+    # Not a benchmark — just that the field is populated, since a receipt whose
+    # timing is always nil is a field nobody can use.
+    receipt = dispatch_and_fetch(pid, "increment")
+    assert is_integer(receipt.elapsed_us) and receipt.elapsed_us >= 0
+  end
+end

--- a/test/mob/agent/receipts_integration_test.exs
+++ b/test/mob/agent/receipts_integration_test.exs
@@ -67,7 +67,21 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
   setup do
     Receipts.reset()
     {:ok, pid} = Mob.Router.start_root(Screen, %{}, nif: Nif)
-    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
+
+    on_exit(fn ->
+      # `start_root/3` brings up Mob.Sender and Mob.Listener under global names,
+      # and leaving the Listener behind silently changes what the renderer does
+      # in every later file: `Mob.Listener.handler/1` wraps a tap tag into
+      # `{:mob_route, ...}` only when a listener is running, so Mob.RendererTest
+      # fails asserting on the unwrapped tag it registered — naming a file that
+      # has never heard of this one.
+      Mob.Test.ProcessHelpers.stop_all([
+        pid,
+        Process.whereis(Mob.Sender),
+        Process.whereis(Mob.Listener)
+      ])
+    end)
+
     %{pid: pid}
   end
 
@@ -188,7 +202,15 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
     Receipts.reset()
     Process.flag(:trap_exit, true)
     {:ok, pid} = Mob.Router.start_root(NoHandlers, %{}, nif: Nif)
-    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
+
+    on_exit(fn ->
+      Mob.Test.ProcessHelpers.stop_all([
+        pid,
+        Process.whereis(Mob.Sender),
+        Process.whereis(Mob.Listener)
+      ])
+    end)
+
     Mob.Screen.dispatch(pid, "anything", %{})
     [receipt] = Receipts.recent(1)
 

--- a/test/mob/agent/receipts_integration_test.exs
+++ b/test/mob/agent/receipts_integration_test.exs
@@ -75,11 +75,7 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
       # `{:mob_route, ...}` only when a listener is running, so Mob.RendererTest
       # fails asserting on the unwrapped tag it registered — naming a file that
       # has never heard of this one.
-      Mob.Test.ProcessHelpers.stop_all([
-        pid,
-        Process.whereis(Mob.Sender),
-        Process.whereis(Mob.Listener)
-      ])
+      Mob.Test.ProcessHelpers.stop_root(pid)
     end)
 
     %{pid: pid}
@@ -127,7 +123,8 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
   end
 
   test "an unmatched event is unhandled, not inert", %{pid: pid} do
-    # `use Mob.Screen` supplies no catch-all, so an unknown event arrives as a
+    # This screen defines its own handle_event/3 clauses, which override the
+    # catch-all `use Mob.Screen` injects — so an unmatched event arrives as a
     # FunctionClauseError. Lumping that in with "the handler crashed" would send
     # someone to read a handler body that was never entered; it is a routing
     # problem — a stale tag, a renamed event.
@@ -186,9 +183,12 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
     # nothing". That is the same lie as the process-wide counter, inverted.
     receipt = dispatch_and_fetch(pid, "go")
 
-    assert Receipt.effect(receipt) == :navigated
-    assert Receipt.owner(receipt) == :none
-    assert Receipt.reached?(receipt, :navigated)
+    assert Receipt.effect(receipt) == :navigation_requested
+
+    # :unknown, not :none — the router may refuse the request (a pop at the
+    # root, a push that fails to resolve) and this screen cannot see that.
+    assert Receipt.owner(receipt) == :unknown
+    assert Receipt.reached?(receipt, :navigation_requested)
     refute Receipt.effect(receipt) == :inert
   end
 
@@ -204,11 +204,7 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
     {:ok, pid} = Mob.Router.start_root(NoHandlers, %{}, nif: Nif)
 
     on_exit(fn ->
-      Mob.Test.ProcessHelpers.stop_all([
-        pid,
-        Process.whereis(Mob.Sender),
-        Process.whereis(Mob.Listener)
-      ])
+      Mob.Test.ProcessHelpers.stop_root(pid)
     end)
 
     Mob.Screen.dispatch(pid, "anything", %{})
@@ -231,6 +227,23 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
 
     refute inspect(receipt) =~ "hunter2",
            "the receipt carried a value out of assigns"
+  end
+
+  test "a :no_render screen reports unobservable, not a false render_function owner" do
+    # `do_paint/5`'s :no_render clause never touches :last_frame, so no frame
+    # stage can be reached. Falling through to :no_visible_change blames a
+    # render function that is not running — and render_mode DEFAULTS to
+    # :no_render, so every screen started outside Mob.Router.start_root/3 would
+    # report it for every action.
+    {:ok, pid} = Mob.Screen.start_link(Screen, %{}, nif: Nif)
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
+
+    Mob.Screen.dispatch(pid, "increment", %{})
+    [receipt] = Receipts.recent(1)
+
+    assert Receipt.effect(receipt) == :unobservable
+    assert Receipt.owner(receipt) == :unknown
+    assert Receipt.reached?(receipt, :assigns_changed)
   end
 
   test "a receipt is retrievable by its id", %{pid: pid} do

--- a/test/mob/agent/receipts_integration_test.exs
+++ b/test/mob/agent/receipts_integration_test.exs
@@ -132,6 +132,9 @@ defmodule Mob.Agent.ReceiptsIntegrationTest do
 
     assert Receipt.effect(receipt) == :unhandled
     assert Receipt.owner(receipt) == :event_routing
+
+    # No handler is named: there is no clause to send anyone to read.
+    assert receipt.handler == nil
     refute Receipt.reached?(receipt, :committed)
   end
 

--- a/test/mob/agent/receipts_store_test.exs
+++ b/test/mob/agent/receipts_store_test.exs
@@ -58,6 +58,43 @@ defmodule Mob.Agent.ReceiptsStoreTest do
     end
   end
 
+  describe "table ownership" do
+    test "receipts survive the death of the process that recorded the first one" do
+      # An ETS table dies with its creator. Creating it lazily from `record/1`
+      # made the owner whichever screen dispatched the first event of the app's
+      # life, so an ordinary `pop` destroyed every held receipt — at zero, not
+      # at 256, with `dropped/0` still reporting 0. Worst case is the headline
+      # case: the screen whose handler raises owns the table, and the crash
+      # receipt is destroyed microseconds later by the same crash.
+      # The spawned process must be the table's *creator*, which is the real
+      # situation: whichever screen dispatches the first event of the app's
+      # life. Tear down what `setup` built so it is.
+      if pid = Process.whereis(Mob.Agent.Receipts.Owner), do: GenServer.stop(pid)
+      if :ets.whereis(:mob_agent_receipts) != :undefined, do: :ets.delete(:mob_agent_receipts)
+      :persistent_term.erase(:mob_agent_receipts_state)
+
+      parent = self()
+
+      recorder =
+        spawn(fn ->
+          Receipts.record(receipt(1))
+          send(parent, :recorded)
+
+          receive do
+            :die -> :ok
+          end
+        end)
+
+      assert_receive :recorded
+      ref = Process.monitor(recorder)
+      send(recorder, :die)
+      assert_receive {:DOWN, ^ref, :process, ^recorder, _}
+
+      assert {:ok, %Receipt{event: "tap-1"}} = Receipts.fetch("id-1"),
+             "the receipt died with the process that wrote it"
+    end
+  end
+
   describe "ordering" do
     test "recent/1 is newest first" do
       for n <- 1..5, do: Receipts.record(receipt(n))
@@ -81,9 +118,9 @@ defmodule Mob.Agent.ReceiptsStoreTest do
   describe "telemetry" do
     test "emits the advertised event, measurements and metadata" do
       Application.put_env(:mob, :telemetry_module, StubTelemetry)
-      # The flag is resolved once at start, so re-resolve it for this test.
-      :persistent_term.erase(:mob_agent_receipts_state)
-      :ets.delete(:mob_agent_receipts)
+      # The flag is resolved once by the owner, so ask it to re-resolve rather
+      # than deleting the table out from under it.
+      Mob.Agent.Receipts.Owner.reload()
 
       Receipts.record(%{receipt(7) | stages: [:dispatched, :handled]})
 
@@ -97,8 +134,7 @@ defmodule Mob.Agent.ReceiptsStoreTest do
 
     test "does not emit when no telemetry module is available" do
       Application.put_env(:mob, :telemetry_module, NotALoadedModule)
-      :persistent_term.erase(:mob_agent_receipts_state)
-      :ets.delete(:mob_agent_receipts)
+      Mob.Agent.Receipts.Owner.reload()
 
       Receipts.record(receipt(1))
 

--- a/test/mob/agent/receipts_store_test.exs
+++ b/test/mob/agent/receipts_store_test.exs
@@ -1,0 +1,108 @@
+defmodule Mob.Agent.ReceiptsStoreTest do
+  use ExUnit.Case, async: false
+
+  alias Mob.Agent.{Receipt, Receipts}
+
+  defmodule StubTelemetry do
+    @moduledoc false
+    def execute(event, measurements, metadata) do
+      send(:receipts_store_test, {:telemetry, event, measurements, metadata})
+      :ok
+    end
+  end
+
+  setup do
+    Process.register(self(), :receipts_store_test)
+    Receipts.reset()
+    on_exit(fn -> Application.delete_env(:mob, :telemetry_module) end)
+    :ok
+  end
+
+  defp receipt(n) do
+    %Receipt{
+      action_id: "id-#{n}",
+      screen: My.Screen,
+      handler: {My.Screen, :handle_event, 3},
+      event: "tap-#{n}",
+      stages: [:dispatched, :handled],
+      elapsed_us: n
+    }
+  end
+
+  describe "bounding" do
+    test "keeps exactly the documented number and reports what it dropped" do
+      # The CHANGELOG and the decision record both state the bound. An
+      # off-by-one here means the published number is wrong — the first version
+      # settled at 257 because eviction kept the boundary row.
+      for n <- 1..600, do: Receipts.record(receipt(n))
+
+      assert Receipts.count() == 256
+      assert Receipts.dropped() == 600 - 256
+    end
+
+    test "the oldest is gone and the newest is still fetchable" do
+      for n <- 1..300, do: Receipts.record(receipt(n))
+
+      assert Receipts.fetch("id-1") == :error
+      assert {:ok, %Receipt{event: "tap-300"}} = Receipts.fetch("id-300")
+    end
+
+    test "a missing id is distinguishable from a forgotten one" do
+      # `fetch/1` returning :error is ambiguous once anything has been evicted.
+      # `dropped/0` is what makes "never existed" and "no longer held"
+      # separable; a diagnostic that silently forgets is one that lies.
+      Receipts.record(receipt(1))
+
+      assert Receipts.dropped() == 0
+      assert Receipts.fetch("never-issued") == :error
+    end
+  end
+
+  describe "ordering" do
+    test "recent/1 is newest first" do
+      for n <- 1..5, do: Receipts.record(receipt(n))
+
+      assert Enum.map(Receipts.recent(3), & &1.event) == ["tap-5", "tap-4", "tap-3"]
+    end
+
+    test "concurrent writers do not share a sequence number" do
+      # `:counters.get` then `:counters.add` is not atomic; two screens
+      # dispatching at once could be issued the same seq, which breaks ordering
+      # and lets eviction delete the wrong row.
+      1..200
+      |> Task.async_stream(&Receipts.record(receipt(&1)), max_concurrency: 20)
+      |> Stream.run()
+
+      assert Receipts.count() == 200
+      assert length(Enum.uniq_by(Receipts.recent(200), & &1.action_id)) == 200
+    end
+  end
+
+  describe "telemetry" do
+    test "emits the advertised event, measurements and metadata" do
+      Application.put_env(:mob, :telemetry_module, StubTelemetry)
+      # The flag is resolved once at start, so re-resolve it for this test.
+      :persistent_term.erase(:mob_agent_receipts_state)
+      :ets.delete(:mob_agent_receipts)
+
+      Receipts.record(%{receipt(7) | stages: [:dispatched, :handled]})
+
+      assert_receive {:telemetry, [:mob, :action, :stop], measurements, metadata}
+      assert measurements.duration_us == 7
+      assert metadata.action_id == "id-7"
+      assert metadata.screen == My.Screen
+      assert metadata.effect == :inert
+      assert metadata.owner == :app_code
+    end
+
+    test "does not emit when no telemetry module is available" do
+      Application.put_env(:mob, :telemetry_module, NotALoadedModule)
+      :persistent_term.erase(:mob_agent_receipts_state)
+      :ets.delete(:mob_agent_receipts)
+
+      Receipts.record(receipt(1))
+
+      refute_receive {:telemetry, _, _, _}, 50
+    end
+  end
+end

--- a/test/mob/safe_area_unknown_test.exs
+++ b/test/mob/safe_area_unknown_test.exs
@@ -67,7 +67,12 @@ defmodule Mob.SafeAreaUnknownTest do
 
   defp start_screen do
     {:ok, pid} = Mob.Router.start_root(Screen, %{}, nif: Nif)
-    on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(pid) end)
+
+    # stop_root/2, not stop_pid/2: start_root/3 also registers Mob.Sender and
+    # Mob.Listener globally, and leaving the Listener behind makes the renderer
+    # wrap tap tags for every file that runs after this one — which failed two
+    # Mob.RendererTest assertions about 1 run in 4.
+    on_exit(fn -> Mob.Test.ProcessHelpers.stop_root(pid) end)
     pid
   end
 

--- a/test/mob/screen_test.exs
+++ b/test/mob/screen_test.exs
@@ -50,7 +50,7 @@ defmodule Mob.ScreenTest do
     test "injects default handle_event that raises" do
       socket = Mob.Socket.new(MinimalScreen)
 
-      assert_raise RuntimeError, ~r/unhandled event/, fn ->
+      assert_raise Mob.Screen.UnhandledEventError, ~r/unhandled event/, fn ->
         MinimalScreen.handle_event("unknown", %{}, socket)
       end
     end
@@ -96,7 +96,7 @@ defmodule Mob.ScreenTest do
     test "unknown event raises RuntimeError when screen has no handle_event at all" do
       socket = Mob.Socket.new(MinimalScreen)
 
-      assert_raise RuntimeError, ~r/unhandled event/, fn ->
+      assert_raise Mob.Screen.UnhandledEventError, ~r/unhandled event/, fn ->
         MinimalScreen.handle_event("unknown", %{}, socket)
       end
     end

--- a/test/support/process_helpers.ex
+++ b/test/support/process_helpers.ex
@@ -108,6 +108,26 @@ defmodule Mob.Test.ProcessHelpers do
   end
 
   @doc """
+  Stop a router started with `Mob.Router.start_root/3`, and the globals it
+  brought up with it.
+
+  `start_root/3` registers `Mob.Sender` and `Mob.Listener` under global names,
+  and leaving the Listener behind silently changes what the renderer does in
+  every file that runs afterwards: `Mob.Listener.handler/1` wraps a tap tag into
+  `{:mob_route, ...}` only when a listener is running, so `Mob.RendererTest`
+  fails asserting on the unwrapped tag it registered — naming a file that has
+  never heard of the one that leaked.
+
+  That is not hypothetical. Before this helper existed the leak was reproducible
+  on master at roughly 1 run in 4, from a single module that stopped only its
+  router pid.
+  """
+  @spec stop_root(pid(), timeout()) :: :ok
+  def stop_root(router, timeout \\ 5_000) do
+    stop_all([router, Process.whereis(Mob.Sender), Process.whereis(Mob.Listener)], timeout)
+  end
+
+  @doc """
   Stop every pid in `pids`, then raise if any of them refused.
 
   `stop_pid/2` raises on timeout, which is correct on its own and wrong in the


### PR DESCRIPTION
Closes MOB-155. Phase 1 of the MOB-149 epic — the substrate everything downstream consumes.

## The problem

An agent driving a Mob app can ask what the assigns are. It cannot ask whether **its** action caused them.

`tap_xy/3` shows why that matters. It records a process-wide UI-event counter, injects the tap, and polls for 300ms:

```objc
if (!mob_await_ui_event(seq_before, MOB_TAP_SETTLE_MS)) { return ... "no_effect"; }
```

That counter belongs to the process, not the tap. A timer, a scroll notification, or a second agent inside the window is indistinguishable from the tap landing — and it fails the other way too: on 2026-09-04 it returned `{:error, :no_effect}` for a tap that demonstrably worked. A window cannot answer a question about causation.

## What lands

Every dispatched event gets an `action_id` and a `%Mob.Agent.Receipt{}` recording which stages it reached. **The stages are observed, not reported** — only `:handled` is proved by the callback; every later stage is a before/after comparison the screen makes itself, so a handler cannot claim an effect it did not have.

The first stage not reached names the owner:

| Stops at | Owner | Reading |
|---|---|---|
| `:unhandled` | `:event_routing` | a stale tag, a renamed event |
| `:handled` | `:app_code` | the handler ran and decided nothing |
| `:assigns_changed` | `:render_function` | `render/1` ignores what changed |
| `:frame_changed` without `:committed` | `:renderer` | a frame built, never handed over |
| `:navigated` / `:committed` + `:frame_changed` | `:none` | nothing to answer for |

"The tap did nothing" is a bug report nobody can route. "The handler ran and changed `:count`, and the frame did not change" points at a `render/1` that never reads `:count`.

## The pre-commit review found five HIGH problems

I had guessed two of them; the other three I had not. Each fix has a test that fails without it (verified by reverting):

- **A navigating tap reported `:inert`.** `reply_after_callback/2` deliberately does not paint when the handler navigates — the owner applies the action and the destination paints — so deriving the verdict from the absence of a paint called a screen push, the commonest successful action in a mobile app, "the handler ran and decided nothing". The same lie as the counter, inverted.
- **The receipt leaked assigns.** It stored the normalised exception, and `KeyError`/`MatchError`/`BadMapError` embed the term that failed — so a `Map.fetch!/2` against assigns put the entire assigns map, secrets included, into ETS and telemetry metadata. That is MOB-147's `SecureField` leak re-created *inside the mitigation citing it*, reaching a sink unredacted against the policy in `2026-09-04-defect-reports-are-a-shipped-feature.md`. A crash is now `{kind, exception module, top MFA}`, message dropped unless the framework built it — truncating does not help when `KeyError`'s rendered message is itself `"key :x not found in: %{...}"`. A test plants a secret and asserts it never appears.
- **`Code.ensure_loaded?/1` per action** cost ~12µs and routed every event in every app through the `:code_server` mailbox — in a module documented as involving no process. A *negative* result is not cached. Resolved once at startup.
- **The store's init order had a crash window.** Table before `:persistent_term` state meant a second process could see the table, skip init, and read a key that did not exist — raising on the event path, and inside the `catch` clause that records crashes, destroying the very report. State first now.
- **The receipt write is wrapped.** A diagnostic that can crash what it observes is worse than none.

## Also from the review

- The assigns comparison is a **term comparison, not two deep hashes**: 0.01µs vs 43µs on a 1000-row list screen, twice per event, to answer a boolean.
- `:tree_changed` → `:frame_changed`; the fingerprint covers `{tree, theme}`, so "the tree changed" was false for a theme-only change.
- `use Mob.Screen` **does** inject a catch-all — my claim that it didn't was wrong. It now raises a typed `Mob.Screen.UnhandledEventError`, so "no clause matched" is distinguishable from "the handler crashed" without string-matching a message.
- Bounded at **256**, not the 257 three documents claimed.
- `:no_render` mode no longer reports a false `:render_function` owner for every action.
- `:atomics.add_get/3` instead of read-then-add, which two concurrent screens could race.
- Telemetry emission is testable through a configurable emitter — with the real `:telemetry` absent, that branch could never execute under `mix test`, so an advertised event shape was unverified.

## Scope, stated plainly

- **`native_commit` is `:unknown`.** Handing a frame to `Mob.Sender` is not proof the platform drew it. This says what the BEAM did; anything stronger would be the counter's overclaim in better clothes.
- **A `render/1` that raises produces no receipt** — the exception escapes the paint, outside the `try`. So the textbook `:render_function` defect is the one case with no record. Covering it means wrapping the paint, which changes what a render crash does to a screen: a bigger decision than this slice.
- Nothing consumes receipts yet; `tap_xy`'s window is still in place, and replacing it needs the native half.
- **No new dependency.** `mob` keeps its single runtime dep.

## Verification

1618 tests pass (up from 1583), `mix credo --strict` clean, `mix format --check-formatted` clean. Every one of the five HIGH fixes was reversion-checked individually.

Decision record: `decisions/2026-09-10-a-receipt-per-action-not-a-window.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)