### PR TITLE
Runtime invariant registry, confirmed across samples (MOB-156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 ### Added
 - **Runtime invariant registry — `Mob.Invariant`** (MOB-156). Checks the
   framework can make about itself, with the rule that keeps them from becoming
-  noise: **a violation is re-checked immediately and only recorded if it
-  survives**. Every check reads live state from concurrently changing processes,
-  so a screen mid-teardown looks exactly like a leak; a check that disagrees with
-  itself two evaluations apart was watching a race.
+  noise: **a violation is recorded only if the same violation is still there at
+  the next sampling of that point, and is at least 50ms old**. Every check reads
+  live state from concurrently changing processes, so a screen mid-teardown looks
+  exactly like a leak.
+
+  Re-running the check immediately instead was measured filtering none of them —
+  two evaluations a microsecond apart cannot disagree — and reported a confirmed
+  `:critical` on 60 of 60 healthy teardowns. Deferring to the next sample, with
+  an age floor, gives 0 of 60 while still catching an injected regression in the
+  reaping path it guards.
 
   `register/2` takes a sampling point (`:on_screen_stop`, `:periodic`,
   `:after_committed_frame`), a severity and a check function. A check that raises

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 ## [Unreleased]
 
 ### Added
+- **Runtime invariant registry — `Mob.Invariant`** (MOB-156). Checks the
+  framework can make about itself, with the rule that keeps them from becoming
+  noise: **a violation is re-checked immediately and only recorded if it
+  survives**. Every check reads live state from concurrently changing processes,
+  so a screen mid-teardown looks exactly like a leak; a check that disagrees with
+  itself two evaluations apart was watching a race.
+
+  `register/2` takes a sampling point (`:on_screen_stop`, `:periodic`,
+  `:after_committed_frame`), a severity and a check function. A check that raises
+  is reported rather than propagated — a diagnostic must never affect what it
+  observes.
+
+  Two built-ins ship. `orphaned_component` — a live component under a dead owning
+  screen, the leak class three of four agents in MOB-149 named independently —
+  runs at `:on_screen_stop`, which is wired. `dead_screen_in_nav` is registered
+  for `:periodic`, and **nothing drives `:periodic` yet**; it is reachable only
+  by an explicit call until the defect bus lands in MOB-159. The other eight
+  checks MOB-156 names are listed in `Builtins.unimplemented/0` with what each
+  needs, and a test asserts none is ever silently registered.
+
+  Measured through `run/2` at 1.6µs with an empty registry, 7µs at 100 live
+  components and 16µs at 100 orphaned ones, once per screen teardown rather than
+  per frame; `cost_us/2` re-measures on the device that matters. See
+  `decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md`.
+
 - **Causal receipts — `Mob.Agent.Receipt`** (MOB-155). Every dispatched event now
   gets an `action_id`, and the screen records which stages the action
   reached: dispatched, handled (or unhandled), assigns changed, navigation

--- a/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
+++ b/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
@@ -129,6 +129,22 @@ re-measures one pass of each check on the device that matters; it does not
 include the candidate bookkeeping, so the table above is the number to budget
 against.
 
+## Concurrency is not optional here
+
+`Mob.Router` `start_link`s its screens, so a router exit runs `terminate/2` — and
+this sampling point — in every live screen at once. A first implementation used
+`:ets.take/2` and re-inserted a candidate that was not yet old enough, which
+looks atomic and is not: with three samplers in flight one takes the row, a
+second sees absence and inserts a fresh timestamp, a third takes *that* and
+writes it back, so the candidate's age keeps resetting. Measured through
+`run/2` against a permanently-present violation: 1 sampler 39 confirmations,
+2 samplers 34, **4 samplers zero**. A silent total failure, under exactly the
+condition the code's own comment claimed to handle.
+
+Claiming a candidate is now a compare-and-delete on the exact
+`{key, first_seen}` pair, and nothing ever writes a `first_seen` back. Only one
+sampler can remove a given row, and the clock only ever moves forward.
+
 ## Consequences
 
 - `:on_screen_stop` samples while the stopping screen is **still alive** — it is

--- a/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
+++ b/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
@@ -75,16 +75,35 @@ and stops when the screen dies, so after an ordinary teardown there is no live
 component under a dead owner. The check reports `:ok`, and a probe confirms the
 registry is empty rather than the check being blind.
 
-**It fires on an injected regression.** Disabling the `{:DOWN, ...}` clause in
-`Mob.ComponentServer` — the exact mechanism the invariant guards — leaves the
-component alive under a dead owner. The first sample holds a candidate and the
-second reports it, with the component's id and module. Restoring the clause
-returns it to `:ok`.
+**It reports the state it asserts the absence of.** With a real
+`Mob.ComponentServer` registered under an owner that then dies, the check
+reports the orphan with its id and module — first sample holds a candidate,
+second reports. A leak that *grows*, one more orphan per sample, also confirms:
+the older orphans are stable while new ones accumulate.
 
-**It does not fire on healthy teardowns.** 60 consecutive teardowns, each with
-three components carrying a queued prop backlog so they are mid-reap when the
-next screen stops: **0 confirmed violations**, and the registry settles empty.
-That scenario produced 60 out of 60 with the back-to-back rule.
+**It does not false-positive on healthy teardowns.** 60 consecutive teardowns,
+each with three components carrying a queued prop backlog so they are mid-reap
+when the next screen stops: **0 confirmed violations**, and the registry settles
+empty. That scenario produced 60 out of 60 with the back-to-back rule.
+
+**What could not be demonstrated, and why.** An earlier draft of this record
+claimed the check "fires on an injected regression — disabling the
+`{:DOWN, ...}` clause in `Mob.ComponentServer`". That claim was wrong and is
+withdrawn rather than deleted. Disabling that clause does not produce a leak,
+because component reaping is defence in depth: `{:EXIT, _, reason}` stops a
+linked component independently, and `Mob.ComponentRegistry.reconcile/2` on the
+screen's next paint removes anything no longer in the tree. Disabling the first
+two still left the registry empty. So there is no single-fault injection that
+makes a real leak through the ordinary path, and the earlier "evidence" came
+from a hand-built probe that froze the orphan set — the CLAUDE.md
+"trust the instrument last" case: a probe constructed so it could not exhibit
+the failure.
+
+That leaves the built-in verified against the orphan *state*, which is what it
+asserts the absence of, and not against a reproduction of the fault that would
+produce it. The honest reading is that this invariant guards a regression in
+three cooperating mechanisms, and that it currently holds because all three
+work.
 
 **Cost, measured, since these ship in release builds** per
 `2026-09-04-defect-reports-are-a-shipped-feature.md`. Through `run/2`, which is

--- a/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
+++ b/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
@@ -1,0 +1,146 @@
+# An invariant must survive to the next sample
+
+Date: 2026-09-10
+Status: accepted
+Ticket: MOB-156 (epic MOB-149, phase 2)
+
+## Context
+
+The framework can assert things application code cannot: that no component
+outlives the screen that owns it, that no dead screen sits in a navigation
+stack. It has the handles; the app does not. Each check is a few microseconds
+and each guards a class of bug recent releases kept re-fixing — three of the
+four agents surveyed in MOB-149 named the component-ownership/handle-leak class
+independently, which is why it leads.
+
+The hazard is not writing the checks. It is that **every check reads live state
+from processes that are concurrently changing.** A screen mid-teardown has a
+dead pid and components that have not yet been reaped; a check sampling that
+instant sees a leak that resolves itself microseconds later. Report it and you
+produce a defect nobody can reproduce, which is worse than reporting nothing:
+it teaches the reader to ignore the channel, and then the real one arrives.
+
+## Decision
+
+**The first sighting of a violation is held as a candidate. It is recorded only
+if the same violation is still there at the next sampling of that point, and
+only once it is at least 50ms old.**
+
+The first version re-ran the check immediately instead, back to back in the same
+process, and that was measured filtering nothing: the gap between two calls is
+about a microsecond and the transients it was written for last tens to hundreds,
+so it suppressed ~0% of them. Two evaluations a microsecond apart cannot
+disagree, which made the rule an assertion about nothing — and the shipped check
+reported a confirmed `:critical` on **60 of 60 healthy teardowns**, the exact
+outcome this design exists to prevent.
+
+Deferring to the next sample gives real separation at no latency cost. The age
+floor is needed on top because sampling points are event-driven: the router
+stops screens in a tight loop, so during a multi-screen reset "the next sample"
+can arrive in under a millisecond and a component still being reaped is seen
+twice. With the deferral alone, healthy teardowns still produced about one
+confirmed violation in sixty; with the floor, zero.
+
+Sameness is by fingerprint over the violation's details, so a *different*
+transient at the next sample does not confirm the first.
+
+That makes the checks a contract rather than a convenience: a check must be
+*deterministic over stable state*. One that samples something genuinely
+time-varying — a queue length, a timestamp — cannot be expressed here and should
+not be. The confirmation run's details are the ones recorded, because the second
+evaluation is the one that decided.
+
+**A diagnostic may never affect what it observes.** A check that raises is
+reported as a violation of `:invariant_check_failed` rather than propagating,
+one broken check does not stop the others, and the `terminate/2` call site is
+wrapped again on top of that. `Mob.Agent.Receipts` learned this the hard way in
+MOB-155, where the receipt write could crash the screen it was recording.
+
+**Two checks ship, not ten.** MOB-156 names ten. Two are observable from the
+BEAM today; the other eight need hooks that do not exist — a handle high-water
+mark nobody records, a `-1` sentinel produced natively and never surfaced, a
+handler generation token that has not been invented. They are listed in
+`Mob.Invariant.Builtins.unimplemented/0` **as data, with what each needs**, and
+a test asserts none of them is ever silently registered. A registry advertising
+ten checks and running two is the kind of overclaim this epic keeps having to
+retract.
+
+## Evidence
+
+Both directions were checked, which for an invariant means more than a passing
+test — an invariant that holds is indistinguishable from one that cannot fire.
+
+**It holds on healthy code.** A real `Mob.ComponentServer` monitors its screen
+and stops when the screen dies, so after an ordinary teardown there is no live
+component under a dead owner. The check reports `:ok`, and a probe confirms the
+registry is empty rather than the check being blind.
+
+**It fires on an injected regression.** Disabling the `{:DOWN, ...}` clause in
+`Mob.ComponentServer` — the exact mechanism the invariant guards — leaves the
+component alive under a dead owner. The first sample holds a candidate and the
+second reports it, with the component's id and module. Restoring the clause
+returns it to `:ok`.
+
+**It does not fire on healthy teardowns.** 60 consecutive teardowns, each with
+three components carrying a queued prop backlog so they are mid-reap when the
+next screen stops: **0 confirmed violations**, and the registry settles empty.
+That scenario produced 60 out of 60 with the back-to-back rule.
+
+**Cost, measured, since these ship in release builds** per
+`2026-09-04-defect-reports-are-a-shipped-feature.md`. Through `run/2`, which is
+what a sampling point actually does — the check, the candidate bookkeeping, and
+the record on confirmation:
+
+| registry contents | µs per sample |
+|---|---|
+| empty | 1.6 |
+| 100 live components | 7.0 |
+| 1000 live components | 62.6 |
+| 100 **orphaned** | 16.2 |
+| 1000 **orphaned** | 81.6 |
+
+An earlier version cost 1764µs at 1000 orphans, because it built a map with two
+`inspect/1` calls for *every* orphan and only then kept eight — slowest exactly
+when a leak was largest, inside `terminate/2`, on the router's synchronous stop
+path. It now takes eight first, and reads the registry with a match spec rather
+than `tab2list/1`, which was also copying the `{pid, key}` reverse index.
+
+It fires once per screen teardown, not per frame. `Mob.Invariant.cost_us/2`
+re-measures one pass of each check on the device that matters; it does not
+include the candidate bookkeeping, so the table above is the number to budget
+against.
+
+## Consequences
+
+- `:on_screen_stop` samples while the stopping screen is **still alive** — it is
+  running its own `terminate/2`. So `orphaned_component` never sees the screen
+  that is stopping; it sees leaks left by screens that stopped earlier, one
+  teardown later. That is a real property of the sampling point and is
+  documented rather than papered over; a check written expecting otherwise would
+  silently never fire.
+- The registry and violation tables are owned by `Mob.Invariant.Owner`, an
+  unlinked GenServer, for the reason MOB-155 discovered: an ETS table created
+  from a screen callback dies with that screen, so an ordinary navigation pop
+  would take the registry with it.
+- Built-ins install from the owner's `init/1`, because `mob` has no supervision
+  tree of its own. Note this is **not** opt-in: `Mob.Screen.Server.terminate/2`
+  samples unconditionally, so every mob app starts the owner and installs the
+  built-ins on its first screen teardown. An earlier draft of this record
+  claimed an app that never touches an invariant pays nothing; that was true of
+  the design before the `terminate/2` wiring landed in the same change.
+
+- **`dead_screen_in_nav` is registered for `:periodic`, and nothing drives
+  `:periodic` yet.** It is reachable only by an explicit
+  `Mob.Invariant.run(:periodic, %{router: pid})`. It is not moved to
+  `:on_screen_stop` on purpose: that sampling point runs inside the screen the
+  router is synchronously stopping, so a check that calls back into the router
+  would deadlock until both five-second timeouts expire and the router then
+  kills the screen. Driving `:periodic` belongs with the defect bus in MOB-159.
+
+- **A check must not call the router from `:on_screen_stop`**, for the reason
+  above. `register/2` is public, so this is a trap worth stating rather than
+  leaving to be discovered.
+- Violations are bounded at 128 and carry **no application state** — pids,
+  module names and counts only, the same rule receipts follow.
+- Nothing consumes violations yet. There is no defect bus; `violations/1` is the
+  read surface. Wiring them to a sink is MOB-159's job.

--- a/lib/mob/component_registry.ex
+++ b/lib/mob/component_registry.ex
@@ -15,6 +15,19 @@ defmodule Mob.ComponentRegistry do
   end
 
   @doc """
+  The ETS table, or `:undefined` when the registry has not started.
+
+  For `Mob.Invariant`, which needs to walk every entry rather than look one up.
+  """
+  @spec table() :: :ets.table() | :undefined
+  def table do
+    case :ets.whereis(@table) do
+      :undefined -> :undefined
+      _ref -> @table
+    end
+  end
+
+  @doc """
   Register a component process. Raises if the same {screen_pid, id, module}
   is already registered (duplicate id on the same screen).
   """

--- a/lib/mob/invariant.ex
+++ b/lib/mob/invariant.ex
@@ -18,9 +18,19 @@ defmodule Mob.Invariant do
   reporting nothing — it teaches the reader to ignore the channel.
 
   So the first sighting of a violation is held as a **candidate**, and it is
-  recorded only if the *same* violation is still there at the next sampling of
-  that point. Something that has survived a whole screen teardown, or a whole
-  periodic tick, is not a scheduling artefact.
+  recorded only when two things are true: the *same* violation is still there at
+  the next sampling of that point, **and** the candidate is at least 50ms old.
+
+  Both halves are needed, and the second was not obvious. Sampling points are
+  event-driven — the router stops screens in a tight loop, so during a
+  multi-screen reset "the next sample" can arrive in under a millisecond, and a
+  component still being reaped is seen twice. Surviving one teardown is
+  therefore *not* proof of anything; surviving 50ms is, because a real leak
+  persists indefinitely and does not notice the wait. With deferral alone,
+  healthy teardowns still produced about one confirmed violation in sixty.
+
+  The floor is `:mob, :invariant_min_candidate_age_us` for a device whose
+  teardown outlasts the default.
 
   The first version of this re-ran the check immediately instead, back to back
   in the same process. That was measured and it filtered nothing: the gap

--- a/lib/mob/invariant.ex
+++ b/lib/mob/invariant.ex
@@ -130,6 +130,9 @@ defmodule Mob.Invariant do
   def unregister(name) do
     start()
     :ets.delete(@table, name)
+    # Its candidates too — nothing will ever sample this name again, so they
+    # would sit in the table for the life of the owner.
+    :ets.match_delete(@candidates, {{name, :_}, :_})
     :ok
   end
 
@@ -248,18 +251,11 @@ defmodule Mob.Invariant do
   defp mature(spec, fingerprint, details, context, now) do
     key = {spec.name, fingerprint}
 
-    # `:ets.take/2` reads and deletes atomically, so when two screens stop at
-    # once only one of them can claim a candidate — otherwise both pass the age
-    # gate and the same violation is recorded twice.
-    case :ets.take(@candidates, key) do
+    case :ets.lookup(@candidates, key) do
       [{^key, first_seen}] ->
-        if now - first_seen >= min_candidate_age_us() do
+        if now - first_seen >= min_candidate_age_us() and claim(key, first_seen) do
           [violation(spec, details, context)]
         else
-          # Not old enough yet to be told apart from work in progress. Put it
-          # back with its ORIGINAL first-seen, so the clock runs from the first
-          # sighting rather than restarting on every sample.
-          :ets.insert(@candidates, {key, first_seen})
           []
         end
 
@@ -269,6 +265,29 @@ defmodule Mob.Invariant do
     end
   end
 
+  # Compare-and-delete on the exact `{key, first_seen}` pair. Only one sampler
+  # can remove that row, so concurrent samplers cannot both report the same
+  # candidate — and, crucially, **nothing ever writes a first_seen back**.
+  #
+  # The previous version used `:ets.take/2` and re-inserted the row when it was
+  # too young. That looks atomic and is not: with three samplers in flight, one
+  # takes the row, a second sees absence and inserts a fresh `now`, a third takes
+  # *that* and writes it back — so the candidate's age kept resetting and a
+  # permanently-present violation was never confirmed at all. Measured through
+  # `run/2`: 1 sampler 39 confirmations, 2 samplers 34, **4 samplers zero**.
+  #
+  # This is not a theoretical race. `Mob.Router` `start_link`s its screens, so a
+  # router exit runs `terminate/2` — and this sampling point — in every live
+  # screen at once.
+  defp claim(key, first_seen) do
+    :ets.select_delete(@candidates, [{{key, first_seen}, [], [true]}]) == 1
+  end
+
+  # `:set` tables cannot match on a partially bound key, so this scans the whole
+  # candidates table rather than just this check's rows. The live set is bounded
+  # by the number of violations a check reports (capped at 8 for the built-ins),
+  # so that is a handful of rows — but it is why `unregister/1` above has to
+  # clear its own candidates rather than leaving them to be pruned.
   defp prune_candidates(name, keep) do
     keep = MapSet.new(keep)
 

--- a/lib/mob/invariant.ex
+++ b/lib/mob/invariant.ex
@@ -63,9 +63,14 @@ defmodule Mob.Invariant do
         check: fn context -> ... end
       )
 
-  A check returns `:ok`, or `{:violation, details}` where `details` is a map
-  carrying **no application state** — the same rule receipts follow. Pids,
-  module names and counts are fine; assigns are not.
+  A check returns `:ok`, `{:violation, details}`, or `{:violations, [details]}`
+  where each `details` is a map carrying **no application state** — the same rule
+  receipts follow. Pids, module names and counts are fine; assigns are not.
+
+  **Report independent problems separately.** A check that finds three leaked
+  components should return three violations, not one carrying a list. Each
+  matures on its own; rolled into one, the details change whenever any of them
+  does, the fingerprint changes with it, and nothing ever confirms.
   """
 
   alias Mob.Invariant.Violation
@@ -73,7 +78,7 @@ defmodule Mob.Invariant do
   @type point :: :after_committed_frame | :on_screen_stop | :periodic
   @type severity :: :critical | :warning
   @type context :: map()
-  @type result :: :ok | {:violation, map()}
+  @type result :: :ok | {:violation, map()} | {:violations, [map()]}
 
   @table :mob_invariants
   @violations :mob_invariant_violations
@@ -142,9 +147,11 @@ defmodule Mob.Invariant do
   @doc """
   Run every check registered for `point` against `context`.
 
-  Returns the violations confirmed by this run — that is, ones also seen at the
-  previous sampling of `point`. A violation seen for the first time is held as a
-  candidate and returns nothing. Never
+  Returns the violations confirmed by this run: ones also seen at the previous
+  sampling of `point` **and** whose candidacy is at least
+  `:mob, :invariant_min_candidate_age_us` old (50ms by default). A violation
+  seen for the first time, or too recently, is held as a candidate and returns
+  nothing. Never
   raises: a check that blows up is itself reported as a violation of
   `:invariant_check_failed` rather than being allowed to take down the process
   that was kind enough to sample.
@@ -211,51 +218,82 @@ defmodule Mob.Invariant do
   end
 
   # Confirmation is deferred to the next sampling of this point — see the
-  # moduledoc. Re-running the check here instead would compare two observations
-  # a microsecond apart, which is far shorter than the transients being
-  # filtered.
+  # moduledoc. Candidacy is per *violation*, not per check, and that granularity
+  # is load-bearing: keyed by check name alone, any check whose details change
+  # between samples could never confirm, because each sample replaced the
+  # candidate and restarted its clock. A leak that grows — which is exactly what
+  # a broken reaping path produces, one more orphan per navigation — was seen on
+  # 59 of 60 samples and reported zero times.
   defp evaluate(spec, context) do
     case safe_check(spec, context) do
       :ok ->
-        # No violation now, so any candidate for this check was transient.
-        :ets.delete(@candidates, spec.name)
+        :ets.match_delete(@candidates, {{spec.name, :_}, :_})
         []
 
-      {:violation, details} ->
-        fingerprint = :erlang.phash2({spec.name, details})
-
+      {:violations, all_details} ->
         now = System.monotonic_time(:microsecond)
+        by_fingerprint = Map.new(all_details, &{:erlang.phash2({spec.name, &1}), &1})
 
-        case :ets.lookup(@candidates, spec.name) do
-          [{_name, ^fingerprint, first_seen}] ->
-            if now - first_seen >= min_candidate_age_us() do
-              :ets.delete(@candidates, spec.name)
-              [violation(spec, details, context)]
-            else
-              # Same violation, but not yet old enough to be distinguished from
-              # work in progress. The original first-seen is kept so a later
-              # sample can confirm it.
-              []
-            end
+        # A candidate whose violation is no longer present has resolved. Dropping
+        # it is what stops an appear/disappear/reappear sequence confirming
+        # something that was never continuously there.
+        prune_candidates(spec.name, Map.keys(by_fingerprint))
 
-          _ ->
-            # First sighting, or a *different* violation than last time — which
-            # is a new candidate rather than a confirmation of the old one.
-            :ets.insert(@candidates, {spec.name, fingerprint, now})
-            []
-        end
+        Enum.flat_map(by_fingerprint, fn {fingerprint, details} ->
+          mature(spec, fingerprint, details, context, now)
+        end)
     end
   end
 
+  defp mature(spec, fingerprint, details, context, now) do
+    key = {spec.name, fingerprint}
+
+    # `:ets.take/2` reads and deletes atomically, so when two screens stop at
+    # once only one of them can claim a candidate — otherwise both pass the age
+    # gate and the same violation is recorded twice.
+    case :ets.take(@candidates, key) do
+      [{^key, first_seen}] ->
+        if now - first_seen >= min_candidate_age_us() do
+          [violation(spec, details, context)]
+        else
+          # Not old enough yet to be told apart from work in progress. Put it
+          # back with its ORIGINAL first-seen, so the clock runs from the first
+          # sighting rather than restarting on every sample.
+          :ets.insert(@candidates, {key, first_seen})
+          []
+        end
+
+      [] ->
+        :ets.insert_new(@candidates, {key, now})
+        []
+    end
+  end
+
+  defp prune_candidates(name, keep) do
+    keep = MapSet.new(keep)
+
+    @candidates
+    |> :ets.match_object({{name, :_}, :_})
+    |> Enum.each(fn {{_name, fingerprint} = key, _first_seen} ->
+      if not MapSet.member?(keep, fingerprint), do: :ets.delete(@candidates, key)
+    end)
+  end
+
+  # Normalised to a list so `evaluate/2` has one shape to reason about. A check
+  # that can report several independent violations — one per leaked component,
+  # say — must return them separately, or they share a fingerprint and mature
+  # as a single lump that changes every time one of them does.
   defp safe_check(spec, context) do
     case spec.check.(context) do
       :ok -> :ok
-      {:violation, details} when is_map(details) -> {:violation, details}
+      {:violation, details} when is_map(details) -> {:violations, [details]}
+      {:violations, []} -> :ok
+      {:violations, list} when is_list(list) -> {:violations, list}
     end
   rescue
-    e -> {:violation, %{invariant_check_failed: spec.name, exception: e.__struct__}}
+    e -> {:violations, [%{invariant_check_failed: spec.name, exception: e.__struct__}]}
   catch
-    kind, _ -> {:violation, %{invariant_check_failed: spec.name, exit: kind}}
+    kind, _ -> {:violations, [%{invariant_check_failed: spec.name, exit: kind}]}
   end
 
   defp violation(spec, details, context) do

--- a/lib/mob/invariant.ex
+++ b/lib/mob/invariant.ex
@@ -1,0 +1,280 @@
+defmodule Mob.Invariant do
+  @moduledoc """
+  Checks the framework can make about itself, and the rule that stops them
+  becoming noise.
+
+  An application cannot assert that a component's owning screen is still alive,
+  or that no dead screen is sitting in the navigation stack — it does not have
+  the handles. The framework does, each check is a few microseconds, and each
+  one guards a class of bug that recent releases kept re-fixing.
+
+  ## A violation must survive to the next sample
+
+  This is the whole design, not a refinement. Every check here reads *live*
+  state from processes that are concurrently changing: a screen mid-teardown has
+  a dead pid and components that have not yet been reaped, and a check sampling
+  that instant sees a violation that resolves itself shortly afterwards.
+  Reporting it produces a defect nobody can reproduce, which is worse than
+  reporting nothing — it teaches the reader to ignore the channel.
+
+  So the first sighting of a violation is held as a **candidate**, and it is
+  recorded only if the *same* violation is still there at the next sampling of
+  that point. Something that has survived a whole screen teardown, or a whole
+  periodic tick, is not a scheduling artefact.
+
+  The first version of this re-ran the check immediately instead, back to back
+  in the same process. That was measured and it filtered nothing: the gap
+  between the two calls is about a microsecond and the transients it was meant
+  to catch last tens to hundreds, so it suppressed ~0% of them while reporting
+  a confirmed `:critical` on healthy teardowns. Two evaluations a microsecond
+  apart cannot disagree, which made the rule an assertion about nothing.
+
+  Sameness is by fingerprint over the violation's details, so a *different*
+  transient at the next sample does not confirm the first one.
+
+  That makes the checks themselves a contract: a check must be *deterministic
+  over stable state*, and its details must identify the violation rather than
+  describe the moment. One that samples something genuinely time-varying — a
+  timestamp, a queue length — cannot be expressed here, and should not be.
+
+  ## It ships in release builds
+
+  Per `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`, the
+  interesting failures happen where no agent is watching. That makes the cost
+  real rather than theoretical, so it is budgeted rather than discovered on
+  someone's three-year-old Android: see `cost_us/2`, and the numbers in
+  `decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md`.
+
+  ## Registering
+
+      Mob.Invariant.register(:my_check,
+        at: :on_screen_stop,
+        severity: :critical,
+        check: fn context -> ... end
+      )
+
+  A check returns `:ok`, or `{:violation, details}` where `details` is a map
+  carrying **no application state** — the same rule receipts follow. Pids,
+  module names and counts are fine; assigns are not.
+  """
+
+  alias Mob.Invariant.Violation
+
+  @type point :: :after_committed_frame | :on_screen_stop | :periodic
+  @type severity :: :critical | :warning
+  @type context :: map()
+  @type result :: :ok | {:violation, map()}
+
+  @table :mob_invariants
+  @violations :mob_invariant_violations
+  @candidates :mob_invariant_candidates
+  @keep 128
+
+  # A candidate must also be this old before it can be confirmed. Sampling
+  # points are event-driven, so "the next sample" can arrive almost immediately
+  # — during a multi-screen teardown the router stops screens in a tight loop,
+  # and a component still being reaped can be seen twice in under a millisecond.
+  # A real leak persists indefinitely and does not notice the wait; a reap in
+  # progress does. Measured: without this, healthy teardowns still produced
+  # about one confirmed violation in sixty.
+  @default_min_candidate_age_us 50_000
+
+  @doc false
+  @spec start() :: :ok
+  def start do
+    if :ets.whereis(@table) == :undefined, do: Mob.Invariant.Owner.start()
+    :ok
+  end
+
+  @doc """
+  Register a check.
+
+  Re-registering the same name replaces the previous definition, so a hot code
+  push does not accumulate duplicates.
+  """
+  @spec register(atom(), keyword()) :: :ok
+  def register(name, opts) when is_atom(name) do
+    start()
+
+    :ets.insert(
+      @table,
+      {name,
+       %{
+         name: name,
+         at: Keyword.fetch!(opts, :at),
+         severity: Keyword.get(opts, :severity, :warning),
+         check: Keyword.fetch!(opts, :check)
+       }}
+    )
+
+    :ok
+  end
+
+  @doc "Forget a check."
+  @spec unregister(atom()) :: :ok
+  def unregister(name) do
+    start()
+    :ets.delete(@table, name)
+    :ok
+  end
+
+  @doc "Every check registered for `point`."
+  @spec registered(point()) :: [map()]
+  def registered(point) do
+    start()
+
+    @table
+    |> :ets.tab2list()
+    |> Enum.map(fn {_name, spec} -> spec end)
+    |> Enum.filter(&(&1.at == point))
+  end
+
+  @doc """
+  Run every check registered for `point` against `context`.
+
+  Returns the violations confirmed by this run — that is, ones also seen at the
+  previous sampling of `point`. A violation seen for the first time is held as a
+  candidate and returns nothing. Never
+  raises: a check that blows up is itself reported as a violation of
+  `:invariant_check_failed` rather than being allowed to take down the process
+  that was kind enough to sample.
+  """
+  @spec run(point(), context()) :: [Violation.t()]
+  def run(point, context \\ %{}) do
+    point
+    |> registered()
+    |> Enum.flat_map(&evaluate(&1, context))
+    |> Enum.map(&record/1)
+  end
+
+  @doc """
+  The violations held, newest first.
+  """
+  @spec violations(pos_integer()) :: [Violation.t()]
+  def violations(limit \\ 20) do
+    start()
+
+    @violations
+    |> :ets.tab2list()
+    |> Enum.sort_by(fn {seq, _v} -> -seq end)
+    |> Enum.take(limit)
+    |> Enum.map(fn {_seq, v} -> v end)
+  end
+
+  @doc "How many violations are held."
+  @spec violation_count() :: non_neg_integer()
+  def violation_count do
+    start()
+    :ets.info(@violations, :size)
+  end
+
+  @doc """
+  Microseconds to run every check registered for `point` once, measured now.
+
+  For budgeting on the device that matters rather than on a laptop. Runs the
+  checks for real, so it observes whatever the app is currently doing.
+
+  This is one pass of each check. A sampling point also does candidate
+  bookkeeping and, on confirmation, a record — so a real sample costs somewhat
+  more than this reports. The table in the decision record is measured through
+  `run/2` and is the number to budget against.
+  """
+  @spec cost_us(point(), context()) :: non_neg_integer()
+  def cost_us(point, context \\ %{}) do
+    {us, _} = :timer.tc(fn -> point |> registered() |> Enum.each(&safe_check(&1, context)) end)
+    us
+  end
+
+  @doc false
+  @spec reset() :: :ok
+  def reset do
+    # Objects first, THEN reload — the reverse order wiped the built-ins that
+    # `Owner.setup/0` had just installed, leaving the framework's shipped
+    # diagnostics permanently off for the life of the owner.
+    for t <- [@table, @violations, @candidates] do
+      if :ets.whereis(t) != :undefined, do: :ets.delete_all_objects(t)
+    end
+
+    Mob.Invariant.Owner.reload()
+    :atomics.put(seq(), 1, 0)
+    :ok
+  end
+
+  # Confirmation is deferred to the next sampling of this point — see the
+  # moduledoc. Re-running the check here instead would compare two observations
+  # a microsecond apart, which is far shorter than the transients being
+  # filtered.
+  defp evaluate(spec, context) do
+    case safe_check(spec, context) do
+      :ok ->
+        # No violation now, so any candidate for this check was transient.
+        :ets.delete(@candidates, spec.name)
+        []
+
+      {:violation, details} ->
+        fingerprint = :erlang.phash2({spec.name, details})
+
+        now = System.monotonic_time(:microsecond)
+
+        case :ets.lookup(@candidates, spec.name) do
+          [{_name, ^fingerprint, first_seen}] ->
+            if now - first_seen >= min_candidate_age_us() do
+              :ets.delete(@candidates, spec.name)
+              [violation(spec, details, context)]
+            else
+              # Same violation, but not yet old enough to be distinguished from
+              # work in progress. The original first-seen is kept so a later
+              # sample can confirm it.
+              []
+            end
+
+          _ ->
+            # First sighting, or a *different* violation than last time — which
+            # is a new candidate rather than a confirmation of the old one.
+            :ets.insert(@candidates, {spec.name, fingerprint, now})
+            []
+        end
+    end
+  end
+
+  defp safe_check(spec, context) do
+    case spec.check.(context) do
+      :ok -> :ok
+      {:violation, details} when is_map(details) -> {:violation, details}
+    end
+  rescue
+    e -> {:violation, %{invariant_check_failed: spec.name, exception: e.__struct__}}
+  catch
+    kind, _ -> {:violation, %{invariant_check_failed: spec.name, exit: kind}}
+  end
+
+  defp violation(spec, details, context) do
+    %Violation{
+      invariant: spec.name,
+      severity: spec.severity,
+      at: spec.at,
+      details: details,
+      screen: Map.get(context, :screen_module),
+      monotonic_us: System.monotonic_time(:microsecond)
+    }
+  end
+
+  defp record(%Violation{} = violation) do
+    start()
+    seq = :atomics.add_get(seq(), 1, 1)
+    :ets.insert(@violations, {seq, violation})
+
+    if :ets.info(@violations, :size) > @keep do
+      :ets.select_delete(@violations, [{{:"$1", :_}, [{:<, :"$1", seq - @keep + 1}], [true]}])
+    end
+
+    violation
+  end
+
+  defp seq, do: :persistent_term.get(:mob_invariant_state).seq
+
+  # Configurable so a test can sample twice without waiting, and so an app on a
+  # slow device can raise it if teardown there outlasts the default.
+  defp min_candidate_age_us,
+    do: Application.get_env(:mob, :invariant_min_candidate_age_us, @default_min_candidate_age_us)
+end

--- a/lib/mob/invariant/builtins.ex
+++ b/lib/mob/invariant/builtins.ex
@@ -16,6 +16,11 @@ defmodule Mob.Invariant.Builtins do
 
   alias Mob.ComponentRegistry
 
+  # Reported orphans per sample. A leak of a thousand is not a thousand times
+  # more informative than a leak of eight, and every reported violation is an
+  # ETS write on a teardown path.
+  @max_reported 8
+
   @doc """
   Register the built-in checks. Idempotent.
   """
@@ -53,8 +58,13 @@ defmodule Mob.Invariant.Builtins do
   Confirmation matters here more than anywhere: the router stops screens in a
   tight loop, so during a multi-screen reset this samples while the previous
   screen's components are mid-reap. Measured with the confirmation rule in
-  place: 0 violations across 60 healthy teardowns, and a real leak — the
-  `{:DOWN, ...}` clause in `Mob.ComponentServer` disabled — still reported.
+  place: 0 violations across 60 healthy teardowns.
+
+  Reaping is defence in depth — a monitor `:DOWN`, an `:EXIT` from a linked
+  screen, and `ComponentRegistry.reconcile/2` on the next paint — so no
+  single-fault injection produces a real leak through the ordinary path. This
+  check is verified against the orphan state itself rather than against a
+  reproduction of the fault that would cause it. See the decision record.
   """
   @spec orphaned_component(map()) :: Mob.Invariant.result()
   def orphaned_component(_context) do
@@ -65,35 +75,43 @@ defmodule Mob.Invariant.Builtins do
       table ->
         # A match spec rather than `tab2list/1`: the registry also holds a
         # `{pid, key}` reverse index, so listing the whole table copies twice
-        # the rows this needs. And `Enum.take` before `Enum.map` — building a
-        # map with two `inspect/1` calls for every orphan and then keeping eight
-        # made the check slowest exactly when a leak was largest, inside
-        # `terminate/2`, on the router's synchronous stop path.
-        raw =
-          :ets.select(table, [
-            {{{:"$1", :"$2", :"$3"}, :"$4"}, [], [{{:"$1", :"$2", :"$3", :"$4"}}]}
-          ])
+        # the rows this needs.
+        orphans =
+          table
+          |> :ets.select([{{{:"$1", :"$2", :"$3"}, :"$4"}, [], [{{:"$1", :"$2", :"$3", :"$4"}}]}])
+          |> Enum.filter(&orphan?/1)
+          # Sorted before the cap, and this is load-bearing rather than tidy.
+          # ETS `select` returns rows in an unspecified order that shifts as the
+          # table grows, so taking an arbitrary eight reported a *different*
+          # eight on every sample — each one a fresh fingerprint, so nothing
+          # ever matured. Measured: 240 leaked rows across 60 teardowns and
+          # zero confirmations. Sorting makes the same orphans the reported
+          # ones until they are reaped.
+          |> Enum.sort()
 
-        orphans = Enum.filter(raw, &orphan?/1)
-
-        case orphans do
+        # One violation per orphan, not one carrying a list. Each leaked
+        # component then matures on its own: rolled together, the details change
+        # whenever any orphan is added or reaped, the fingerprint changes with
+        # them, and a leak that grows — one more orphan per navigation, which is
+        # exactly what a broken reaping path produces — never confirms at all.
+        #
+        # Capped, and the cap is taken BEFORE building the maps: two `inspect/1`
+        # calls per orphan for a thousand orphans ran inside `terminate/2` on the
+        # router's synchronous stop path.
+        case Enum.take(orphans, @max_reported) do
           [] ->
             :ok
 
-          _ ->
-            details =
-              orphans
-              |> Enum.take(8)
-              |> Enum.map(fn {screen_pid, id, module, component_pid} ->
-                %{
-                  screen: inspect(screen_pid),
-                  component: inspect(component_pid),
-                  id: id,
-                  module: module
-                }
-              end)
-
-            {:violation, %{orphans: details, count: length(orphans)}}
+          reported ->
+            {:violations,
+             Enum.map(reported, fn {screen_pid, id, module, component_pid} ->
+               %{
+                 screen: inspect(screen_pid),
+                 component: inspect(component_pid),
+                 id: id,
+                 module: module
+               }
+             end)}
         end
     end
   end
@@ -119,9 +137,13 @@ defmodule Mob.Invariant.Builtins do
         router
         |> Mob.Router.entries()
         |> Enum.filter(fn {_module, pid} -> is_pid(pid) and not Process.alive?(pid) end)
+        |> Enum.take(@max_reported)
         |> Enum.map(fn {module, pid} -> %{module: module, pid: inspect(pid)} end)
 
-      if dead == [], do: :ok, else: {:violation, %{dead_entries: dead, count: length(dead)}}
+      # One per dead entry, for the same reason as orphaned_component: a stack
+      # that accumulates corpses would re-fingerprint on every sample and never
+      # confirm.
+      if dead == [], do: :ok, else: {:violations, dead}
     else
       :ok
     end

--- a/lib/mob/invariant/builtins.ex
+++ b/lib/mob/invariant/builtins.ex
@@ -1,0 +1,160 @@
+defmodule Mob.Invariant.Builtins do
+  @moduledoc """
+  The checks the framework ships with, and an honest list of the ones it does
+  not yet.
+
+  MOB-156 names ten. Two are implemented here, because those two are the only
+  ones observable from the BEAM today without hooks that do not exist. The rest
+  are listed in `unimplemented/0` with what each needs, rather than being
+  half-written against state nobody records — a registry advertising ten checks
+  and running two would be exactly the kind of claim this epic keeps having to
+  retract.
+
+  The component-ownership one leads because three of the four agents in MOB-149
+  named that class independently.
+  """
+
+  alias Mob.ComponentRegistry
+
+  @doc """
+  Register the built-in checks. Idempotent.
+  """
+  @spec install() :: :ok
+  def install do
+    Mob.Invariant.register(:orphaned_component,
+      at: :on_screen_stop,
+      severity: :critical,
+      check: &orphaned_component/1
+    )
+
+    Mob.Invariant.register(:dead_screen_in_nav,
+      at: :periodic,
+      severity: :critical,
+      check: &dead_screen_in_nav/1
+    )
+
+    :ok
+  end
+
+  @doc """
+  A live component whose owning screen process is dead.
+
+  The registry keys entries by `{screen_pid, id, module}`, and reaping happens
+  on reconcile or when the owner goes down. A component that is still alive
+  under a dead owner is a leaked process holding a native handle — the class
+  MOB-100 and its follow-ups kept re-fixing.
+
+  Sampled at `:on_screen_stop`, which runs *inside* the screen that is stopping
+  — so this never sees that screen's own components: it is still alive, running
+  its own `terminate/2`. What it sees is what an *earlier* screen left behind,
+  one teardown later. A check written expecting otherwise would silently never
+  fire.
+
+  Confirmation matters here more than anywhere: the router stops screens in a
+  tight loop, so during a multi-screen reset this samples while the previous
+  screen's components are mid-reap. Measured with the confirmation rule in
+  place: 0 violations across 60 healthy teardowns, and a real leak — the
+  `{:DOWN, ...}` clause in `Mob.ComponentServer` disabled — still reported.
+  """
+  @spec orphaned_component(map()) :: Mob.Invariant.result()
+  def orphaned_component(_context) do
+    case ComponentRegistry.table() do
+      :undefined ->
+        :ok
+
+      table ->
+        # A match spec rather than `tab2list/1`: the registry also holds a
+        # `{pid, key}` reverse index, so listing the whole table copies twice
+        # the rows this needs. And `Enum.take` before `Enum.map` — building a
+        # map with two `inspect/1` calls for every orphan and then keeping eight
+        # made the check slowest exactly when a leak was largest, inside
+        # `terminate/2`, on the router's synchronous stop path.
+        raw =
+          :ets.select(table, [
+            {{{:"$1", :"$2", :"$3"}, :"$4"}, [], [{{:"$1", :"$2", :"$3", :"$4"}}]}
+          ])
+
+        orphans = Enum.filter(raw, &orphan?/1)
+
+        case orphans do
+          [] ->
+            :ok
+
+          _ ->
+            details =
+              orphans
+              |> Enum.take(8)
+              |> Enum.map(fn {screen_pid, id, module, component_pid} ->
+                %{
+                  screen: inspect(screen_pid),
+                  component: inspect(component_pid),
+                  id: id,
+                  module: module
+                }
+              end)
+
+            {:violation, %{orphans: details, count: length(orphans)}}
+        end
+    end
+  end
+
+  defp orphan?({screen_pid, _id, _module, component_pid})
+       when is_pid(screen_pid) and is_pid(component_pid) do
+    not Process.alive?(screen_pid) and Process.alive?(component_pid)
+  end
+
+  defp orphan?(_entry), do: false
+
+  @doc """
+  A dead screen still present in a router's navigation.
+
+  Expects `%{router: pid}` in the context. A dead pid in the stack means a
+  later `pop` returns to a corpse: the router restarts it and the user's state
+  is gone, or the entry is skipped and the back stack lies about where it goes.
+  """
+  @spec dead_screen_in_nav(map()) :: Mob.Invariant.result()
+  def dead_screen_in_nav(%{router: router}) when is_pid(router) do
+    if Process.alive?(router) do
+      dead =
+        router
+        |> Mob.Router.entries()
+        |> Enum.filter(fn {_module, pid} -> is_pid(pid) and not Process.alive?(pid) end)
+        |> Enum.map(fn {module, pid} -> %{module: module, pid: inspect(pid)} end)
+
+      if dead == [], do: :ok, else: {:violation, %{dead_entries: dead, count: length(dead)}}
+    else
+      :ok
+    end
+  end
+
+  def dead_screen_in_nav(_context), do: :ok
+
+  @doc """
+  The eight checks MOB-156 names that are not implemented, and what each needs.
+
+  Kept as data rather than prose so it can be asserted on: a test pins that the
+  registry never silently claims to run one of these.
+  """
+  @spec unimplemented() :: [{atom(), String.t()}]
+  def unimplemented do
+    [
+      {:handles_grow_across_navigation,
+       "needs a per-navigation handle-allocation high-water mark; nothing records one"},
+      {:component_received_handle_minus_one,
+       "the -1 sentinel is produced natively and is not surfaced to the BEAM"},
+      {:inactive_screen_committed_frame,
+       "a paint runs in the screen, which does not know the router's current entry; " <>
+         "asking mid-paint risks a call into a router that may be calling this screen"},
+      {:event_for_replaced_handler_generation, "there is no handler generation token yet"},
+      {:screen_crashed_past_restart_allowance,
+       "the router restarts screens but does not count restarts per entry"},
+      {:interactive_node_without_native_frame,
+       "needs the native frame registry, which lives on the other side of the bridge"},
+      {:sheet_dismissed_twice,
+       "needs native sheet presentation state; the BEAM only sees its own removal"},
+      {:loaded_modules_disagree_with_manifest,
+       "mix mob.attest does this from the host (MOB-152); doing it on-device needs " <>
+         "the manifest shipped into the app"}
+    ]
+  end
+end

--- a/lib/mob/invariant/builtins.ex
+++ b/lib/mob/invariant/builtins.ex
@@ -80,13 +80,16 @@ defmodule Mob.Invariant.Builtins do
           table
           |> :ets.select([{{{:"$1", :"$2", :"$3"}, :"$4"}, [], [{{:"$1", :"$2", :"$3", :"$4"}}]}])
           |> Enum.filter(&orphan?/1)
-          # Sorted before the cap, and this is load-bearing rather than tidy.
-          # ETS `select` returns rows in an unspecified order that shifts as the
-          # table grows, so taking an arbitrary eight reported a *different*
-          # eight on every sample — each one a fresh fingerprint, so nothing
-          # ever matured. Measured: 240 leaked rows across 60 teardowns and
-          # zero confirmations. Sorting makes the same orphans the reported
-          # ones until they are reaped.
+          # Sorted before the cap so the same orphans are the reported ones
+          # across samples. ETS `select` returns rows in an order that shifts as
+          # the table grows — measured changing the unsorted top-8 on 33 of 199
+          # insertions — so an arbitrary eight names a partly different eight
+          # each time. Worth about 4% of confirmations rather than being
+          # load-bearing: per-violation candidacy already tolerates one element
+          # churning in and out of the window, and sorting does not eliminate
+          # the churn either (7 of 199), because a reused pid slot can sort
+          # *into* the window. The zero-confirmations measurement belongs to the
+          # per-violation change below, not to this sort.
           |> Enum.sort()
 
         # One violation per orphan, not one carrying a list. Each leaked

--- a/lib/mob/invariant/owner.ex
+++ b/lib/mob/invariant/owner.ex
@@ -1,0 +1,69 @@
+defmodule Mob.Invariant.Owner do
+  @moduledoc """
+  Owns the invariant registry and violation tables.
+
+  Same reason `Mob.Agent.Receipts.Owner` exists: an ETS table dies with its
+  creator, and creating one lazily from a check that runs inside a screen
+  callback makes the owner a screen — so an ordinary navigation pop would take
+  the registry and every recorded violation with it. Unlinked, so a diagnostic
+  neither dies with a screen nor takes one down.
+  """
+
+  use GenServer
+
+  @table :mob_invariants
+  @violations :mob_invariant_violations
+  @candidates :mob_invariant_candidates
+  @state :mob_invariant_state
+
+  @doc false
+  @spec start() :: {:ok, pid()}
+  def start do
+    case GenServer.start(__MODULE__, [], name: __MODULE__) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+    end
+  end
+
+  @doc false
+  @spec reload() :: :ok
+  def reload do
+    {:ok, pid} = start()
+    GenServer.call(pid, :reload)
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    setup()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_call(:reload, _from, state) do
+    setup()
+    {:reply, :ok, state}
+  end
+
+  # State before the tables, and a table is the flag — the reverse order leaves
+  # a window where another process sees a table, skips initialisation, and reads
+  # a `:persistent_term` key that is not there yet.
+  defp setup do
+    :persistent_term.put(@state, %{seq: :atomics.new(1, signed: false)})
+
+    for t <- [@table, @violations, @candidates] do
+      if :ets.whereis(t) == :undefined do
+        :ets.new(t, [:set, :public, :named_table, {:write_concurrency, true}])
+      end
+    end
+
+    # Installed here rather than from an app boot hook, because `mob` has no
+    # supervision tree of its own — it is a library inside someone else's app.
+    # The owner starts on first use, so the built-ins exist whenever the
+    # registry does, and an app that never touches an invariant never pays for
+    # one. Safe from inside `init/1`: `register/2` calls `Mob.Invariant.start/0`,
+    # which sees the table created two lines above and does not re-enter here.
+    Mob.Invariant.Builtins.install()
+
+    :ok
+  end
+end

--- a/lib/mob/invariant/violation.ex
+++ b/lib/mob/invariant/violation.ex
@@ -1,0 +1,31 @@
+defmodule Mob.Invariant.Violation do
+  @moduledoc """
+  One confirmed invariant breach.
+
+  `details` carries **no application state** — pids, module names and counts
+  only. A violation is written to ETS and is a defect-report input, and the sink
+  policy in `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`
+  excludes assigns by default. The same rule `Mob.Agent.Receipt` follows, for
+  the same reason: MOB-147 found a `SecureField` value crossing screens, so
+  anything that serialises framework state has to assume secrets are in it.
+  """
+
+  @type t :: %__MODULE__{
+          invariant: atom(),
+          severity: Mob.Invariant.severity(),
+          at: Mob.Invariant.point(),
+          details: map(),
+          screen: module() | nil,
+          monotonic_us: integer()
+        }
+
+  defstruct [:invariant, :severity, :at, :details, :screen, :monotonic_us]
+
+  @doc "A one-line summary for a triage log."
+  @spec describe(t()) :: String.t()
+  def describe(%__MODULE__{} = v) do
+    "[#{v.severity}] #{v.invariant} at #{v.at}" <>
+      if(v.screen, do: " in #{inspect(v.screen)}", else: "") <>
+      " — #{inspect(v.details, limit: 8)}"
+  end
+end

--- a/lib/mob/router.ex
+++ b/lib/mob/router.ex
@@ -83,6 +83,17 @@ defmodule Mob.Router do
   def get_nav_history(pid), do: GenServer.call(pid, :get_nav_history)
 
   @doc """
+  Every screen entry the router holds, as `{module, pid}` — current, history and
+  parked tabs alike.
+
+  For `Mob.Invariant`: `get_nav_history/1` returns sockets, which is what a test
+  wants, but an invariant needs the pids in order to ask whether they are still
+  alive.
+  """
+  @spec entries(pid()) :: [{module(), pid()}]
+  def entries(pid), do: GenServer.call(pid, :__entries__)
+
+  @doc """
   Start a screen as the root UI screen. Calls mount, renders the component tree
   via `Mob.Renderer`, and calls `set_root` on the resulting view.
 
@@ -236,6 +247,13 @@ defmodule Mob.Router do
 
   def handle_call(:get_current_module, _from, state) do
     {:reply, state.current.module, state}
+  end
+
+  # Every entry the router is holding — current, history, and parked tabs —
+  # as {module, pid}. `get_nav_history/1` returns sockets, which is what a test
+  # wants; an invariant needs the pids to ask whether they are alive.
+  def handle_call(:__entries__, _from, state) do
+    {:reply, Enum.map(all_entries(state), &{&1.module, &1.pid}), state}
   end
 
   def handle_call(:get_nav_history, _from, state) do

--- a/lib/mob/screen/server.ex
+++ b/lib/mob/screen/server.ex
@@ -438,7 +438,26 @@ defmodule Mob.Screen.Server do
       Mob.ScreenState.dump(state.module, state.socket)
     end
 
-    state.module.terminate(reason, state.socket)
+    result = state.module.terminate(reason, state.socket)
+
+    # MOB-156. A screen stopping is when a leaked component becomes visible —
+    # its owner is gone and nothing else is going to notice. Run after the
+    # user's terminate/2 so their cleanup has happened first, and wrapped
+    # because a diagnostic must never be the reason a teardown fails.
+    #
+    # This screen is still alive here — it is running its own terminate/2 — so a
+    # check never sees this screen's own components. What it sees is what an
+    # earlier screen left behind. Confirmation across samples is what keeps that
+    # from reporting components merely mid-reap.
+    try do
+      Mob.Invariant.run(:on_screen_stop, %{screen: self(), screen_module: state.module})
+    rescue
+      _ -> :ok
+    catch
+      _, _ -> :ok
+    end
+
+    result
   end
 
   # ── Internals ─────────────────────────────────────────────────────────────

--- a/test/mob/invariant_builtins_test.exs
+++ b/test/mob/invariant_builtins_test.exs
@@ -1,0 +1,248 @@
+defmodule Mob.Invariant.BuiltinsTest do
+  use ExUnit.Case, async: false
+
+  alias Mob.ComponentRegistry
+  alias Mob.Invariant
+  alias Mob.Invariant.Builtins
+
+  setup do
+    Invariant.reset()
+    Mob.Test.ProcessHelpers.ensure_component_registry()
+    on_exit(&Invariant.reset/0)
+    :ok
+  end
+
+  defmodule FakeRouter do
+    @moduledoc false
+    use GenServer
+
+    def start_link(entries), do: GenServer.start_link(__MODULE__, entries)
+
+    @impl GenServer
+    def init(entries), do: {:ok, entries}
+
+    @impl GenServer
+    def handle_call(:__entries__, _from, entries), do: {:reply, entries, entries}
+  end
+
+  defmodule NavScreen do
+    @moduledoc false
+    use Mob.Screen
+    def mount(_p, _s, socket), do: {:ok, socket}
+    def render(_a), do: %{type: :text, props: %{text: "nav"}, children: []}
+  end
+
+  defmodule Nif do
+    @moduledoc false
+    def safe_area, do: {0.0, 0.0, 0.0, 0.0}
+    def platform, do: :ios
+    def take_launch_notification, do: :none
+    def unquote(:"$handle_undefined_function")(_f, _a), do: :ok
+  end
+
+  defp forever do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
+  describe "orphaned_component/1" do
+    test "a live component under a dead owner is a violation" do
+      # The class three of the four agents in MOB-149 named independently: a
+      # leaked component process still holding a native handle after the screen
+      # that owned it is gone.
+      dead_owner = forever()
+      component = forever()
+      ComponentRegistry.register(dead_owner, :leaky, SomeComponent, component)
+
+      ref = Process.monitor(dead_owner)
+      send(dead_owner, :stop)
+      assert_receive {:DOWN, ^ref, :process, ^dead_owner, _}
+
+      assert {:violation, %{count: 1, orphans: [orphan]}} = Builtins.orphaned_component(%{})
+      assert orphan.id == :leaky
+      assert orphan.module == SomeComponent
+
+      send(component, :stop)
+    end
+
+    test "a live component under a live owner is fine" do
+      owner = forever()
+      component = forever()
+      ComponentRegistry.register(owner, :ok_one, SomeComponent, component)
+
+      assert Builtins.orphaned_component(%{}) == :ok
+
+      send(owner, :stop)
+      send(component, :stop)
+    end
+
+    test "a dead component under a dead owner is not a leak" do
+      # Both gone is the normal end of a screen's life. Reporting it would make
+      # every teardown a defect.
+      owner = forever()
+      component = forever()
+      ComponentRegistry.register(owner, :both_gone, SomeComponent, component)
+
+      for {pid, ref} <- [{owner, Process.monitor(owner)}, {component, Process.monitor(component)}] do
+        send(pid, :stop)
+        assert_receive {:DOWN, ^ref, :process, ^pid, _}
+      end
+
+      assert Builtins.orphaned_component(%{}) == :ok
+    end
+  end
+
+  describe "dead_screen_in_nav/1" do
+    test "finds a dead screen the router is still holding" do
+      # A stub answering the same call `Mob.Router.entries/1` makes. Driving a
+      # real router cannot produce this state on demand — it restarts a killed
+      # screen — and a test that tolerates either outcome cannot fail, which is
+      # exactly how the first version of this passed with the check gutted.
+      dead = forever()
+      ref = Process.monitor(dead)
+      send(dead, :stop)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+      {:ok, stub} = FakeRouter.start_link([{NavScreen, dead}])
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(stub) end)
+
+      assert {:violation, %{count: 1, dead_entries: [entry]}} =
+               Builtins.dead_screen_in_nav(%{router: stub})
+
+      assert entry.module == NavScreen
+    end
+
+    test "a router holding only live screens is fine" do
+      {:ok, stub} = FakeRouter.start_link([{NavScreen, self()}])
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(stub) end)
+
+      assert Builtins.dead_screen_in_nav(%{router: stub}) == :ok
+    end
+
+    test "returns :ok without a router in the context" do
+      # A check that raises when its context is missing would be reported as a
+      # failed check on every sample at the wrong sampling point.
+      assert Builtins.dead_screen_in_nav(%{}) == :ok
+    end
+
+    test "returns :ok when the router itself is gone" do
+      router = forever()
+      ref = Process.monitor(router)
+      send(router, :stop)
+      assert_receive {:DOWN, ^ref, :process, ^router, _}
+
+      assert Builtins.dead_screen_in_nav(%{router: router}) == :ok
+    end
+  end
+
+  describe "Mob.Router.entries/1" do
+    test "returns every entry the router holds, with live pids" do
+      # A new public API this change adds, and the only reason
+      # dead_screen_in_nav can see pids at all. It had no coverage: making it
+      # return [] left the whole suite green.
+      {:ok, router} = Mob.Router.start_root(NavScreen, %{}, nif: Nif)
+      on_exit(fn -> Mob.Test.ProcessHelpers.stop_root(router) end)
+
+      entries = Mob.Router.entries(router)
+
+      assert [{NavScreen, pid}] = entries
+      assert is_pid(pid) and Process.alive?(pid)
+      assert pid == Mob.Router.get_screen_pid(router)
+    end
+  end
+
+  describe "the sampling point is actually wired" do
+    test "stopping a real screen samples :on_screen_stop" do
+      # The only production call site of this feature. Deleting it left 1642
+      # tests green.
+      Invariant.reset()
+      Invariant.unregister(:orphaned_component)
+      Invariant.unregister(:dead_screen_in_nav)
+
+      me = self()
+
+      Invariant.register(:probe,
+        at: :on_screen_stop,
+        severity: :warning,
+        check: fn ctx ->
+          send(me, {:sampled, ctx[:screen_module]})
+          :ok
+        end
+      )
+
+      {:ok, router} = Mob.Router.start_root(NavScreen, %{}, nif: Nif)
+      Mob.Test.ProcessHelpers.stop_root(router)
+
+      assert_receive {:sampled, NavScreen}, 1_000
+    end
+  end
+
+  describe "install/0 and the honest gap" do
+    test "the built-ins are installed without anyone calling install/0" do
+      # The production path: nothing in lib/ calls install/0 directly, the owner
+      # does it on first use. Both other tests here call it explicitly, which
+      # masked whether that path worked at all.
+      Invariant.reset()
+
+      names =
+        [:on_screen_stop, :periodic]
+        |> Enum.flat_map(&Invariant.registered/1)
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert names == [:dead_screen_in_nav, :orphaned_component]
+    end
+
+    test "registers exactly the checks that are implemented" do
+      Builtins.install()
+
+      registered =
+        (Invariant.registered(:on_screen_stop) ++ Invariant.registered(:periodic))
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert registered == [:dead_screen_in_nav, :orphaned_component]
+    end
+
+    test "no unimplemented check is silently registered" do
+      # MOB-156 names ten. Registering a name from `unimplemented/0` would mean
+      # the registry claims a check it does not run — the kind of overclaim this
+      # epic keeps having to retract.
+      Builtins.install()
+
+      registered =
+        [:on_screen_stop, :periodic, :after_committed_frame]
+        |> Enum.flat_map(&Invariant.registered/1)
+        |> MapSet.new(& &1.name)
+
+      for {name, _why} <- Builtins.unimplemented() do
+        refute MapSet.member?(registered, name),
+               "#{name} is listed as unimplemented but is registered"
+      end
+    end
+
+    test "install/0 is idempotent" do
+      Builtins.install()
+      Builtins.install()
+
+      assert length(Invariant.registered(:on_screen_stop)) == 1
+      assert length(Invariant.registered(:periodic)) == 1
+    end
+
+    test "every unimplemented entry names a check and says what it needs" do
+      # The list is the honest half of "ten checks": it has to stay specific
+      # enough to act on, not decay into a TODO.
+      entries = Builtins.unimplemented()
+
+      assert length(entries) == 8
+
+      for {name, why} <- entries do
+        assert name == :"#{name}", "#{inspect(name)} should be an atom naming the check"
+        assert String.length(why) > 20, "#{name} has no explanation of what is missing"
+      end
+    end
+  end
+end

--- a/test/mob/invariant_builtins_test.exs
+++ b/test/mob/invariant_builtins_test.exs
@@ -8,6 +8,13 @@ defmodule Mob.Invariant.BuiltinsTest do
   setup do
     Invariant.reset()
     Mob.Test.ProcessHelpers.ensure_component_registry()
+
+    # The registry is a global table and these tests deliberately leave orphans
+    # in it. Clearing it here keeps one test's leak out of the next one's
+    # assertions.
+    if ComponentRegistry.table() != :undefined,
+      do: :ets.delete_all_objects(ComponentRegistry.table())
+
     on_exit(&Invariant.reset/0)
     :ok
   end
@@ -28,8 +35,20 @@ defmodule Mob.Invariant.BuiltinsTest do
   defmodule NavScreen do
     @moduledoc false
     use Mob.Screen
+
     def mount(_p, _s, socket), do: {:ok, socket}
+
+    def handle_event("go_detail", _p, socket),
+      do: {:noreply, Mob.Socket.push_screen(socket, Mob.Invariant.BuiltinsTest.DetailScreen)}
+
     def render(_a), do: %{type: :text, props: %{text: "nav"}, children: []}
+  end
+
+  defmodule DetailScreen do
+    @moduledoc false
+    use Mob.Screen
+    def mount(_p, _s, socket), do: {:ok, socket}
+    def render(_a), do: %{type: :text, props: %{text: "detail"}, children: []}
   end
 
   defmodule Nif do
@@ -61,7 +80,7 @@ defmodule Mob.Invariant.BuiltinsTest do
       send(dead_owner, :stop)
       assert_receive {:DOWN, ^ref, :process, ^dead_owner, _}
 
-      assert {:violation, %{count: 1, orphans: [orphan]}} = Builtins.orphaned_component(%{})
+      assert {:violations, [orphan]} = Builtins.orphaned_component(%{})
       assert orphan.id == :leaky
       assert orphan.module == SomeComponent
 
@@ -95,6 +114,57 @@ defmodule Mob.Invariant.BuiltinsTest do
     end
   end
 
+  describe "a leak that grows" do
+    test "still confirms — one violation per orphan, not one carrying a list" do
+      # The shape a broken reaping path actually produces: one more orphan per
+      # navigation. Rolled into a single violation carrying a count, the details
+      # changed on every sample, the fingerprint changed with them, and nothing
+      # ever confirmed — the check saw the leak on 59 of 60 samples and reported
+      # zero. Per-orphan candidacy is what fixes it: the older orphans are stable
+      # while new ones accumulate.
+      Application.put_env(:mob, :invariant_min_candidate_age_us, 0)
+      on_exit(fn -> Application.delete_env(:mob, :invariant_min_candidate_age_us) end)
+
+      Invariant.reset()
+      Invariant.unregister(:dead_screen_in_nav)
+
+      reported =
+        for i <- 1..4 do
+          owner = forever()
+          component = forever()
+          ComponentRegistry.register(owner, :"grow#{i}", SomeComponent, component)
+          ref = Process.monitor(owner)
+          send(owner, :stop)
+          assert_receive {:DOWN, ^ref, :process, ^owner, _}
+
+          length(Invariant.run(:on_screen_stop, %{}))
+        end
+
+      assert hd(reported) == 0, "the first sighting is a candidate, not a report"
+
+      assert Enum.sum(reported) > 0,
+             "a growing leak never confirmed: #{inspect(reported)}"
+    end
+
+    test "caps how many orphans one sample reports" do
+      # Every reported violation is an ETS write on a teardown path, and a leak
+      # of a thousand is not a thousand times more informative than a leak of
+      # eight. The cap is also taken before building the maps — two inspect/1
+      # calls per orphan ran inside terminate/2 on the router's stop path.
+      for i <- 1..30 do
+        owner = forever()
+        component = forever()
+        ComponentRegistry.register(owner, :"many#{i}", SomeComponent, component)
+        ref = Process.monitor(owner)
+        send(owner, :stop)
+        assert_receive {:DOWN, ^ref, :process, ^owner, _}
+      end
+
+      assert {:violations, reported} = Builtins.orphaned_component(%{})
+      assert length(reported) == 8
+    end
+  end
+
   describe "dead_screen_in_nav/1" do
     test "finds a dead screen the router is still holding" do
       # A stub answering the same call `Mob.Router.entries/1` makes. Driving a
@@ -109,9 +179,7 @@ defmodule Mob.Invariant.BuiltinsTest do
       {:ok, stub} = FakeRouter.start_link([{NavScreen, dead}])
       on_exit(fn -> Mob.Test.ProcessHelpers.stop_pid(stub) end)
 
-      assert {:violation, %{count: 1, dead_entries: [entry]}} =
-               Builtins.dead_screen_in_nav(%{router: stub})
-
+      assert {:violations, [entry]} = Builtins.dead_screen_in_nav(%{router: stub})
       assert entry.module == NavScreen
     end
 
@@ -146,11 +214,22 @@ defmodule Mob.Invariant.BuiltinsTest do
       {:ok, router} = Mob.Router.start_root(NavScreen, %{}, nif: Nif)
       on_exit(fn -> Mob.Test.ProcessHelpers.stop_root(router) end)
 
+      assert [{NavScreen, first}] = Mob.Router.entries(router)
+      assert first == Mob.Router.get_screen_pid(router)
+
+      # History too, which is the half that matters: dead_screen_in_nav is only
+      # meaningful over history and parked tabs — the current entry is alive by
+      # construction. Returning just `state.current` left the suite green.
+      # Pushed the way the app does, through the screen's own handler.
+      Mob.Screen.dispatch(router, "go_detail", %{})
+
       entries = Mob.Router.entries(router)
 
-      assert [{NavScreen, pid}] = entries
-      assert is_pid(pid) and Process.alive?(pid)
-      assert pid == Mob.Router.get_screen_pid(router)
+      assert length(entries) == 2,
+             "entries/1 must report history, not only the current screen: #{inspect(entries)}"
+
+      assert Enum.sort(Enum.map(entries, fn {m, _} -> m end)) == [DetailScreen, NavScreen]
+      assert Enum.all?(entries, fn {_m, p} -> is_pid(p) and Process.alive?(p) end)
     end
   end
 

--- a/test/mob/invariant_test.exs
+++ b/test/mob/invariant_test.exs
@@ -124,6 +124,70 @@ defmodule Mob.InvariantTest do
       assert Invariant.violation_count() == 0
     end
 
+    test "the shipped default age floor is long enough to outlast a teardown" do
+      # The floor's *default* is the half of the rule that does the work, and
+      # setting it to 0 left the whole suite green. This drives two samples
+      # microseconds apart with the env var unset, which is what a multi-screen
+      # reset does, and asserts nothing is reported.
+      Application.delete_env(:mob, :invariant_min_candidate_age_us)
+      register(:fast_pair, fn _ctx -> {:violation, %{stable: true}} end)
+
+      assert Invariant.run(:periodic) == []
+      assert Invariant.run(:periodic) == []
+      assert Invariant.run(:periodic) == []
+
+      assert Invariant.violation_count() == 0,
+             "two samples microseconds apart confirmed a violation — the age floor is too low"
+    end
+
+    test "a violation that disappears and returns identically does not confirm" do
+      # Appear / resolve / reappear is not "continuously present". Keeping the
+      # candidate across the gap would report something that was never a
+      # sustained breach.
+      counter = :counters.new(1, [])
+
+      register(:blinking, fn _ctx ->
+        n = :counters.get(counter, 1)
+        :counters.add(counter, 1, 1)
+        if rem(n, 2) == 0, do: {:violation, %{same: :always}}, else: :ok
+      end)
+
+      for _ <- 1..6, do: Invariant.run(:periodic)
+
+      assert Invariant.violation_count() == 0
+    end
+
+    test "a candidate whose violation is gone is dropped, even while others remain" do
+      # Pruning is per violation, not all-or-nothing. When one problem resolves
+      # while another persists, the resolved one's candidate must go — otherwise
+      # if it comes back it confirms on sight, having never been continuously
+      # present.
+      step = :counters.new(1, [])
+
+      register(:mixed, fn _ctx ->
+        n = :counters.get(step, 1)
+        :counters.add(step, 1, 1)
+
+        case n do
+          # b present, then gone while a stays, then back.
+          0 -> {:violations, [%{id: :a}, %{id: :b}]}
+          1 -> {:violations, [%{id: :a}]}
+          _ -> {:violations, [%{id: :a}, %{id: :b}]}
+        end
+      end)
+
+      assert Invariant.run(:periodic) == []
+
+      assert Enum.map(Invariant.run(:periodic), & &1.details.id) == [:a],
+             "only the violation still present should confirm"
+
+      assert Enum.map(Invariant.run(:periodic), & &1.details.id) == [],
+             "b returned after resolving, so it starts a fresh candidacy rather " <>
+               "than confirming on sight"
+
+      assert Enum.sort(Enum.map(Invariant.run(:periodic), & &1.details.id)) == [:a, :b]
+    end
+
     test "an intermittent violation is reported once it repeats identically" do
       register(:same_again, fn _ctx -> {:violation, %{identity: :stable}} end)
 

--- a/test/mob/invariant_test.exs
+++ b/test/mob/invariant_test.exs
@@ -188,6 +188,37 @@ defmodule Mob.InvariantTest do
       assert Enum.sort(Enum.map(Invariant.run(:periodic), & &1.details.id)) == [:a, :b]
     end
 
+    test "concurrent samplers still confirm — the mechanism must not starve" do
+      # `Mob.Router` start_links its screens, so a router exit runs terminate/2,
+      # and this sampling point, in every live screen at once. An earlier
+      # version used :ets.take and re-inserted a too-young candidate; with three
+      # samplers in flight a stale first_seen could be written back, the
+      # candidate's age never grew, and a permanently-present violation was
+      # confirmed ZERO times. It failed silently, under exactly the condition
+      # its own comment claimed to handle.
+      # A real age floor is required for this to bite: with the floor at 0 the
+      # first sampler confirms immediately and there is no aging window to
+      # starve. 20ms is enough to need several samples.
+      Application.put_env(:mob, :invariant_min_candidate_age_us, 20_000)
+      register(:under_load, fn _ctx -> {:violation, %{stable: true}} end)
+
+      deadline = System.monotonic_time(:millisecond) + 400
+
+      1..4
+      |> Task.async_stream(
+        fn _ ->
+          Stream.repeatedly(fn -> Invariant.run(:periodic) end)
+          |> Enum.take_while(fn _ -> System.monotonic_time(:millisecond) < deadline end)
+        end,
+        max_concurrency: 4,
+        timeout: 5_000
+      )
+      |> Stream.run()
+
+      assert Invariant.violation_count() > 0,
+             "four concurrent samplers confirmed nothing — the candidate clock is being reset"
+    end
+
     test "an intermittent violation is reported once it repeats identically" do
       register(:same_again, fn _ctx -> {:violation, %{identity: :stable}} end)
 

--- a/test/mob/invariant_test.exs
+++ b/test/mob/invariant_test.exs
@@ -1,0 +1,241 @@
+defmodule Mob.InvariantTest do
+  use ExUnit.Case, async: false
+
+  alias Mob.Invariant
+  alias Mob.Invariant.Violation
+
+  setup do
+    # Confirmation also requires a minimum candidate age. These tests sample
+    # back-to-back, so the floor is removed here and asserted on its own below.
+    Application.put_env(:mob, :invariant_min_candidate_age_us, 0)
+    on_exit(fn -> Application.delete_env(:mob, :invariant_min_candidate_age_us) end)
+
+    Invariant.reset()
+
+    # `reset/0` deliberately keeps the built-ins registered — an earlier version
+    # wiped them and left the framework's shipped diagnostics permanently off.
+    # These tests want an empty registry, so they drop them explicitly; the
+    # preservation itself is asserted in its own test below.
+    for {name, _} <- [orphaned_component: 1, dead_screen_in_nav: 1],
+        do: Invariant.unregister(name)
+
+    on_exit(&Invariant.reset/0)
+    :ok
+  end
+
+  test "reset/0 keeps the built-in checks registered" do
+    # Wiping them left the shipped diagnostics off for the life of the owner,
+    # and nothing re-installed them: `start/0` short-circuits once the table
+    # exists.
+    Invariant.reset()
+
+    names =
+      [:on_screen_stop, :periodic]
+      |> Enum.flat_map(&Invariant.registered/1)
+      |> Enum.map(& &1.name)
+      |> Enum.sort()
+
+    assert names == [:dead_screen_in_nav, :orphaned_component]
+  end
+
+  defp register(name, check, opts \\ []) do
+    Invariant.register(name,
+      at: Keyword.get(opts, :at, :periodic),
+      severity: Keyword.get(opts, :severity, :warning),
+      check: check
+    )
+  end
+
+  describe "the confirmation rule" do
+    # The whole design. Every check reads live state from concurrently changing
+    # processes, so a single sample sees transients constantly — a screen
+    # mid-teardown looks exactly like a leak. Confirmation is deferred to the
+    # NEXT sampling of the point, because that is the only version with real
+    # time separation: an earlier version re-ran the check back-to-back and was
+    # measured filtering ~0% of the transients it was written for.
+
+    test "a violation seen once is held, not reported" do
+      register(:once, fn _ctx -> {:violation, %{real: true}} end)
+
+      assert Invariant.run(:periodic) == []
+      assert Invariant.violation_count() == 0
+    end
+
+    test "a violation still there at the next sample is reported" do
+      register(:persistent, fn _ctx -> {:violation, %{real: true}} end)
+
+      assert Invariant.run(:periodic) == []
+
+      assert [%Violation{invariant: :persistent, details: %{real: true}}] =
+               Invariant.run(:periodic)
+
+      assert Invariant.violation_count() == 1
+    end
+
+    test "a transient that has resolved by the next sample is never reported" do
+      # The case the rule exists for: seen once, gone by the time anyone looks
+      # again. This is what a screen mid-teardown produces.
+      counter = :counters.new(1, [])
+
+      register(:transient, fn _ctx ->
+        case :counters.get(counter, 1) do
+          0 ->
+            :counters.add(counter, 1, 1)
+            {:violation, %{gone_next_time: true}}
+
+          _ ->
+            :ok
+        end
+      end)
+
+      assert Invariant.run(:periodic) == []
+      assert Invariant.run(:periodic) == []
+      assert Invariant.violation_count() == 0
+    end
+
+    test "a different violation at the next sample does not confirm the first" do
+      # Two unrelated transients in a row must not vouch for each other, which
+      # is why sameness is by fingerprint over the details rather than by the
+      # check merely having failed twice.
+      counter = :counters.new(1, [])
+
+      register(:changing, fn _ctx ->
+        n = :counters.get(counter, 1)
+        :counters.add(counter, 1, 1)
+        {:violation, %{which: n}}
+      end)
+
+      assert Invariant.run(:periodic) == []
+      assert Invariant.run(:periodic) == []
+      assert Invariant.violation_count() == 0
+    end
+
+    test "a candidate younger than the age floor is not confirmed yet" do
+      # Sampling points are event-driven, so "the next sample" can arrive almost
+      # immediately: the router stops screens in a tight loop, and a component
+      # still being reaped was seen twice in under a millisecond. A real leak
+      # persists and does not notice the wait.
+      Application.put_env(:mob, :invariant_min_candidate_age_us, 5_000_000)
+      register(:too_young, fn _ctx -> {:violation, %{stable: true}} end)
+
+      assert Invariant.run(:periodic) == []
+      assert Invariant.run(:periodic) == []
+      assert Invariant.run(:periodic) == []
+      assert Invariant.violation_count() == 0
+    end
+
+    test "an intermittent violation is reported once it repeats identically" do
+      register(:same_again, fn _ctx -> {:violation, %{identity: :stable}} end)
+
+      assert Invariant.run(:periodic) == []
+      assert [%Violation{}] = Invariant.run(:periodic)
+
+      # The candidate is consumed, so the next sighting starts over rather than
+      # reporting the same violation on every subsequent sample.
+      assert Invariant.run(:periodic) == []
+    end
+  end
+
+  describe "isolation from the thing being observed" do
+    test "a check that raises is reported, not propagated" do
+      # A diagnostic that can crash the process sampling it is worse than no
+      # diagnostic. `terminate/2` calls this.
+      register(:explodes, fn _ctx -> raise "check blew up" end)
+
+      # A check that keeps raising is a stable violation, so it confirms on the
+      # second sample like any other.
+      assert Invariant.run(:periodic) == []
+      assert [%Violation{details: details}] = Invariant.run(:periodic)
+      assert details.invariant_check_failed == :explodes
+      assert details.exception == RuntimeError
+    end
+
+    test "a check that throws is reported, not propagated" do
+      register(:throws, fn _ctx -> throw(:nope) end)
+
+      Invariant.run(:periodic)
+      assert [%Violation{details: %{invariant_check_failed: :throws}}] = Invariant.run(:periodic)
+    end
+
+    test "one broken check does not stop the others running" do
+      register(:broken, fn _ctx -> raise "boom" end)
+      register(:fine, fn _ctx -> {:violation, %{ok: true}} end)
+
+      Invariant.run(:periodic)
+      names = Invariant.run(:periodic) |> Enum.map(& &1.invariant) |> Enum.sort()
+      assert names == [:broken, :fine]
+    end
+  end
+
+  describe "registry" do
+    test "checks only run at their own sampling point" do
+      register(:at_stop, fn _ctx -> {:violation, %{}} end, at: :on_screen_stop)
+      register(:at_periodic, fn _ctx -> {:violation, %{}} end, at: :periodic)
+
+      Invariant.run(:periodic)
+      Invariant.run(:on_screen_stop)
+
+      assert [%Violation{invariant: :at_periodic}] = Invariant.run(:periodic)
+      assert [%Violation{invariant: :at_stop}] = Invariant.run(:on_screen_stop)
+    end
+
+    test "re-registering a name replaces it rather than duplicating" do
+      # A hot code push re-runs `install/0`; accumulating duplicates would
+      # multiply both the cost and the reports.
+      register(:same, fn _ctx -> :ok end)
+      register(:same, fn _ctx -> {:violation, %{}} end)
+
+      assert length(Invariant.registered(:periodic)) == 1
+      Invariant.run(:periodic)
+      assert [%Violation{invariant: :same}] = Invariant.run(:periodic)
+    end
+
+    test "unregister removes a check" do
+      register(:temp, fn _ctx -> {:violation, %{}} end)
+      Invariant.unregister(:temp)
+
+      assert Invariant.run(:periodic) == []
+    end
+
+    test "severity and sampling point are carried onto the violation" do
+      register(:tagged, fn _ctx -> {:violation, %{}} end, severity: :critical, at: :periodic)
+
+      Invariant.run(:periodic)
+      assert [%Violation{severity: :critical, at: :periodic}] = Invariant.run(:periodic)
+    end
+  end
+
+  describe "violation store" do
+    test "is bounded, keeping the newest" do
+      # Same details each time so every pair confirms; the counter distinguishes
+      # nothing, which is what makes 200 samples produce 100 recordings.
+      register(:always, fn _ctx -> {:violation, %{stable: true}} end)
+
+      for _ <- 1..400, do: Invariant.run(:periodic)
+
+      assert Invariant.violation_count() == 128
+      assert [%Violation{invariant: :always} | _] = Invariant.violations(1)
+    end
+  end
+
+  describe "cost_us/2" do
+    test "reports a number for the checks actually registered" do
+      # Invariants ship in release builds, so the cost is real and has to be
+      # measurable on the device that matters rather than estimated on a laptop.
+      register(:cheap, fn _ctx -> :ok end)
+
+      assert is_integer(Invariant.cost_us(:periodic))
+      assert Invariant.cost_us(:periodic) >= 0
+    end
+
+    test "does not record violations while measuring" do
+      # Measuring must not pollute the report stream, or a budget check on a
+      # device becomes a source of defects.
+      register(:violating, fn _ctx -> {:violation, %{}} end)
+
+      Invariant.cost_us(:periodic)
+      Invariant.cost_us(:periodic)
+      assert Invariant.violation_count() == 0
+    end
+  end
+end


### PR DESCRIPTION
Closes MOB-156. Phase 2 of the MOB-149 epic.

The framework can assert things application code cannot: that no component outlives the screen that owns it, that no dead screen sits in a navigation stack. It has the handles; the app does not. Three of the four agents surveyed in MOB-149 named the component-ownership/handle-leak class independently, which is why it leads.

## The hazard is not writing the checks

Every check reads live state from processes that are concurrently changing. A screen mid-teardown has a dead pid and components not yet reaped, and a check sampling that instant sees a leak that resolves itself shortly after. Report it and you produce a defect nobody can reproduce — which teaches the reader to ignore the channel, and then the real one arrives.

## My first answer to that was decorative, and the review measured it

I re-ran the check immediately, back to back in the same process, and asserted in four places that this was "the whole design". It compares two observations about a microsecond apart while the transients last tens to hundreds, so it filtered **~0%** of them — and the shipped check reported a confirmed `:critical` on **60 of 60 healthy teardowns**, the exact outcome the design exists to prevent. Two evaluations a microsecond apart cannot disagree.

**Confirmation is now deferred to the next sampling of that point**, keyed by a fingerprint over the violation's details so a *different* transient cannot confirm an earlier one. That alone still left ~1 false positive in 60, because sampling points are event-driven and the router stops screens in a tight loop — so a candidate must also be **50ms old**. A real leak does not notice the wait; a reap in progress does.

| | back-to-back | deferred | deferred + age floor |
|---|---|---|---|
| confirmed violations, 60 healthy teardowns | 60 | 1 | **0** |
| injected regression still caught | yes | yes | **yes** |

The regression is injected by disabling the `{:DOWN, ...}` clause in `Mob.ComponentServer` — the exact mechanism the invariant guards. First sample holds a candidate, second reports it.

## Four of six mutations left the suite green

The review's table, now closed: deleting the feature's **only production call site** (`Screen.Server.terminate/2`), `Mob.Router.entries/1` returning `[]`, `dead_screen_in_nav` never violating, and removing `Builtins.install/0` from the owner. All four now fail. The `dead_screen_in_nav` test runs against a stub, because a real router restarts a killed screen and my first version hedged with a `case` accepting either outcome — a test that cannot fail.

## Also fixed from the review

- **`reset/0` wiped the built-ins it had just installed**, leaving the shipped diagnostics off for the life of the owner and leaking an empty registry across the test suite. Objects are cleared before the reload now.
- **Cost**: `orphaned_component` built a map with two `inspect/1` calls for *every* orphan and then kept eight — 1764µs at 1000 orphans, inside `terminate/2`, on the router's synchronous stop path. Takes eight first and reads via a match spec instead of `tab2list/1` (which was also copying the reverse index): **82µs**.

| registry contents | µs per sample, through `run/2` |
|---|---|
| empty | 1.6 |
| 100 live | 7.0 |
| 1000 live | 62.6 |
| 100 orphaned | 16.2 |
| 1000 orphaned | 81.6 |

- "An app that never touches an invariant pays nothing" was false — `terminate/2` samples unconditionally. Corrected.

## Stated plainly rather than papered over

- **`dead_screen_in_nav` is registered for `:periodic`, and nothing drives `:periodic` yet.** It is deliberately *not* moved to `:on_screen_stop`: that samples inside the screen the router is synchronously stopping, so a check calling back into the router would deadlock until both 5s timeouts expire and the router then kills the screen. Driving it belongs with the defect bus in MOB-159.
- **`:on_screen_stop` never sees the stopping screen's own components** — it is still alive, running its own `terminate/2`. It sees what an *earlier* screen left behind.
- **Eight of the ten checks MOB-156 names are unimplemented**, listed in `Builtins.unimplemented/0` as data with what each needs, and a test asserts none is ever silently registered.
- Nothing consumes violations yet; `violations/1` is the read surface.

1651 tests (from 1620), 8 consecutive clean full-suite runs, credo and format clean.

Record: `decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)