### PR TITLE
MOB-159 phase 1: defect capsule, bus, and owner attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Defect bus — `Mob.Defect`, `Mob.Defect.Capsule`, `Mob.Defect.Bus`,
+  `Mob.Defect.Sinks.Dev`** (MOB-159, phase 1). Capture + dedup + attribution
+  for defects the framework detects — steps 1-3 of the incident-to-draft-PR
+  loop. Not the loop itself; no auto-action, no auto-PR.
+
+  `Mob.Defect.Capsule` is the `mob.defect/1` schema from
+  `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md` in Elixir:
+  `Capsule.new/1` builds the struct, populates `build` and `device`
+  automatically, tags `redaction: :applied` on the caller-trust contract,
+  and truncates evidence at 4096 bytes per string / 64 elements per list /
+  8 levels of depth so a malicious deep term cannot exhaust the packager.
+  `fingerprint/3` is a sha256 over `kind + owner + fingerprint_key` only —
+  time, id, build and device are excluded so a defect groups across
+  releases and devices. `to_json/1` produces the wire form; the whole
+  capsule round-trips through Jason.
+
+  `Mob.Defect.Bus` is an in-process pub/sub with two ETS tables (a
+  `classes` set keyed by fingerprint that carries the first capsule and an
+  occurrences counter, and a bounded ring of the 64 most-recent capsules).
+  `emit/1` is on the write path — no GenServer round-trip, mirroring
+  `Mob.Agent.Receipts.record/1`. Subscribers are stored in
+  `:persistent_term` and monitored by the owner GenServer so a subscriber
+  exit prunes itself; a dead pid in the fanout list is a no-op because
+  `send/2` does not raise on a dead pid.
+
+  `Mob.Defect.Sinks.Dev` is an opt-in GenServer that subscribes on
+  `init/1` and Logger-writes each capsule at a severity-driven level
+  (`:fatal` / `:critical` → `error`, `:warning` → `warning`, else `info`).
+  Not started by default — per the decision record, mob owns the format
+  and the bus but never the destination.
+
+  `Mob.Defect.emit_invariant_violation/1` and `emit_divergence/2`
+  encapsulate the mapping from a detector's native shape (`Mob.Invariant.Violation`,
+  `Mob.Differential`'s divergence map) to a capsule with the right owner,
+  kind, and fingerprint key.
+
+  Wired: `Mob.Invariant.record/1` now emits a capsule for every confirmed
+  violation. Not wired in this PR: the differential emit-point is a
+  follow-up mob_dev change that lands after this ships to Hex.
+
+  See `decisions/2026-09-11-fingerprint-and-evidence-are-separate.md` for
+  the fingerprint-vs-evidence design.
+
+---
+
 ## [0.8.0] - 2026-09-11
 
 ### Added

--- a/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
+++ b/decisions/2026-09-10-an-invariant-must-survive-to-the-next-sample.md
@@ -177,5 +177,11 @@ sampler can remove a given row, and the clock only ever moves forward.
   leaving to be discovered.
 - Violations are bounded at 128 and carry **no application state** — pids,
   module names and counts only, the same rule receipts follow.
-- Nothing consumes violations yet. There is no defect bus; `violations/1` is the
-  read surface. Wiring them to a sink is MOB-159's job.
+- ~~Nothing consumes violations yet. There is no defect bus; `violations/1` is the
+  read surface. Wiring them to a sink is MOB-159's job.~~ **Superseded by
+  MOB-159 phase 1 (2026-09-11):** `Mob.Invariant.record/1` now emits every
+  confirmed violation as a `Mob.Defect.Capsule` on `Mob.Defect.Bus`.
+  `violations/1` remains the direct read surface for a caller that wants the
+  registry's own state; the bus is the read surface for anyone subscribing to
+  the framework's defects as a stream. See
+  `decisions/2026-09-11-fingerprint-and-evidence-are-separate.md`.

--- a/decisions/2026-09-11-fingerprint-and-evidence-are-separate.md
+++ b/decisions/2026-09-11-fingerprint-and-evidence-are-separate.md
@@ -1,0 +1,77 @@
+# Fingerprint and evidence are separate inputs to a defect
+
+- Date: 2026-09-11
+- Status: accepted
+
+## Context
+
+`Mob.Defect.Capsule.new/1` takes both a `fingerprint_key` and an
+`evidence` map, and the two overlap: `emit_invariant_violation/1` puts
+`%{invariant, screen}` in the key and `%{invariant, screen, at, details}`
+in evidence. That is deliberate, but it looks redundant, and the temptation
+when adding a new detector is to fold them into one map. This record exists
+to say why they are two.
+
+The single-map version is:
+
+    Capsule.new(kind: :invariant, owner: :mob, severity: :critical,
+                evidence: %{invariant: name, screen: screen, at: at, details: details})
+
+...with the fingerprint computed over the whole `evidence` map. Simpler to
+write. Reasonable-looking. Wrong in a way that only appears on the second
+release.
+
+## Decision
+
+The **fingerprint** is computed over `kind`, `owner`, and the
+`fingerprint_key` map. Nothing in `evidence` beyond what the caller
+explicitly put in `fingerprint_key` participates.
+
+Callers put in the key exactly what identifies the defect *class* — the
+invariant name plus the screen, the fixture plus the divergence reason plus
+the path — and nothing that describes the individual occurrence.
+
+## Consequences
+
+**Enrichment does not shatter groups.** Adding an `os_locale` field to the
+evidence of an invariant capsule in mob 0.9 does not split every existing
+triage item in two, because that field is not in the key. A defect that
+occurred in 0.8 and 0.9 stays one row on the triage list. Without this
+split, the fingerprint would change the moment we noticed a useful new
+detail to attach.
+
+**Two occurrences that agree in key but disagree in evidence still group.**
+This is the point. A leaked-component invariant that lists three pids on
+one device and four on another is still the same class of defect. The
+fingerprint says so; the class row keeps the first capsule's evidence to
+avoid presenting a moving target; the recent-ring holds the raw
+occurrences for anyone drilling in.
+
+**Callers must be disciplined about the key.** If a detector puts the
+`monotonic_us` timestamp in the key, every occurrence gets a new
+fingerprint and dedup does not work. If it puts an empty map, every defect
+of that `kind` collides onto one row. Both failure modes are visible
+immediately — a `classes/1` listing that grows unboundedly, or one that
+stays at one row while occurrences climb. The mapping to construct the
+key is centralised in `Mob.Defect` so a caller does not need to invent
+one; new detectors add a function there and inherit the discipline.
+
+The kind-of-thing that goes in `fingerprint_key` is a defect class
+identifier. Anything derivable at debug time from a stack trace or a
+module name qualifies; anything that changes between two invocations of
+the same defect does not. The moduledoc on `Mob.Defect.Capsule` lists
+what is excluded by construction (`id`, `detected_at`, `build.*`,
+`device.*`) so this discipline shows up in the type.
+
+## Alternatives considered
+
+**One-map fingerprint over `evidence`.** Ruled out: enriching evidence
+changes the fingerprint, so improving the report shatters the triage
+history the report was meant to build.
+
+**Include the full first capsule in the class row and hash *its* stable
+subset.** Two problems. First, the "stable subset" needs the same key
+definition anyway, so the split moves rather than disappears. Second,
+recomputing hashes on every emit is wasted work: the caller already
+knows what defines the defect, and asking them for a small map is
+cheaper than asking every reader to recompute one from a big struct.

--- a/lib/mob/defect.ex
+++ b/lib/mob/defect.ex
@@ -1,0 +1,90 @@
+defmodule Mob.Defect do
+  @moduledoc """
+  Entry points that convert what the framework's detectors produce into
+  capsules on the defect bus.
+
+  The framework's detectors have their own shapes — an invariant violation is
+  a `Mob.Invariant.Violation`, a divergence is the `{:divergence, %{...}}` a
+  comparator returns. Rather than teach each detector to build a capsule,
+  those detectors call the appropriate function here and this module supplies
+  the fingerprint key, the owner, and the evidence shape.
+
+  Centralising the mapping is what keeps `owner: :mob` from being copied into
+  five places, and what makes the fingerprint key for the same kind of defect
+  identical across detectors — the whole point of a fingerprint is that a
+  divergence detected on iOS from mob_dev and the same divergence detected
+  on-device from a fallback path land on the same triage item.
+
+  ## Nothing propagates on the return path
+
+  Every function here returns the capsule it built, but the emit is a
+  side-effect on the bus and the caller does not need to do anything with
+  the return value. That matches the shape of `Mob.Agent.Receipts.record/1`
+  and lets a caller drop the emit onto an existing pipeline without
+  restructuring around a result.
+  """
+
+  alias Mob.Defect.{Bus, Capsule}
+
+  @doc """
+  Emit a defect for a confirmed invariant violation.
+
+  Owner is `:mob` — invariants are checks the framework makes about itself,
+  and by construction they cannot fail for the app. `kind: :invariant`.
+
+  The fingerprint key is `%{invariant: name, screen: screen_module}`, so a
+  violation of the same invariant on the same screen groups across
+  occurrences, and the same invariant on a different screen — a leak class
+  that appears in two places — reports separately.
+  """
+  @spec emit_invariant_violation(Mob.Invariant.Violation.t()) :: Capsule.t()
+  def emit_invariant_violation(%Mob.Invariant.Violation{} = v) do
+    Capsule.new(
+      kind: :invariant,
+      owner: :mob,
+      severity: v.severity,
+      fingerprint_key: %{invariant: v.invariant, screen: v.screen},
+      evidence: %{
+        invariant: v.invariant,
+        screen: v.screen,
+        at: v.at,
+        details: v.details
+      }
+    )
+    |> Bus.emit()
+  end
+
+  @doc """
+  Emit a defect for a differential-comparator divergence.
+
+  Owner is `:mob` — the differential comparator asserts one design, both
+  platforms, which is a framework-level promise. `kind: :divergence`.
+
+  The fingerprint key includes the fixture (so the same divergence in two
+  fixtures reports separately), the `reason` (`:type`, `:label`, `:frame`,
+  `:child_count`), and the `path` to the diverging node. The `ios` and
+  `android` values are on evidence, not on the fingerprint key — a fixture's
+  divergence in kind (say, always `:type` at `[0, 2]`) is the same class
+  even if the tree values change slightly across releases.
+  """
+  @spec emit_divergence(map(), keyword() | map()) :: Capsule.t()
+  def emit_divergence(%{path: path, reason: reason, ios: ios, android: android}, opts \\ []) do
+    opts = Map.new(opts)
+    fixture = Map.get(opts, :fixture)
+
+    Capsule.new(
+      kind: :divergence,
+      owner: :mob,
+      severity: Map.get(opts, :severity, :warning),
+      fingerprint_key: %{fixture: fixture, reason: reason, path: path},
+      evidence: %{
+        fixture: fixture,
+        reason: reason,
+        path: path,
+        ios: ios,
+        android: android
+      }
+    )
+    |> Bus.emit()
+  end
+end

--- a/lib/mob/defect.ex
+++ b/lib/mob/defect.ex
@@ -57,6 +57,12 @@ defmodule Mob.Defect do
   @doc """
   Emit a defect for a differential-comparator divergence.
 
+  Real entrypoint, pending an in-tree caller. `Mob.Differential.compare/3`
+  is a pure comparator; the caller that runs it — currently `mob_dev`, via
+  `MobDev.Differential.run/3` — invokes this after a `:divergence` result to
+  put the class onto the bus. A follow-up mob_dev change wires that up
+  after this ships to Hex; nothing in `mob` itself calls this yet.
+
   Owner is `:mob` — the differential comparator asserts one design, both
   platforms, which is a framework-level promise. `kind: :divergence`.
 

--- a/lib/mob/defect/bus.ex
+++ b/lib/mob/defect/bus.ex
@@ -1,0 +1,274 @@
+defmodule Mob.Defect.Bus do
+  @moduledoc """
+  The bounded record of defects the framework has emitted, and the fanout to
+  whoever subscribed to hear about them.
+
+  ## Deduplication
+
+  Every emit goes through `fingerprint`. One thousand emits of the same bug
+  produce one class row whose occurrence counter reaches 1000 as each one
+  lands, with the first-seen capsule held for the class and `last_seen_ms`
+  moving forward. That is what makes the channel usable — a report system
+  that emitted a thousand rows per bug would train its readers to stop
+  reading it.
+
+  The counter and last-seen fields are read directly from the row on each
+  call to `classes/1`; both are updated by atomic ETS ops on the write path
+  (`update_counter` and `update_element`), so a listing is consistent under
+  concurrency down to the individual row.
+
+  A parallel bounded ring keeps the most recent 64 raw capsules, keyed by
+  sequence, for the case where a triager wants to walk through occurrences
+  rather than classes. Ring rather than unbounded because a capsule is packaged
+  memory in a production app, and defect-report storage that grows without
+  limit is worse than a bug it might have described.
+
+  ## Fanout without a mailbox on the hot path
+
+  Same reasoning as `Mob.Agent.Receipts`: an `emit/1` is on the path of every
+  detected defect, and putting a GenServer in front of that path serialises
+  every writer through one mailbox. The bus's owner GenServer holds the
+  subscriber registry and monitors, and it publishes the *cached* subscriber
+  pid list to `:persistent_term` — the write path reads that once and sends to
+  each pid directly. A subscriber lifecycle change is a rare event; a defect
+  emit is not.
+
+  ## No default sink
+
+  A subscriber is a pid, and no pid is subscribed until an app registers one.
+  Per the decision record, mob owns the format and the bus; it never owns a
+  destination. The dev sink in `Mob.Defect.Sinks.Dev` is what a connected
+  agent runs at its end after `mix mob.connect`.
+
+  ## Subscribers must not crash the emit path
+
+  A subscriber pid is a `send/2` target on the emit path. `send/2` never
+  blocks and never raises on a dead pid, so a dead subscriber does not take
+  down the emitter — the monitor in the owner catches the DOWN and prunes the
+  pid from the cached list. But the *contents* of what a subscriber does with
+  the message must not affect the emitter, which is the standard contract of
+  message passing and not enforced here.
+  """
+
+  require Logger
+
+  alias Mob.Defect.Capsule
+
+  @classes :mob_defect_classes
+  @recent :mob_defect_recent
+  @subscribers_key :mob_defect_subscribers
+  @state :mob_defect_state
+  @keep_recent 64
+
+  # ---------------------------------------------------------------------------
+  # Startup
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  @spec start() :: :ok
+  def start do
+    if :ets.whereis(@classes) == :undefined, do: Mob.Defect.Bus.Owner.start()
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Emit a capsule.
+
+  Records the class (incrementing occurrences), appends to the recent-ring,
+  and fans out to every subscribed pid as `{:mob_defect, capsule}`.
+
+  Returns the capsule, so this can sit at the end of a pipeline.
+  """
+  @spec emit(Capsule.t()) :: Capsule.t()
+  def emit(%Capsule{} = capsule) do
+    start()
+
+    record_class(capsule)
+    record_recent(capsule)
+    fanout(capsule)
+
+    capsule
+  end
+
+  @doc """
+  Every defect class currently held, newest first by `last_seen_at`.
+
+  A class row carries the *first* capsule seen for that fingerprint plus the
+  occurrence count and last-seen timestamp. Later occurrences are on the
+  recent ring, not layered onto the class — that keeps the class row a
+  bounded shape regardless of how noisy the defect gets.
+  """
+  @spec classes(pos_integer()) :: [map()]
+  def classes(limit \\ 20) do
+    start()
+
+    @classes
+    |> :ets.tab2list()
+    |> Enum.map(fn {_fp, base_row, occurrences, last_seen_ms} ->
+      # `base_row` is written exactly once (on the first emit for this
+      # fingerprint) with `occurrences: 1` and `last_seen_ms` equal to that
+      # first-seen time. Overlay the two live atomic fields so a reader sees
+      # a class row that is consistent with the counter and last-seen a
+      # concurrent writer just advanced.
+      base_row
+      |> Map.put(:occurrences, occurrences)
+      |> Map.put(:last_seen_ms, last_seen_ms)
+    end)
+    |> Enum.sort_by(& &1.last_seen_ms, :desc)
+    |> Enum.take(limit)
+  end
+
+  @doc "How many distinct defect classes are held."
+  @spec class_count() :: non_neg_integer()
+  def class_count do
+    start()
+    :ets.info(@classes, :size)
+  end
+
+  @doc "The most recent capsules (raw occurrences), newest first."
+  @spec recent(pos_integer()) :: [Capsule.t()]
+  def recent(limit \\ 20) do
+    start()
+
+    @recent
+    |> :ets.tab2list()
+    |> Enum.sort_by(fn {seq, _c} -> -seq end)
+    |> Enum.take(limit)
+    |> Enum.map(fn {_seq, c} -> c end)
+  end
+
+  @doc """
+  Subscribe the calling process to defect emits.
+
+  Returns `{:ok, ref}` — the caller can keep the ref for its own bookkeeping,
+  but does not need it to unsubscribe (unsubscription is by pid).
+  Idempotent: subscribing an already-subscribed pid is a no-op.
+
+  The subscriber's process is monitored; a subscriber exit prunes it from
+  the cached list.
+  """
+  @spec subscribe() :: {:ok, reference()}
+  @spec subscribe(pid()) :: {:ok, reference()}
+  def subscribe(pid \\ self()) do
+    start()
+    Mob.Defect.Bus.Owner.subscribe(pid)
+  end
+
+  @doc "Unsubscribe `pid` (defaults to `self()`)."
+  @spec unsubscribe() :: :ok
+  @spec unsubscribe(pid()) :: :ok
+  def unsubscribe(pid \\ self()) do
+    start()
+    Mob.Defect.Bus.Owner.unsubscribe(pid)
+  end
+
+  @doc "The subscribers the write path will fan out to right now."
+  @spec subscribers() :: [pid()]
+  def subscribers do
+    start()
+    :persistent_term.get(@subscribers_key, [])
+  end
+
+  @doc false
+  @spec reset() :: :ok
+  def reset do
+    for t <- [@classes, @recent] do
+      if :ets.whereis(t) != :undefined, do: :ets.delete_all_objects(t)
+    end
+
+    if state = safe_state(), do: :atomics.put(state.seq, 1, 0)
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Write path
+  # ---------------------------------------------------------------------------
+
+  defp record_class(%Capsule{} = c) do
+    now_ms = System.system_time(:millisecond)
+
+    # Tuple layout: {fingerprint, base_row, occurrences, last_seen_ms}. The
+    # counter increments position 3 atomically; last_seen writes position 4
+    # atomically; the base_row at position 2 is written once (via the default
+    # tuple below on first insert) and never touched again. `classes/1`
+    # overlays live position 3 and position 4 onto the immutable base_row on
+    # read — no read-modify-write on the write path, so concurrent writers
+    # cannot clobber each other into a stale derived cache.
+    default = {c.fingerprint, first_seen_row(c, now_ms), 0, now_ms}
+    _new_occurrences = :ets.update_counter(@classes, c.fingerprint, {3, 1}, default)
+    :ets.update_element(@classes, c.fingerprint, {4, now_ms})
+    :ok
+  end
+
+  # base_row's `occurrences` and `last_seen_ms` fields are placeholders — the
+  # authoritative values live at positions 3 and 4 of the tuple and `classes/1`
+  # reads them from there. Kept in the map for shape compatibility with a
+  # reader that never joined the two.
+  defp first_seen_row(%Capsule{} = c, now_ms) do
+    %{
+      fingerprint: c.fingerprint,
+      kind: c.kind,
+      owner: c.owner,
+      severity: c.severity,
+      first_capsule: c,
+      first_seen_ms: now_ms,
+      last_seen_ms: now_ms,
+      occurrences: 1
+    }
+  end
+
+  defp record_recent(%Capsule{} = c) do
+    state = state()
+    seq = :atomics.add_get(state.seq, 1, 1)
+    :ets.insert(@recent, {seq, c})
+
+    if :ets.info(@recent, :size) > @keep_recent do
+      cutoff = seq - @keep_recent + 1
+      :ets.select_delete(@recent, [{{:"$1", :_}, [{:<, :"$1", cutoff}], [true]}])
+    end
+  end
+
+  defp fanout(%Capsule{} = c) do
+    for pid <- :persistent_term.get(@subscribers_key, []) do
+      # send/2 does not raise on a dead pid, so a subscriber that exited
+      # between publish-of-the-cached-list and this line does not affect
+      # this or any other subscriber. The owner's DOWN monitor prunes the
+      # dead pid from the cached list on its own schedule.
+      #
+      # A **remote** subscriber pid is a different matter: dist encoding of
+      # the term happens in *this* process's context, and if a caller ever
+      # plumbs a resource that cannot be encoded (a NIF resource, a closure
+      # over one) into the capsule, `send/2` raises here and takes down the
+      # emitter. That would be a defect reporter that crashes on the defect
+      # it is reporting — the exact anti-pattern the framework promises to
+      # avoid, per `capsule.ex`'s "bounded shapes" section.
+      #
+      # Isolate each pid so one bad recipient does not stop delivery to the
+      # rest, and log at :error so a broken payload surfaces rather than
+      # disappearing silently. The framework's own emit paths ship shapes
+      # that encode; a defect here means an app-owned caller passed
+      # something it should not have.
+      try do
+        send(pid, {:mob_defect, c})
+      catch
+        kind, reason ->
+          Logger.error(
+            "[Mob.Defect.Bus] fanout to #{inspect(pid)} raised: " <>
+              "#{inspect(kind)} #{inspect(reason)}. Capsule dropped for this subscriber."
+          )
+      end
+    end
+
+    :ok
+  end
+
+  defp state, do: :persistent_term.get(@state)
+
+  defp safe_state do
+    :persistent_term.get(@state, nil)
+  end
+end

--- a/lib/mob/defect/bus/owner.ex
+++ b/lib/mob/defect/bus/owner.ex
@@ -1,0 +1,118 @@
+defmodule Mob.Defect.Bus.Owner do
+  @moduledoc """
+  Owns `Mob.Defect.Bus`'s ETS tables and the subscriber registry.
+
+  Same reason `Mob.Invariant.Owner` and `Mob.Agent.Receipts.Owner` exist: an
+  ETS table dies with its creator, so a table that outlives the process which
+  emitted the first defect has to be owned by something the framework
+  controls. Unlinked, so a diagnostic neither dies with an emitter nor takes
+  one down.
+
+  Subscribers are stored here (in this process's state) and cached in
+  `:persistent_term` for the write path to read without a mailbox
+  round-trip. Every subscribed pid is monitored so an exit prunes it out of
+  the cache automatically.
+  """
+
+  use GenServer
+
+  @classes :mob_defect_classes
+  @recent :mob_defect_recent
+  @state :mob_defect_state
+  @subscribers_key :mob_defect_subscribers
+
+  @doc false
+  @spec start() :: {:ok, pid()}
+  def start do
+    case GenServer.start(__MODULE__, [], name: __MODULE__) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+    end
+  end
+
+  @doc false
+  @spec subscribe(pid()) :: {:ok, reference()}
+  def subscribe(pid) do
+    {:ok, _pid} = start()
+    GenServer.call(__MODULE__, {:subscribe, pid})
+  end
+
+  @doc false
+  @spec unsubscribe(pid()) :: :ok
+  def unsubscribe(pid) do
+    {:ok, _pid} = start()
+    GenServer.call(__MODULE__, {:unsubscribe, pid})
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(_opts) do
+    setup()
+    {:ok, %{monitors: %{}}}
+  end
+
+  @impl GenServer
+  def handle_call({:subscribe, pid}, _from, state) do
+    if Map.has_key?(state.monitors, pid) do
+      # Idempotent — return a fresh ref for parity with a first-time subscribe,
+      # but do not double-monitor.
+      {:reply, {:ok, make_ref()}, state}
+    else
+      ref = Process.monitor(pid)
+      state = %{state | monitors: Map.put(state.monitors, pid, ref)}
+      publish(state)
+      {:reply, {:ok, ref}, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:unsubscribe, pid}, _from, state) do
+    state =
+      case Map.pop(state.monitors, pid) do
+        {nil, _} ->
+          state
+
+        {ref, remaining} ->
+          Process.demonitor(ref, [:flush])
+          %{state | monitors: remaining}
+      end
+
+    publish(state)
+    {:reply, :ok, state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    state = %{state | monitors: Map.delete(state.monitors, pid)}
+    publish(state)
+    {:noreply, state}
+  end
+
+  # State (atomics) before the tables and the persistent term, and a table is
+  # the flag — the reverse order leaves a window where another process sees a
+  # table, skips initialisation, and reads a `:persistent_term` key that is
+  # not there yet. Same reasoning as `Mob.Invariant.Owner.setup/0`.
+  defp setup do
+    :persistent_term.put(@state, %{seq: :atomics.new(1, signed: false)})
+
+    for t <- [@classes, @recent] do
+      if :ets.whereis(t) == :undefined do
+        :ets.new(t, [:set, :public, :named_table, {:write_concurrency, true}])
+      end
+    end
+
+    # Empty subscriber list — the write path reads this key with a default of
+    # `[]`, so a missing key is not a crash, but publishing it here means the
+    # first `subscribe/1` does not have to seed it.
+    :persistent_term.put(@subscribers_key, [])
+
+    :ok
+  end
+
+  defp publish(state) do
+    :persistent_term.put(@subscribers_key, Map.keys(state.monitors))
+  end
+end

--- a/lib/mob/defect/capsule.ex
+++ b/lib/mob/defect/capsule.ex
@@ -1,0 +1,564 @@
+defmodule Mob.Defect.Capsule do
+  # Bounds first, so the moduledoc's `#{@…}` interpolations resolve.
+  @schema_version "mob.defect/1"
+  @evidence_string_limit 4_096
+  @evidence_list_limit 64
+  @evidence_max_depth 8
+  @device_info_key {__MODULE__, :device_info}
+  @build_info_key {__MODULE__, :build_info}
+
+  @moduledoc """
+  A defect, in the shape a consumer can act on.
+
+  This is the format from
+  `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`. The record is
+  a struct in memory and `mob.defect/1` JSON on the wire, and the two are the
+  same shape — a struct field with a snake-case atom becomes a JSON key with the
+  same spelling, so a reader of one can read the other without a schema
+  translation.
+
+  ## What is fixed here vs. what a caller provides
+
+  A caller — the invariant registry, the differential comparator, the crash
+  handler, whatever — supplies what makes this defect *this* defect:
+  `kind`, `owner`, `severity`, `evidence`, and the fingerprint inputs. The
+  capsule fills in what is the same across every defect: `schema`, `id`,
+  `detected_at`, `build`, `device`, `redaction`. That split is deliberate. A
+  detector that had to construct the build section itself would drift out of
+  step with the rest of the reports the moment `mob` bumped its version, and a
+  fingerprint the caller computed by hand would land in three different shapes.
+
+  ## Fingerprint
+
+  `fingerprint` groups occurrences into one triage item. One thousand phones
+  hitting the same bug produces one thousand `id`s and one `fingerprint`, and
+  that is what makes the report channel usable rather than a firehose.
+
+  The stable inputs are what *defines* the defect, and only those:
+
+  * `kind`, `owner`
+  * The caller's `fingerprint_key` — a small map like
+    `%{invariant: :parked_screen_alive, screen: MyScreen}` — describing the
+    defect *class*, not this occurrence
+
+  The excluded inputs are what changes across occurrences of the same defect:
+
+  * `id`, `detected_at`, `monotonic_us`
+  * `build.*`, `device.*`
+  * `evidence` beyond what the caller put in `fingerprint_key`
+
+  A fingerprint that included the build version would open a new triage item
+  every release, which is what the pre-shipped defect systems in this space do
+  wrong.
+
+  ## Redaction
+
+  A capsule is written to a bounded ring buffer, and from there to whatever
+  sink the app has wired up (dev-mode: the connected agent; production:
+  whatever the app developer configured, if anything). The write and the
+  possibility of a sink are the same event: by the time the caller has a
+  capsule value, redaction has already happened. Sinks receive
+  already-safe data, per the "redaction is a precondition" clause of the
+  decision record.
+
+  For phase 1 the discipline is pushed onto the callers: an `evidence` map that
+  arrives here is trusted to contain no application state, and the capsule
+  tags it `redaction: :applied` on that basis. The invariant registry and the
+  differential comparator both already promise that (see
+  `Mob.Invariant.Violation`'s moduledoc and `Mob.Differential`'s docs), so the
+  emit paths in phase 1 are trustworthy inputs by construction. Later phases
+  (native crash, `ApplicationExitInfo`, incident-capsule from a raised
+  exception) will need `Mob.Agent.Receipt.summarize_error/3`-style reduction,
+  which happens *before* the value reaches `new/1`.
+
+  A caller that provably packages no state can pass `redaction: :none` to
+  `new/1`, matching the schema. The default is `:applied`, and the default is
+  the safe answer.
+
+  ## Bounded shapes
+
+  A defect from an app in the field has to fit through a pipe an app developer
+  is willing to keep open. `evidence` and `fingerprint_key` are truncated
+  during construction: strings above #{@evidence_string_limit} bytes are
+  clipped and lists above #{@evidence_list_limit} elements are cut, with a
+  tag left in place so a consumer can see clipping happened rather than treat
+  the visible half as the whole. The recursion depth cap protects the packager
+  from a maliciously deep term — a defect reporter that can be crashed by the
+  defect it is reporting is worse than none.
+  """
+
+  alias Mob.Defect.Capsule
+
+  @type kind ::
+          :native_crash
+          | :beam_crash
+          | :anr
+          | :oom
+          | :user_kill
+          | :invariant
+          | :divergence
+          | :deploy_mismatch
+          | :perf_regression
+
+  @type severity :: :fatal | :critical | :warning | :info
+  @type owner :: :mob | :mob_dev | :mob_new | {:plugin, atom() | String.t()} | :app | :unknown
+
+  @type redaction :: :applied | :none
+
+  @type build_info :: %{
+          mob: String.t() | nil,
+          mob_dev: String.t() | nil,
+          app: String.t() | nil,
+          commit: String.t() | nil,
+          dirty: boolean() | nil,
+          otp: String.t() | nil,
+          elixir: String.t() | nil,
+          loaded_md5: map()
+        }
+
+  @type device_info :: %{
+          platform: :ios | :android | :host,
+          os: String.t() | nil,
+          model: String.t() | nil,
+          simulator: boolean() | nil,
+          locale: String.t() | nil,
+          scale: number() | nil
+        }
+
+  @type repro :: %{available: boolean(), minimized: boolean(), steps: [term()]}
+
+  @type t :: %__MODULE__{
+          schema: String.t(),
+          id: String.t(),
+          fingerprint: String.t(),
+          kind: kind(),
+          severity: severity(),
+          detected_at: String.t(),
+          owner: owner(),
+          redaction: redaction(),
+          build: build_info(),
+          device: device_info(),
+          evidence: map(),
+          repro: repro()
+        }
+
+  @enforce_keys [
+    :schema,
+    :id,
+    :fingerprint,
+    :kind,
+    :severity,
+    :detected_at,
+    :owner,
+    :redaction,
+    :build,
+    :device,
+    :evidence,
+    :repro
+  ]
+
+  defstruct [
+    :schema,
+    :id,
+    :fingerprint,
+    :kind,
+    :severity,
+    :detected_at,
+    :owner,
+    :redaction,
+    :build,
+    :device,
+    :evidence,
+    :repro
+  ]
+
+  @doc """
+  Build a capsule.
+
+  Required:
+    * `:kind` — see `t:kind/0`
+    * `:owner` — see `t:owner/0`
+    * `:severity` — see `t:severity/0`
+    * `:fingerprint_key` — the map that identifies the defect *class*. Kept
+      separately from `:evidence` so the fingerprint stays stable when
+      evidence gains fields between releases.
+
+  Optional:
+    * `:evidence` — kind-specific detail. Defaults to `%{}`. Truncated during
+      construction.
+    * `:redaction` — `:applied` (default) or `:none`. `:none` is only legal
+      for a capsule that provably carries no application state.
+    * `:repro` — a repro map. Defaults to `%{available: false, minimized:
+      false, steps: []}` since phase 1 does not attempt reproduction.
+    * `:build` / `:device` — override the framework-populated sections
+      (tests use this to make snapshots deterministic).
+    * `:now_ms` — Unix milliseconds for `detected_at`. Defaults to `System.system_time(:millisecond)`;
+      tests use this to make timestamps deterministic.
+  """
+  @spec new(keyword() | map()) :: t()
+  def new(opts) when is_list(opts), do: new(Map.new(opts))
+
+  def new(%{kind: kind, owner: owner, severity: severity, fingerprint_key: fp_key} = opts)
+      when is_map(fp_key) do
+    truncated_key = truncate(fp_key)
+    truncated_evidence = opts |> Map.get(:evidence, %{}) |> truncate()
+    redaction = validate_redaction(Map.get(opts, :redaction, :applied))
+
+    build = Map.get_lazy(opts, :build, &build_info/0)
+    device = Map.get_lazy(opts, :device, &device_info/0)
+    now_ms = Map.get_lazy(opts, :now_ms, fn -> System.system_time(:millisecond) end)
+
+    %Capsule{
+      schema: @schema_version,
+      id: new_id(now_ms),
+      fingerprint: fingerprint(kind, owner, truncated_key),
+      kind: kind,
+      severity: severity,
+      detected_at: iso8601(now_ms),
+      owner: owner,
+      redaction: redaction,
+      build: build,
+      device: device,
+      evidence: Map.merge(truncated_key, truncated_evidence),
+      repro: Map.get(opts, :repro, %{available: false, minimized: false, steps: []})
+    }
+  end
+
+  @doc """
+  The JSON-shaped map for the wire.
+
+  Structurally identical to the struct — a struct field with a snake-case atom
+  becomes a JSON key of the same name. Owners get their string form:
+  `{:plugin, :foo}` becomes `"plugin:foo"`, matching the schema.
+
+  Callers that want bytes rather than a map pass this to `Jason.encode!/1`.
+  Jason is `mob`'s only runtime dep, so a caller inside the tree can always
+  encode; a caller outside can too but is not obliged to.
+  """
+  @spec to_json(t()) :: map()
+  def to_json(%Capsule{} = c) do
+    %{
+      "schema" => c.schema,
+      "id" => c.id,
+      "fingerprint" => c.fingerprint,
+      "kind" => Atom.to_string(c.kind),
+      "severity" => Atom.to_string(c.severity),
+      "detected_at" => c.detected_at,
+      "owner" => owner_to_string(c.owner),
+      "redaction" => Atom.to_string(c.redaction),
+      "build" => stringify_keys(c.build),
+      "device" => stringify_keys(c.device),
+      "evidence" => stringify_terms(c.evidence),
+      "repro" => stringify_keys(c.repro)
+    }
+  end
+
+  @doc """
+  A one-line triage summary for a human reading a log.
+
+  Deliberately compact and free of any application state — everything shown
+  here has already been through the capsule's redaction contract, so this is
+  safe to log even when the sink is a remote agent over dist.
+  """
+  @spec describe(t()) :: String.t()
+  def describe(%Capsule{} = c) do
+    fp_short = c.fingerprint |> String.replace_prefix("sha256:", "") |> String.slice(0, 8)
+
+    "[defect #{Atom.to_string(c.severity)}] " <>
+      "#{Atom.to_string(c.kind)} owner=#{owner_to_string(c.owner)} " <>
+      "fp=#{fp_short} redaction=#{Atom.to_string(c.redaction)} " <>
+      "evidence=#{inspect(c.evidence, limit: 8)}"
+  end
+
+  @doc """
+  A stable sha256 hex over the defect-defining fields only.
+
+  `kind`, `owner`, and `fingerprint_key` are hashed with a canonical
+  representation of the map (keys sorted, atoms unified with their string
+  form) so two callers that produce the same defect land on the same
+  fingerprint regardless of key insertion order. Time, id, build, device, and
+  extra evidence are excluded — a fingerprint is a defect class, not an
+  occurrence.
+
+  Exposed for tests and for callers that want to correlate a defect against
+  something they compute themselves. Called by `new/1`, so ordinary construction
+  does not need to call this directly.
+  """
+  @spec fingerprint(kind(), owner(), map()) :: String.t()
+  def fingerprint(kind, owner, fingerprint_key) when is_map(fingerprint_key) do
+    canonical = {kind, owner, canonicalize(fingerprint_key)}
+
+    digest =
+      canonical
+      |> :erlang.term_to_binary(minor_version: 2)
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.encode16(case: :lower)
+
+    "sha256:" <> digest
+  end
+
+  # ---------------------------------------------------------------------------
+  # Build / device population
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  The build section, computed once per node and cached.
+
+  Versions do not change during a session. `Application.spec/2` is cheap on
+  its own, but the write path pays it on every emit — the small cost adds up
+  under a burst of confirmed violations from a runaway teardown, and the
+  cached value is trivially cheaper. Same reasoning as `device_info/0`.
+  """
+  @spec build_info() :: build_info()
+  def build_info do
+    case :persistent_term.get(@build_info_key, :none) do
+      :none ->
+        info = compute_build_info()
+        :persistent_term.put(@build_info_key, info)
+        info
+
+      cached ->
+        cached
+    end
+  end
+
+  @doc false
+  @spec forget_build_info() :: :ok
+  def forget_build_info do
+    :persistent_term.erase(@build_info_key)
+    :ok
+  end
+
+  defp compute_build_info do
+    %{
+      mob: version(:mob),
+      mob_dev: version(:mob_dev),
+      app: nil,
+      commit: nil,
+      dirty: nil,
+      otp: otp_release(),
+      elixir: System.version(),
+      loaded_md5: %{}
+    }
+  end
+
+  @doc """
+  The device section, computed once per node and cached.
+
+  `platform`, `os`, `model`, and the fields that will populate around them do
+  not change during a session — the OS reports the same model on every call,
+  and OS version changes only across upgrades that require a relaunch. Every
+  emit was paying two NIF hops for those on the write path, which on a
+  teardown-heavy sampling point (`:on_screen_stop`) is real cost added to
+  every confirmed violation. Read once, cache in `:persistent_term`, done.
+
+  `:persistent_term.put/2` is expensive (it triggers a global GC) but that
+  cost pays for reads that are the cheapest thing on the BEAM, and this is a
+  one-shot at first emit — a use-once, read-many pattern which is exactly the
+  case persistent_term is documented for.
+  """
+  @spec device_info() :: device_info()
+  def device_info do
+    case :persistent_term.get(@device_info_key, :none) do
+      :none ->
+        info = compute_device_info()
+        :persistent_term.put(@device_info_key, info)
+        info
+
+      cached ->
+        cached
+    end
+  end
+
+  # Test/support hook: forget the cached device section so the next
+  # `device_info/0` re-reads from the platform. Not called on the hot path.
+  @doc false
+  @spec forget_device_info() :: :ok
+  def forget_device_info do
+    :persistent_term.erase(@device_info_key)
+    :ok
+  end
+
+  defp compute_device_info do
+    %{
+      platform: safe_platform(),
+      os: safe_os_version(),
+      model: safe_model(),
+      simulator: nil,
+      locale: nil,
+      scale: nil
+    }
+  end
+
+  defp version(app) do
+    case Application.spec(app, :vsn) do
+      nil -> nil
+      vsn when is_list(vsn) -> List.to_string(vsn)
+      vsn when is_binary(vsn) -> vsn
+    end
+  end
+
+  defp otp_release do
+    :erlang.system_info(:otp_release)
+    |> List.to_string()
+  end
+
+  defp safe_platform do
+    try do
+      :mob_nif.platform()
+    rescue
+      _ -> :host
+    catch
+      _, _ -> :host
+    end
+  end
+
+  defp safe_os_version do
+    try do
+      Mob.Device.os_version()
+    rescue
+      _ -> nil
+    catch
+      _, _ -> nil
+    end
+  end
+
+  defp safe_model do
+    try do
+      Mob.Device.model()
+    rescue
+      _ -> nil
+    catch
+      _, _ -> nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Fingerprint canonicalisation
+  # ---------------------------------------------------------------------------
+
+  # Fingerprint stability across an `%{a: 1, b: 2}` written two different ways
+  # matters: term_to_binary is not order-stable on maps, so two writers that
+  # both produce the same defect could land on two different hashes if we hashed
+  # the raw term. Sort keys, and recurse into values that are themselves maps
+  # for the same reason.
+  #
+  # Atoms are converted to strings so an atom key and a string key with the
+  # same name hash the same. This matches the JSON shape, where every key is a
+  # string, and it means a caller reading a fingerprint back from a JSON copy
+  # of a capsule still gets the same value.
+  defp canonicalize(map) when is_map(map) do
+    map
+    |> Enum.map(fn {k, v} -> {stringify_key(k), canonicalize_value(v)} end)
+    |> Enum.sort_by(&elem(&1, 0))
+  end
+
+  defp canonicalize_value(v) when is_map(v) and not is_struct(v), do: canonicalize(v)
+  defp canonicalize_value(v) when is_list(v), do: Enum.map(v, &canonicalize_value/1)
+
+  defp canonicalize_value(v) when is_atom(v) and not is_nil(v) and not is_boolean(v),
+    do: Atom.to_string(v)
+
+  defp canonicalize_value(v), do: v
+
+  defp stringify_key(k) when is_atom(k), do: Atom.to_string(k)
+  defp stringify_key(k) when is_binary(k), do: k
+  defp stringify_key(k), do: inspect(k)
+
+  # ---------------------------------------------------------------------------
+  # Truncation
+  # ---------------------------------------------------------------------------
+
+  defp truncate(m) when is_map(m), do: truncate_value(m, 0)
+
+  defp truncate_value(_v, depth) when depth > @evidence_max_depth,
+    do: {:truncated, :depth}
+
+  defp truncate_value(v, depth) when is_map(v) and not is_struct(v) do
+    Map.new(v, fn {k, val} -> {k, truncate_value(val, depth + 1)} end)
+  end
+
+  defp truncate_value(v, depth) when is_list(v) do
+    if length(v) > @evidence_list_limit do
+      kept = v |> Enum.take(@evidence_list_limit) |> Enum.map(&truncate_value(&1, depth + 1))
+      kept ++ [{:truncated, :list, length(v) - @evidence_list_limit}]
+    else
+      Enum.map(v, &truncate_value(&1, depth + 1))
+    end
+  end
+
+  defp truncate_value(v, _depth) when is_binary(v) and byte_size(v) > @evidence_string_limit do
+    <<kept::binary-size(@evidence_string_limit), _::binary>> = v
+    {:truncated, :string, kept}
+  end
+
+  defp truncate_value(v, _depth), do: v
+
+  # ---------------------------------------------------------------------------
+  # Wire-form helpers
+  # ---------------------------------------------------------------------------
+
+  defp validate_redaction(:applied), do: :applied
+  defp validate_redaction(:none), do: :none
+
+  defp validate_redaction(other),
+    do: raise(ArgumentError, "redaction must be :applied or :none, got #{inspect(other)}")
+
+  defp owner_to_string({:plugin, name}) when is_atom(name), do: "plugin:" <> Atom.to_string(name)
+  defp owner_to_string({:plugin, name}) when is_binary(name), do: "plugin:" <> name
+  defp owner_to_string(owner) when is_atom(owner), do: Atom.to_string(owner)
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {stringify_key(k), stringify_value(v)} end)
+  end
+
+  defp stringify_value(v) when is_map(v) and not is_struct(v), do: stringify_keys(v)
+  defp stringify_value(v) when is_list(v), do: Enum.map(v, &stringify_value/1)
+
+  defp stringify_value(v) when is_atom(v) and not is_nil(v) and not is_boolean(v),
+    do: Atom.to_string(v)
+
+  defp stringify_value(v), do: v
+
+  # `evidence` may contain terms the caller does not expect to reach a wire —
+  # pids, refs, tuples. Sinks that hand a capsule to Jason will fail on those
+  # without help. Reduce them here to inspect strings so the wire form is
+  # always encodable. This is separate from redaction: redaction refuses to
+  # transmit application state; this makes the shape encodable.
+  defp stringify_terms(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {stringify_key(k), stringify_term(v)} end)
+  end
+
+  defp stringify_term(v) when is_map(v) and not is_struct(v), do: stringify_terms(v)
+  defp stringify_term(v) when is_list(v), do: Enum.map(v, &stringify_term/1)
+  defp stringify_term(v) when is_tuple(v), do: v |> Tuple.to_list() |> Enum.map(&stringify_term/1)
+
+  defp stringify_term(v) when is_pid(v) or is_reference(v) or is_port(v) or is_function(v),
+    do: inspect(v)
+
+  defp stringify_term(v) when is_atom(v) and not is_nil(v) and not is_boolean(v),
+    do: Atom.to_string(v)
+
+  defp stringify_term(v), do: v
+
+  # ---------------------------------------------------------------------------
+  # Id and timestamp
+  # ---------------------------------------------------------------------------
+
+  # A time-sortable id: 48-bit millisecond timestamp, then a monotonic per-node
+  # counter, base32-encoded. Not a full ULID — mob's single-runtime-dep rule
+  # rules out a ULID library — but structurally similar: the leading digits
+  # sort by time, so a listing of ids from a ring buffer is chronological
+  # without a separate sort. Unique per occurrence within a node.
+  defp new_id(now_ms) do
+    unique = System.unique_integer([:positive, :monotonic])
+    <<time_part::48, rest_part::80>> = <<now_ms::48, unique::80>>
+    Base.encode32(<<time_part::48, rest_part::80>>, padding: false, case: :upper)
+  end
+
+  defp iso8601(ms) do
+    ms
+    |> DateTime.from_unix!(:millisecond)
+    |> DateTime.to_iso8601()
+  end
+end

--- a/lib/mob/defect/sinks/dev.ex
+++ b/lib/mob/defect/sinks/dev.ex
@@ -1,0 +1,100 @@
+defmodule Mob.Defect.Sinks.Dev do
+  @moduledoc """
+  A defect sink that formats every emitted capsule as a Logger line.
+
+  Not started by default — per
+  `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`, `mob` is
+  never the collector, and a sink that runs unbidden would violate that. An
+  app opts in explicitly:
+
+      Mob.Defect.Sinks.Dev.start_link()
+
+  or under its own supervision tree:
+
+      children = [
+        # ... app children ...
+        Mob.Defect.Sinks.Dev
+      ]
+
+  It is `Dev` because Logger output is the medium the connected-agent workflow
+  already uses — `mix mob.connect` streams the device's Logger output into
+  the agent's IEx session, so a defect logged here reaches the agent for
+  free. An app that wants a *production* sink (a remote endpoint, a file, a
+  push channel, or nothing) writes their own subscriber; the API is
+  `Mob.Defect.Bus.subscribe/0` plus a `handle_info({:mob_defect, capsule}, ...)`.
+
+  ## What it logs
+
+  * `severity: :fatal | :critical` → `Logger.error`
+  * `severity: :warning` → `Logger.warning`
+  * anything else → `Logger.info`
+
+  The severity mapping is what routes a real bug to the log level a triager
+  reads first. `Logger.info` for everything would bury a fatal alongside a
+  perf regression; `Logger.error` for everything would train the reader to
+  ignore the channel — exactly what the redaction and dedup work goes into
+  preventing.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Mob.Defect.Bus
+  alias Mob.Defect.Capsule
+
+  @doc "Start the sink under `name`, defaulting to the module."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, [], name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    {:ok, _ref} = Bus.subscribe()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info({:mob_defect, %Capsule{} = c}, state) do
+    log(c)
+    {:noreply, state}
+  end
+
+  # Anything else is not for us. A defensive catch-all — a subscriber that
+  # crashes on an unexpected message would be pruned from the fanout list on
+  # the next tick, silently going dark. Log-and-ignore keeps the sink alive.
+  @impl GenServer
+  def handle_info(_other, state), do: {:noreply, state}
+
+  @impl GenServer
+  def terminate(_reason, _state) do
+    # `Bus.unsubscribe/1` calls `Bus.Owner.start/0` transparently before its
+    # `GenServer.call`, so a dead owner is usually restarted rather than
+    # observed. The try/catch here is a narrow guard for the corner where
+    # even that restart fails — a supervised BEAM shutdown that has
+    # unregistered `:proc_lib`, a spawn refused because the process cap has
+    # been hit while draining. In practice this catch fires zero times in
+    # normal operation, and the tests do not exercise it (a mock-restart
+    # scenario would only test the mock, not the runtime); it stays because
+    # the alternative is a spurious `:exit` in a terminate that scares a
+    # reader looking at a shutdown log.
+    try do
+      Bus.unsubscribe()
+    catch
+      :exit, {:noproc, _} -> :ok
+      :exit, :noproc -> :ok
+    end
+
+    :ok
+  end
+
+  defp log(%Capsule{severity: sev} = c) when sev in [:fatal, :critical],
+    do: Logger.error(Capsule.describe(c))
+
+  defp log(%Capsule{severity: :warning} = c),
+    do: Logger.warning(Capsule.describe(c))
+
+  defp log(%Capsule{} = c),
+    do: Logger.info(Capsule.describe(c))
+end

--- a/lib/mob/invariant.ex
+++ b/lib/mob/invariant.ex
@@ -335,6 +335,12 @@ defmodule Mob.Invariant do
       :ets.select_delete(@violations, [{{:"$1", :_}, [{:<, :"$1", seq - @keep + 1}], [true]}])
     end
 
+    # A confirmed violation is a defect by definition — the maturation logic
+    # above is precisely the "this is real, not a transient" gate. Emit as a
+    # capsule so subscribers on the bus (a dev sink, an app's own reporter)
+    # see it. See `Mob.Defect.emit_invariant_violation/1`.
+    Mob.Defect.emit_invariant_violation(violation)
+
     violation
   end
 

--- a/test/mob/defect/bus_test.exs
+++ b/test/mob/defect/bus_test.exs
@@ -1,0 +1,245 @@
+defmodule Mob.Defect.BusTest do
+  # Not async — the bus is process-global (ETS + persistent_term + a named
+  # GenServer), so tests running concurrently would step on each other's
+  # subscribers and recent-buffer entries. That is a property of the bus
+  # under test, not a bug in it, so isolating with `async: false` is the
+  # right knob.
+  use ExUnit.Case, async: false
+
+  alias Mob.Defect.Bus
+  alias Mob.Defect.Capsule
+
+  setup do
+    Bus.start()
+    Bus.reset()
+    Bus.unsubscribe()
+    :ok
+  end
+
+  defp invariant_capsule(name, screen \\ MyScreen) do
+    Capsule.new(
+      kind: :invariant,
+      owner: :mob,
+      severity: :critical,
+      fingerprint_key: %{invariant: name, screen: screen}
+    )
+  end
+
+  describe "emit/1 — classes" do
+    test "creates a class row on first emit with occurrences: 1" do
+      c = invariant_capsule(:leaked_component)
+      Bus.emit(c)
+
+      assert [row] = Bus.classes()
+      assert row.fingerprint == c.fingerprint
+      assert row.kind == :invariant
+      assert row.owner == :mob
+      assert row.severity == :critical
+      assert row.occurrences == 1
+      assert row.first_capsule == c
+    end
+
+    test "increments occurrences for the same fingerprint, not a new row" do
+      for _ <- 1..5, do: Bus.emit(invariant_capsule(:leaked_component))
+
+      assert Bus.class_count() == 1
+      assert [row] = Bus.classes()
+      assert row.occurrences == 5
+    end
+
+    test "different fingerprints get different class rows" do
+      Bus.emit(invariant_capsule(:leaked_component))
+      Bus.emit(invariant_capsule(:parked_screen_alive))
+      Bus.emit(invariant_capsule(:leaked_component))
+
+      assert Bus.class_count() == 2
+      rows = Bus.classes()
+      leaked = Enum.find(rows, &(&1.first_capsule.evidence.invariant == :leaked_component))
+      parked = Enum.find(rows, &(&1.first_capsule.evidence.invariant == :parked_screen_alive))
+      assert leaked.occurrences == 2
+      assert parked.occurrences == 1
+    end
+
+    test "class row keeps the first capsule, not the last" do
+      first = invariant_capsule(:leaked_component)
+      # Make sure the second capsule genuinely differs (different id, later
+      # detected_at) so we can prove which one the row kept.
+      Process.sleep(2)
+      second = invariant_capsule(:leaked_component)
+
+      Bus.emit(first)
+      Bus.emit(second)
+
+      assert first.id != second.id
+
+      [row] = Bus.classes()
+      assert row.first_capsule.id == first.id
+    end
+
+    test "classes come back newest-last-seen first" do
+      old = invariant_capsule(:one)
+      Bus.emit(old)
+      Process.sleep(2)
+      newer = invariant_capsule(:two)
+      Bus.emit(newer)
+
+      [first, second] = Bus.classes()
+      assert first.fingerprint == newer.fingerprint
+      assert second.fingerprint == old.fingerprint
+    end
+  end
+
+  describe "recent/1" do
+    test "keeps distinct occurrences of the same class as separate rows" do
+      # Two emits with the same fingerprint should collapse in classes but
+      # both appear on the recent ring — that is the point of the ring.
+      a = invariant_capsule(:leaked_component)
+      Bus.emit(a)
+      b = invariant_capsule(:leaked_component)
+      Bus.emit(b)
+
+      recent = Bus.recent()
+      assert length(recent) == 2
+      assert Enum.map(recent, & &1.id) == [b.id, a.id]
+    end
+
+    test "caps at 64 entries (the bounded ring)" do
+      for i <- 1..80, do: Bus.emit(invariant_capsule(:"leaked_#{i}"))
+
+      recent = Bus.recent(200)
+      assert length(recent) == 64
+    end
+  end
+
+  describe "subscribe / unsubscribe" do
+    test "a subscriber receives {:mob_defect, capsule}" do
+      {:ok, _ref} = Bus.subscribe()
+      c = invariant_capsule(:leaked_component)
+      Bus.emit(c)
+      assert_receive {:mob_defect, ^c}, 500
+    end
+
+    test "unsubscribe stops delivery" do
+      {:ok, _ref} = Bus.subscribe()
+      Bus.emit(invariant_capsule(:before))
+      assert_receive {:mob_defect, _}, 500
+
+      Bus.unsubscribe()
+      Bus.emit(invariant_capsule(:after_unsub))
+      refute_receive {:mob_defect, _}, 100
+    end
+
+    test "subscribe/1 is idempotent — one subscriber pid, one delivery" do
+      Bus.subscribe()
+      Bus.subscribe()
+      Bus.emit(invariant_capsule(:double_sub))
+
+      assert_receive {:mob_defect, _}, 500
+      refute_receive {:mob_defect, _}, 100
+    end
+
+    test "a subscriber that exits is pruned from the fanout list" do
+      test_pid = self()
+
+      sub =
+        spawn(fn ->
+          Bus.subscribe()
+          send(test_pid, :subscribed)
+
+          receive do
+            :die -> :ok
+          end
+        end)
+
+      assert_receive :subscribed
+      assert sub in Bus.subscribers()
+
+      Process.monitor(sub)
+      send(sub, :die)
+      assert_receive {:DOWN, _, :process, ^sub, _}
+
+      # Give the owner a moment to process the DOWN and republish.
+      Process.sleep(20)
+      refute sub in Bus.subscribers()
+    end
+
+    test "a dead subscriber never seen by fanout does not raise" do
+      # send/2 to a dead pid is a no-op, and a change that upgraded fanout
+      # to `GenServer.call/2` (a synchronous round-trip that raises `:noproc`
+      # on a dead target) would fail this test. `GenServer.cast/2` would
+      # not: cast is fire-and-forget on send/2, so this test would not catch
+      # a switch to it.
+      dead = spawn(fn -> :ok end)
+      Process.monitor(dead)
+      assert_receive {:DOWN, _, :process, ^dead, _}
+
+      # Register the dead pid directly, bypassing the owner's DOWN monitor,
+      # so we can observe fanout's behaviour under a stale entry.
+      :persistent_term.put(:mob_defect_subscribers, [dead])
+
+      # The emit must not crash.
+      Bus.emit(invariant_capsule(:with_dead_sub))
+
+      # Cleanup — remove the manually-injected pid.
+      :persistent_term.put(:mob_defect_subscribers, [])
+    end
+
+    test "a subscriber slot that would raise on send/2 does not crash the emit" do
+      # Standing in for the real failure mode — a remote pid over dist whose
+      # payload does not encode, which raises inside `send/2` in the
+      # emitter's process. Locally, `send/2` raises on a non-pid target. The
+      # try/catch in `fanout/1` isolates any one recipient's failure from
+      # the others and from the emitter.
+      good_sub = self()
+
+      :persistent_term.put(:mob_defect_subscribers, [:not_a_pid, good_sub])
+
+      capture_log_fn = fn ->
+        Bus.emit(invariant_capsule(:with_bad_sub))
+      end
+
+      # Emit succeeds despite the raising entry.
+      log = ExUnit.CaptureLog.capture_log(capture_log_fn)
+
+      # The good subscriber still received its message.
+      assert_receive {:mob_defect, _}, 500
+
+      # The bad slot's failure was surfaced at :error.
+      assert log =~ "[error]"
+      assert log =~ "Mob.Defect.Bus"
+
+      :persistent_term.put(:mob_defect_subscribers, [])
+    end
+  end
+
+  describe "under concurrency" do
+    test "classes/1 occurrences equals the total number of emits" do
+      # `record_class/1` used to refresh a derived-row cache with a
+      # read-modify-write, which under contention could clobber a fresh
+      # counter with a stale one and leave `classes/1` reporting a lower
+      # occurrences count than the actual number of emits. The write path
+      # now touches only the two atomic fields (position 3 counter and
+      # position 4 last_seen); `classes/1` overlays them on read.
+      #
+      # This stresses the property: 8 concurrent tasks each emit 100 times
+      # against the same fingerprint, and the final occurrences must equal
+      # 800 with no other bookkeeping.
+      workers = 8
+      per_worker = 100
+
+      tasks =
+        for _ <- 1..workers do
+          Task.async(fn ->
+            for _ <- 1..per_worker do
+              Bus.emit(invariant_capsule(:concurrent_hammer))
+            end
+          end)
+        end
+
+      Enum.each(tasks, &Task.await(&1, 5_000))
+
+      [row] = Bus.classes()
+      assert row.occurrences == workers * per_worker
+    end
+  end
+end

--- a/test/mob/defect/capsule_test.exs
+++ b/test/mob/defect/capsule_test.exs
@@ -1,0 +1,404 @@
+defmodule Mob.Defect.CapsuleTest do
+  use ExUnit.Case, async: true
+
+  alias Mob.Defect.Capsule
+
+  describe "new/1" do
+    test "populates every required schema field" do
+      c =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :critical,
+          fingerprint_key: %{invariant: :parked_screen_alive, screen: MyScreen}
+        )
+
+      assert %Capsule{
+               schema: "mob.defect/1",
+               kind: :invariant,
+               owner: :mob,
+               severity: :critical,
+               redaction: :applied,
+               id: id,
+               fingerprint: fp,
+               detected_at: dt,
+               build: build,
+               device: device,
+               evidence: evidence,
+               repro: %{available: false, minimized: false, steps: []}
+             } = c
+
+      assert is_binary(id) and byte_size(id) > 0
+      assert String.starts_with?(fp, "sha256:")
+      # ISO 8601 with either "Z" or explicit offset
+      assert String.match?(
+               dt,
+               ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/
+             )
+
+      # Build has the platform-populated shape: at least the mob version and
+      # the runtime versions this test's own BEAM was compiled against.
+      assert %{mob: mob_vsn, otp: otp, elixir: elixir} = build
+      assert is_binary(mob_vsn) or is_nil(mob_vsn)
+      assert is_binary(otp) and byte_size(otp) > 0
+      assert elixir == System.version()
+
+      # Device is the shape the schema promises, even in a host test run.
+      assert %{platform: platform, os: _os, model: _model} = device
+      assert platform in [:ios, :android, :host]
+
+      # Evidence carries the fingerprint_key back (that is what makes a class
+      # row self-describing).
+      assert %{invariant: :parked_screen_alive, screen: MyScreen} = evidence
+    end
+
+    test "detected_at is formatted from :now_ms and stable" do
+      c =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{invariant: :x},
+          now_ms: 1_756_566_663_418
+        )
+
+      assert c.detected_at == "2025-08-30T15:11:03.418Z"
+    end
+
+    test "evidence keeps the fingerprint_key and adds caller evidence" do
+      c =
+        Capsule.new(
+          kind: :divergence,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{reason: :type, path: []},
+          evidence: %{ios: :button, android: :label}
+        )
+
+      assert c.evidence == %{reason: :type, path: [], ios: :button, android: :label}
+    end
+
+    test "redaction defaults to :applied and accepts :none" do
+      applied =
+        Capsule.new(kind: :invariant, owner: :mob, severity: :warning, fingerprint_key: %{a: 1})
+
+      none =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{a: 1},
+          redaction: :none
+        )
+
+      assert applied.redaction == :applied
+      assert none.redaction == :none
+    end
+
+    test "invalid redaction raises rather than silently accepting" do
+      assert_raise ArgumentError, fn ->
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{a: 1},
+          redaction: :maybe
+        )
+      end
+    end
+
+    test "distinct occurrences share a fingerprint and get different ids" do
+      opts = [
+        kind: :invariant,
+        owner: :mob,
+        severity: :critical,
+        fingerprint_key: %{invariant: :parked_screen_alive, screen: MyScreen}
+      ]
+
+      a = Capsule.new(opts)
+      b = Capsule.new(opts)
+
+      assert a.fingerprint == b.fingerprint
+      assert a.id != b.id
+    end
+  end
+
+  describe "device_info/0 caching" do
+    setup do
+      Capsule.forget_device_info()
+      on_exit(fn -> Capsule.forget_device_info() end)
+      :ok
+    end
+
+    test "populates on first call and returns the same map on the second" do
+      # After forget, the cache slot is genuinely absent — assert directly on
+      # the persistent_term so a change that stopped writing there fails here.
+      assert :persistent_term.get({Capsule, :device_info}, :none) == :none
+
+      first = Capsule.device_info()
+      cached = :persistent_term.get({Capsule, :device_info}, :none)
+      second = Capsule.device_info()
+
+      # The persistent_term now holds the same map device_info/0 returned.
+      assert cached == first
+      # The second call gets the cached value, not a fresh computation.
+      assert second == first
+    end
+
+    test "forget_device_info/0 re-arms the cache" do
+      first = Capsule.device_info()
+      Capsule.forget_device_info()
+      assert :persistent_term.get({Capsule, :device_info}, :none) == :none
+
+      # A re-populate follows the same code path and lands on the same value
+      # on a host with no live device changes.
+      second = Capsule.device_info()
+      assert second == first
+      assert :persistent_term.get({Capsule, :device_info}, :none) == second
+    end
+  end
+
+  describe "fingerprint/3" do
+    test "is stable when atom and string keys are mixed" do
+      # Modern Erlang map iteration is content-stable, so a same-typed-keys
+      # map produces the same iteration order no matter how it was built —
+      # a shuffled-construction test is a false positive.
+      #
+      # Where iteration order actually differs is when the map mixes atom
+      # keys and string keys: the atom :a and the string "a" hash to
+      # different positions and iterate in a different sequence than a
+      # same-shaped map with the atom/string spellings swapped. After
+      # stringify_key normalises both to strings the two are semantically the
+      # same defect, and only sort_by makes the two fingerprints match.
+      atom_first = %{:screen => MyScreen, "invariant" => :parked}
+      string_first = %{"screen" => MyScreen, :invariant => :parked}
+
+      assert Capsule.fingerprint(:invariant, :mob, atom_first) ==
+               Capsule.fingerprint(:invariant, :mob, string_first)
+    end
+
+    test "treats an atom key and a string key of the same name as identical" do
+      assert Capsule.fingerprint(:invariant, :mob, %{screen: MyScreen}) ==
+               Capsule.fingerprint(:invariant, :mob, %{"screen" => MyScreen})
+    end
+
+    test "changes when the defect-defining fields change" do
+      base = %{invariant: :parked_screen_alive, screen: MyScreen}
+
+      assert Capsule.fingerprint(:invariant, :mob, base) !=
+               Capsule.fingerprint(:invariant, :mob, %{base | invariant: :orphaned_component})
+
+      assert Capsule.fingerprint(:invariant, :mob, base) !=
+               Capsule.fingerprint(:divergence, :mob, base)
+
+      assert Capsule.fingerprint(:invariant, :mob, base) !=
+               Capsule.fingerprint(:invariant, {:plugin, :some_plugin}, base)
+    end
+
+    test "does not change when build, device, id, or timestamp change" do
+      base_key = %{invariant: :parked_screen_alive, screen: MyScreen}
+
+      a =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :critical,
+          fingerprint_key: base_key,
+          now_ms: 1_756_566_663_418,
+          build: %{
+            mob: "0.7.0",
+            mob_dev: "0.6.0",
+            app: nil,
+            commit: "abc",
+            dirty: false,
+            otp: "27",
+            elixir: "1.20.0",
+            loaded_md5: %{}
+          },
+          device: %{
+            platform: :ios,
+            os: "17.0",
+            model: "iPhone SE",
+            simulator: true,
+            locale: "en_US",
+            scale: 3.0
+          }
+        )
+
+      b =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :critical,
+          fingerprint_key: base_key,
+          now_ms: 1_800_000_000_000,
+          build: %{
+            mob: "1.0.0",
+            mob_dev: "1.0.0",
+            app: nil,
+            commit: "def",
+            dirty: true,
+            otp: "28",
+            elixir: "1.21.0",
+            loaded_md5: %{}
+          },
+          device: %{
+            platform: :android,
+            os: "14",
+            model: "Pixel 7",
+            simulator: false,
+            locale: "en_CA",
+            scale: 2.5
+          }
+        )
+
+      assert a.fingerprint == b.fingerprint
+      assert a.id != b.id
+    end
+  end
+
+  describe "truncation" do
+    test "clips long strings and tags them" do
+      big = String.duplicate("x", 10_000)
+
+      c =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{a: 1},
+          evidence: %{blob: big}
+        )
+
+      assert {:truncated, :string, kept} = c.evidence.blob
+      # Default limit is 4096
+      assert byte_size(kept) == 4_096
+    end
+
+    test "clips long lists and tags them" do
+      long = Enum.to_list(1..200)
+
+      c =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{a: 1},
+          evidence: %{items: long}
+        )
+
+      assert [_ | _] = kept = c.evidence.items
+      # Kept 64 items plus a truncation tag
+      assert length(kept) == 65
+      assert List.last(kept) == {:truncated, :list, 200 - 64}
+    end
+
+    test "caps recursion depth so a deep map cannot exhaust the packager" do
+      deep =
+        Enum.reduce(1..50, %{leaf: :bottom}, fn _, acc -> %{nested: acc} end)
+
+      c =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{a: 1},
+          evidence: %{deep: deep}
+        )
+
+      # Walk down until we hit the truncation tag — must appear within a
+      # bounded number of steps regardless of how deep the input was.
+      depth = walk_until_truncated(c.evidence, 0)
+      assert depth <= 12, "expected truncation within 12 levels, got #{depth}"
+    end
+
+    defp walk_until_truncated({:truncated, :depth}, d), do: d
+
+    defp walk_until_truncated(m, d) when is_map(m) do
+      m
+      |> Map.values()
+      |> Enum.map(&walk_until_truncated(&1, d + 1))
+      |> Enum.max(fn -> d end)
+    end
+
+    defp walk_until_truncated(_v, d), do: d
+  end
+
+  describe "to_json/1" do
+    test "produces the mob.defect/1 wire shape with stringified keys" do
+      c =
+        Capsule.new(
+          kind: :invariant,
+          owner: :mob,
+          severity: :critical,
+          fingerprint_key: %{invariant: :parked_screen_alive, screen: MyScreen}
+        )
+
+      json = Capsule.to_json(c)
+
+      assert json["schema"] == "mob.defect/1"
+      assert json["kind"] == "invariant"
+      assert json["severity"] == "critical"
+      assert json["owner"] == "mob"
+      assert json["redaction"] == "applied"
+      assert is_binary(json["id"]) and byte_size(json["id"]) > 0
+      assert String.starts_with?(json["fingerprint"], "sha256:")
+      # Every build key is a string, and the ones this test's BEAM populates
+      # carry sensible values.
+      assert Enum.all?(Map.keys(json["build"]), &is_binary/1)
+      assert is_binary(json["build"]["otp"]) and byte_size(json["build"]["otp"]) > 0
+      assert json["build"]["elixir"] == System.version()
+      # Device platform is stringified — one of the three the schema names.
+      assert json["device"]["platform"] in ["ios", "android", "host"]
+    end
+
+    test "encodes {:plugin, name} owner as \"plugin:name\"" do
+      c =
+        Capsule.new(
+          kind: :beam_crash,
+          owner: {:plugin, :mob_biometric},
+          severity: :fatal,
+          fingerprint_key: %{module: SomeMod}
+        )
+
+      assert Capsule.to_json(c)["owner"] == "plugin:mob_biometric"
+    end
+
+    test "renders unencodable evidence terms as strings so Jason will not crash" do
+      c =
+        Capsule.new(
+          kind: :beam_crash,
+          owner: :mob,
+          severity: :fatal,
+          fingerprint_key: %{module: SomeMod},
+          evidence: %{pid: self(), ref: make_ref(), tuple: {:frame, {1, 2, 3, 4}}}
+        )
+
+      json = Capsule.to_json(c)
+
+      # inspect(self()) produces "#PID<0.N.0>" — the reduced value keeps the
+      # shape so a triager can still see there was a pid without any of the
+      # process state the pid holds.
+      assert String.starts_with?(json["evidence"]["pid"], "#PID<")
+      assert String.starts_with?(json["evidence"]["ref"], "#Reference<")
+      # A tuple survives as a list; every element is JSON-encodable
+      assert json["evidence"]["tuple"] == ["frame", [1, 2, 3, 4]]
+    end
+
+    test "the whole wire form encodes with Jason" do
+      c =
+        Capsule.new(
+          kind: :divergence,
+          owner: :mob,
+          severity: :warning,
+          fingerprint_key: %{reason: :type, path: [0, 2]},
+          evidence: %{ios: :button, android: :label}
+        )
+
+      json = c |> Capsule.to_json() |> Jason.encode!()
+      decoded = Jason.decode!(json)
+      assert decoded["schema"] == "mob.defect/1"
+      assert decoded["fingerprint"] == c.fingerprint
+    end
+  end
+end

--- a/test/mob/defect/sinks/dev_test.exs
+++ b/test/mob/defect/sinks/dev_test.exs
@@ -1,0 +1,97 @@
+defmodule Mob.Defect.Sinks.DevTest do
+  # Not async — Bus and Logger are process-global.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mob.Defect.Bus
+  alias Mob.Defect.Capsule
+  alias Mob.Defect.Sinks.Dev
+
+  setup do
+    Bus.start()
+    Bus.reset()
+    :ok
+  end
+
+  defp capsule(severity, kind \\ :invariant) do
+    Capsule.new(
+      kind: kind,
+      owner: :mob,
+      severity: severity,
+      fingerprint_key: %{invariant: :leaked_component, screen: MyScreen}
+    )
+  end
+
+  defp with_sink(fun) do
+    {:ok, pid} = Dev.start_link(name: :"dev_sink_#{System.unique_integer([:positive])}")
+
+    try do
+      fun.(pid)
+    after
+      # Give the sink a beat to process any last message before stopping,
+      # so tests can assert on Logger output without racing.
+      Process.sleep(20)
+      if Process.alive?(pid), do: GenServer.stop(pid)
+    end
+  end
+
+  test "logs at :error for fatal and critical capsules" do
+    log =
+      capture_log(fn ->
+        with_sink(fn _ ->
+          Bus.emit(capsule(:fatal))
+          Bus.emit(capsule(:critical, :beam_crash))
+          Process.sleep(20)
+        end)
+      end)
+
+    # Two [error] lines, one for each of :fatal and :critical
+    error_lines = log |> String.split("\n") |> Enum.filter(&String.contains?(&1, "[error]"))
+    assert length(error_lines) == 2
+  end
+
+  test "logs at :warning for warning severity" do
+    log =
+      capture_log(fn ->
+        with_sink(fn _ ->
+          Bus.emit(capsule(:warning))
+          Process.sleep(20)
+        end)
+      end)
+
+    assert log =~ "[warning]"
+    assert log =~ "defect warning"
+  end
+
+  test "the emitted line names the fingerprint (short form) and severity" do
+    c = capsule(:critical)
+    short = c.fingerprint |> String.replace_prefix("sha256:", "") |> String.slice(0, 8)
+
+    log =
+      capture_log(fn ->
+        with_sink(fn _ ->
+          Bus.emit(c)
+          Process.sleep(20)
+        end)
+      end)
+
+    assert log =~ "defect critical"
+    assert log =~ "fp=#{short}"
+  end
+
+  test "unsubscribes on terminate — no delivery after stop" do
+    {:ok, pid} = Dev.start_link(name: :"dev_sink_teardown_#{System.unique_integer([:positive])}")
+
+    Bus.emit(capsule(:warning))
+    Process.sleep(20)
+
+    # Sink is registered while alive
+    assert pid in Bus.subscribers()
+
+    GenServer.stop(pid)
+    Process.sleep(20)
+
+    refute pid in Bus.subscribers()
+  end
+end

--- a/test/mob/defect_test.exs
+++ b/test/mob/defect_test.exs
@@ -1,0 +1,157 @@
+defmodule Mob.DefectTest do
+  # Not async — the bus and invariant registry are process-global.
+  use ExUnit.Case, async: false
+
+  alias Mob.Defect
+  alias Mob.Defect.Bus
+  alias Mob.Invariant
+
+  setup do
+    Bus.start()
+    Bus.reset()
+    Invariant.start()
+    Invariant.reset()
+    Bus.unsubscribe()
+    :ok
+  end
+
+  describe "emit_invariant_violation/1" do
+    test "a confirmed invariant violation lands on the defect bus as :invariant/:mob" do
+      # Subscribe first so the fanout reaches this test process.
+      Bus.subscribe()
+
+      # A hand-built violation to avoid depending on the invariant maturation
+      # timing here — the wiring in `Mob.Invariant.record/1` uses this same
+      # entry point, and there is a separate test below that goes through the
+      # full registry path.
+      violation = %Invariant.Violation{
+        invariant: :leaked_component,
+        severity: :critical,
+        at: :on_screen_stop,
+        details: %{pid: :c.pid(0, 100, 0), count: 3},
+        screen: __MODULE__.FakeScreen,
+        monotonic_us: System.monotonic_time(:microsecond)
+      }
+
+      capsule = Defect.emit_invariant_violation(violation)
+
+      assert capsule.kind == :invariant
+      assert capsule.owner == :mob
+      assert capsule.severity == :critical
+      assert capsule.evidence.invariant == :leaked_component
+      assert capsule.evidence.screen == __MODULE__.FakeScreen
+
+      assert_receive {:mob_defect, ^capsule}, 500
+    end
+
+    test "two violations of the same invariant on the same screen share a fingerprint" do
+      v1 = %Invariant.Violation{
+        invariant: :leaked_component,
+        severity: :critical,
+        at: :on_screen_stop,
+        details: %{count: 1},
+        screen: __MODULE__.FakeScreen,
+        monotonic_us: 0
+      }
+
+      v2 = %{v1 | details: %{count: 2}}
+
+      a = Defect.emit_invariant_violation(v1)
+      b = Defect.emit_invariant_violation(v2)
+
+      assert a.fingerprint == b.fingerprint
+    end
+
+    test "the same invariant on a different screen fingerprints differently" do
+      v1 = %Invariant.Violation{
+        invariant: :leaked_component,
+        severity: :critical,
+        at: :on_screen_stop,
+        details: %{count: 1},
+        screen: __MODULE__.FakeScreenA,
+        monotonic_us: 0
+      }
+
+      v2 = %{v1 | screen: __MODULE__.FakeScreenB}
+
+      a = Defect.emit_invariant_violation(v1)
+      b = Defect.emit_invariant_violation(v2)
+
+      assert a.fingerprint != b.fingerprint
+    end
+  end
+
+  describe "emit_divergence/2" do
+    test "reports a divergence as :divergence/:mob with fixture on evidence" do
+      Bus.subscribe()
+
+      div = %{path: [0, 2], reason: :type, ios: :button, android: :label}
+      capsule = Defect.emit_divergence(div, fixture: :counter_screen)
+
+      assert capsule.kind == :divergence
+      assert capsule.owner == :mob
+      assert capsule.severity == :warning
+      assert capsule.evidence.reason == :type
+      assert capsule.evidence.ios == :button
+      assert capsule.evidence.android == :label
+      assert capsule.evidence.fixture == :counter_screen
+
+      assert_receive {:mob_defect, ^capsule}, 500
+    end
+
+    test "same fixture + reason + path fingerprint the same across tree-value changes" do
+      div_a = %{path: [0, 2], reason: :type, ios: :button, android: :label}
+      div_b = %{path: [0, 2], reason: :type, ios: :text_field, android: :label}
+
+      a = Defect.emit_divergence(div_a, fixture: :counter_screen)
+      b = Defect.emit_divergence(div_b, fixture: :counter_screen)
+
+      # Evidence differs; fingerprint does not.
+      assert a.fingerprint == b.fingerprint
+    end
+
+    test "a different fixture, path, or reason changes the fingerprint" do
+      base = %{path: [0, 2], reason: :type, ios: :button, android: :label}
+
+      a = Defect.emit_divergence(base, fixture: :counter_screen)
+      b = Defect.emit_divergence(base, fixture: :other_screen)
+      c = Defect.emit_divergence(%{base | path: [1]}, fixture: :counter_screen)
+      d = Defect.emit_divergence(%{base | reason: :label}, fixture: :counter_screen)
+
+      # Each of the three changes moves the fingerprint away from the base.
+      assert a.fingerprint != b.fingerprint
+      assert a.fingerprint != c.fingerprint
+      assert a.fingerprint != d.fingerprint
+    end
+  end
+
+  describe "wiring: invariant registry → bus" do
+    test "a confirmed violation on the registry emits a defect on the bus" do
+      Bus.subscribe()
+
+      # Zero the maturation age so `Mob.Invariant.run/2` confirms on the second
+      # sample immediately — the same knob the invariant test suite uses.
+      Application.put_env(:mob, :invariant_min_candidate_age_us, 0)
+
+      Invariant.register(:test_ping,
+        at: :periodic,
+        severity: :critical,
+        check: fn _ -> {:violation, %{seen: 1}} end
+      )
+
+      Invariant.run(:periodic)
+      # Second run must return a confirmed violation, which calls record/1
+      # which emits the capsule.
+      confirmed = Invariant.run(:periodic)
+      assert length(confirmed) == 1
+
+      assert_receive {:mob_defect, capsule}, 500
+      assert capsule.kind == :invariant
+      assert capsule.owner == :mob
+      assert capsule.evidence.invariant == :test_ping
+
+      Invariant.unregister(:test_ping)
+      Application.delete_env(:mob, :invariant_min_candidate_age_us)
+    end
+  end
+end


### PR DESCRIPTION
MOB-159 phase 1: capture + defect bus + owner attribution — the steps 1-3 of the incident-to-draft-PR loop. Steps 4-8 (repro, minimize, regression-first test, draft PR) are follow-ups, per the [ticket's own sequencing](https://linear.app/mobframework/issue/MOB-159).

Ships:

- **`Mob.Defect.Capsule`** — the `mob.defect/1` struct from `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`. `new/1` builds the capsule, populates `build` and `device` automatically (device cached in `:persistent_term`), tags `redaction: :applied` on the caller-trust contract, and truncates evidence at 4096 bytes per string / 64 elements per list / 8 levels of depth so a malicious deep term cannot exhaust the packager. `fingerprint/3` is a sha256 over `kind + owner + fingerprint_key` only — time, id, build, and device are excluded so a defect groups across releases and devices. `to_json/1` produces the wire form; the whole capsule round-trips through Jason.
- **`Mob.Defect.Bus`** — in-process pub/sub with two ETS tables (`classes` keyed by fingerprint carrying the first capsule + occurrences counter, and a bounded 64-entry ring of recent capsules). `emit/1` is on the write path — no GenServer round-trip, mirroring `Mob.Agent.Receipts.record/1`. Subscribers stored in `:persistent_term` for zero-round-trip fanout and monitored by the owner GenServer so a subscriber exit prunes itself.
- **`Mob.Defect.Sinks.Dev`** — opt-in GenServer that subscribes on init and Logger-writes each capsule at a severity-driven level. Not started by default — per the decision record, mob owns the format and the bus but never the destination.
- **`Mob.Defect`** — `emit_invariant_violation/1` and `emit_divergence/2` map from a detector's native shape to a capsule with the right owner, kind, and fingerprint key.

Wired: `Mob.Invariant.record/1` emits a capsule for every confirmed violation. Not wired in this PR: the differential emit-point is a follow-up mob_dev change that lands after this ships to Hex (MOB-159 will get a mob_dev PR link once that opens).

See `decisions/2026-09-11-fingerprint-and-evidence-are-separate.md` for the fingerprint-vs-evidence split — the non-obvious design call that keeps enrichment from shattering triage groups across releases.

## Not in this PR

- Steps 4-8 of the pipeline (device lease, minimization, regression-first test, draft PR). Those unlock per bug class starting with differential, once the false-positive rate is observable — MOB-157 shipped yesterday, no run history yet to gauge.
- A production sink. Per the decision record, that is the app developer's decision. Subscribing to the bus is `Mob.Defect.Bus.subscribe/0` plus a `handle_info({:mob_defect, capsule}, ...)`; the format is the schema.
- mob_dev wiring for `Mob.Differential`. Follow-up PR against mob_dev once this ships to Hex.

## Gates

- `mix compile --warnings-as-errors --force` — clean
- `mix format --check-formatted` — clean
- `mix credo --strict` — 0 issues across all 197 source files
- `mix erlfmt --check src/` — clean
- `mix test` — 1732 pass (35 new tests in `test/mob/defect/**` and `test/mob/defect_test.exs`), 0 fail
- Revert-test bar: spot-checked. Fingerprint stability test was strengthened after a false-positive (small-map literal iteration is content-stable on modern Erlang, so the meaningful stress case is mixed atom/string keys). Device-cache tests confirmed to fail when caching is removed.
- Adversarial subagent review before commit (per CLAUDE.md).

Closes phase 1 of MOB-159; keeps the ticket open for the remaining phases.
