### PR TITLE
Bump to 0.8.1 — defect capsule, bus, and owner attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ---
 
-## [Unreleased]
+## [0.8.1] - 2026-09-11
 
 ### Added
 - **Defect bus — `Mob.Defect`, `Mob.Defect.Capsule`, `Mob.Defect.Bus`,
@@ -47,9 +47,10 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   `Mob.Differential`'s divergence map) to a capsule with the right owner,
   kind, and fingerprint key.
 
-  Wired: `Mob.Invariant.record/1` now emits a capsule for every confirmed
-  violation. Not wired in this PR: the differential emit-point is a
-  follow-up mob_dev change that lands after this ships to Hex.
+  Wired: the invariant registry's record path now emits a capsule for
+  every confirmed violation. Not wired in this release: the differential
+  emit-point, a follow-up mob_dev change that lands after this ships to
+  Hex.
 
   See `decisions/2026-09-11-fingerprint-and-evidence-are-separate.md` for
   the fingerprint-vs-evidence design.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mob.MixProject do
   def project do
     [
       app: :mob,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
Cut mob 0.8.1 to Hex — patch bump for [MOB-159 phase 1](https://linear.app/mobframework/issue/MOB-159): the `Mob.Defect` subsystem (capsule, bus, dev sink, owner attribution) that landed as #152, plus the invariant registry's wire-up to emit capsules for confirmed violations.

Additive-only. `git log 0.8.0..HEAD` = one prior merge (#152). Nothing removed, no API changes to what was already published.

## Release-review gate

Subagent reviewed `git diff 0.8.0..HEAD` before the bump — verdict RELEASE OK. Verified:
- version-sanity — 0.8.1 not on Hex yet, `mix hex.info mob` currently shows 0.8.0 as latest
- shipping window matches CHANGELOG — every module the diff adds is enumerated in the `[0.8.1]` section
- cross-repo lockstep is a no-op — mob_dev pins `~> 0.7.25 or ~> 0.8` (resolves cleanly) and does not yet call `Mob.Defect`
- public surface is fully doc-covered — every public function has `@doc`, ready for hexdocs
- seam — the injected `Mob.Defect.emit_invariant_violation/1` in the invariant sampler's write path does not break the pre-existing invariant suite (21 pass)

One nitpick — CHANGELOG referenced `Mob.Invariant.record/1` which is `defp`; reworded to "the invariant registry's record path" in this bump commit.

## Local preflight

- `mix format --check-formatted` clean
- `mix credo --strict` 0 issues (2276 mods/funs)
- `mix compile --warnings-as-errors --force` clean
- `mix test` 1736 pass, 0 fail, 38 excluded
- Pre-push hook full-suite preflight (fires when mix.exs changes) green

## Trigger

Per RELEASE.md, the release workflow fires on a push to master modifying `mix.exs`. Merging this PR (squash) puts the bump commit on master and the workflow does tag → GitHub Release → `mix hex.publish --yes`, each step independently idempotent.
