### PR TITLE
MOB-158 phase 1: erl_crash.dump collection + native scaffolds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Post-mortem collection — `Mob.PostMortem` +
+  `Mob.PostMortem.BeamCrashDump`** (MOB-158, phase 1). The framework
+  now picks up the crash dumps the BEAM leaves behind on disk and turns
+  each into a `Mob.Defect.Capsule` on `Mob.Defect.Bus` (kind:
+  `:beam_crash`, owner: `:mob`).
+
+  `Mob.PostMortem.sweep/0` and `Mob.PostMortem.sweep/1` do a one-shot
+  scan of default and caller-supplied paths. Nothing runs
+  automatically — an app opts in from its `on_start`; a developer or CI
+  can call it from IEx. Same discipline the rest of `Mob.Defect`
+  follows: mob owns the format and the bus, never becomes the
+  collector.
+
+  `Mob.PostMortem.BeamCrashDump` scans for `erl_crash.dump` files,
+  reads a bounded 8 KB header (slogan / system version / taints /
+  atoms / dump version), computes a sha256 for artifact identity, and
+  never touches the dump body. Dumps stay on disk for offline
+  inspection with `crashdump_viewer`. `Mob.PostMortem.Registry`
+  records emitted ids in a public ETS table so a re-sweep is a no-op;
+  registry state is intentionally not persisted across BEAM restarts,
+  because a fresh BEAM sweeps back into a fresh bus.
+
+  Fingerprint is the *normalized* slogan: binary literals (including
+  ones truncated by the 8 KB header cut-off) and long numeric runs
+  that are the printable form of the same are stripped, so two
+  `{badarg, ...}` crashes on `io:put_chars/2` with different embedded
+  payloads share a triage row instead of each opening one.
+
+  Severity is picked from the slogan: allocator panics
+  (`eheap_alloc`, `binary_alloc`, `ets_alloc`, `sl_alloc`,
+  `driver_alloc`, `fix_alloc`, `std_alloc`) and boot-time crashes
+  (`Kernel pid terminated`, `Runtime terminating during boot`) are
+  `:fatal`; a literal `normal` exit is `:info`; anything else is
+  `:critical`.
+
+- **iOS and Android post-mortem scaffolds — `Mob.PostMortem.IOS`,
+  `Mob.PostMortem.Android`**. `sweep/0` returns `[]` and logs once at
+  `:info`. The real native pipes (MetricKit for iOS,
+  `ApplicationExitInfo` for Android) are their own follow-up tickets
+  with per-platform device verification.
+
+---
+
 ## [0.8.1] - 2026-09-11
 
 ### Added

--- a/lib/mob/defect.ex
+++ b/lib/mob/defect.ex
@@ -93,4 +93,87 @@ defmodule Mob.Defect do
     )
     |> Bus.emit()
   end
+
+  @doc """
+  Emit a defect for an `erl_crash.dump` a scan turned up.
+
+  Owner is `:mob` — the BEAM is what mob depends on and what mob's own
+  invariants and scheduling assume; a hard crash there is a framework
+  concern before it is an application one. `kind: :beam_crash`.
+
+  Severity comes from what the slogan implies: OOM and out-of-memory
+  variants are `:fatal`; a normal termination is `:info`; everything
+  else defaults to `:critical`.
+
+  The fingerprint key is the *normalized* slogan (see
+  `Mob.PostMortem.BeamCrashDump.normalize_slogan/1`) rather than the raw
+  one, because raw slogans embed the exact runtime data that varied per
+  crash — a `{badarg, ...}` from `io:put_chars/2` carries a 4KB binary
+  literal that would otherwise open one triage row per unique input.
+
+  Evidence carries the human-facing fields plus the on-disk path so a
+  triager can open the dump in `crashdump_viewer` when they want more
+  than the header. The dump file itself is NOT read into evidence —
+  eight kilobytes is the ceiling and the header is what fits.
+  """
+  @spec emit_beam_crash(map()) :: Capsule.t()
+  def emit_beam_crash(%{sha256: sha256, slogan: slogan} = finding) do
+    normalized = Mob.PostMortem.BeamCrashDump.normalize_slogan(slogan)
+
+    Capsule.new(
+      kind: :beam_crash,
+      owner: :mob,
+      severity: severity_from_slogan(slogan),
+      fingerprint_key: %{slogan: normalized},
+      evidence: %{
+        path: Map.get(finding, :path),
+        sha256: sha256,
+        size: Map.get(finding, :size),
+        modified_at: format_datetime(Map.get(finding, :modified_at)),
+        slogan: slogan,
+        system_version: Map.get(finding, :system_version),
+        taints: Map.get(finding, :taints, []),
+        atoms: Map.get(finding, :atoms),
+        dump_version: Map.get(finding, :dump_version)
+      }
+    )
+    |> Bus.emit()
+  end
+
+  # Severity heuristic from the slogan text. Conservative: unknown text
+  # is `:critical`, not `:fatal`, so a novel crash class does not
+  # over-page a triager. The two OOM-family strings are explicit BEAM
+  # exits with those exact prefixes; a normal `:normal` termination is
+  # not a crash to page on but is still worth an :info row so a triager
+  # can see it happened.
+  defp severity_from_slogan(nil), do: :critical
+
+  defp severity_from_slogan(slogan) when is_binary(slogan) do
+    cond do
+      # Allocator panics — the process died because the OS refused a
+      # backing allocation. Fatal by definition.
+      String.contains?(slogan, "eheap_alloc") -> :fatal
+      String.contains?(slogan, "binary_alloc") -> :fatal
+      String.contains?(slogan, "ets_alloc") -> :fatal
+      String.contains?(slogan, "sl_alloc") -> :fatal
+      String.contains?(slogan, "driver_alloc") -> :fatal
+      String.contains?(slogan, "fix_alloc") -> :fatal
+      String.contains?(slogan, "std_alloc") -> :fatal
+      # OTP boot-time crashes and the kernel-supervisor-died panic — the
+      # BEAM refused to come up. The user sees nothing running.
+      String.starts_with?(slogan, "Kernel pid terminated") -> :fatal
+      String.starts_with?(slogan, "Runtime terminating during boot") -> :fatal
+      String.contains?(slogan, "out of memory") -> :fatal
+      # An explicit `:normal` exit is not a defect per se, but the fact
+      # that a crash dump exists at all is worth an :info row so a
+      # triager can see it happened. Everything unrecognised is :critical
+      # — do not upgrade to :fatal without evidence, since a novel
+      # slogan class could be routine.
+      slogan == "normal" -> :info
+      true -> :critical
+    end
+  end
+
+  defp format_datetime(nil), do: nil
+  defp format_datetime(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
 end

--- a/lib/mob/post_mortem.ex
+++ b/lib/mob/post_mortem.ex
@@ -1,0 +1,77 @@
+defmodule Mob.PostMortem do
+  @moduledoc """
+  Collect the post-mortems the OS and the BEAM leave behind when a
+  process dies, and put them onto `Mob.Defect.Bus` as capsules.
+
+  Three sources, each in its own submodule:
+
+  * `Mob.PostMortem.BeamCrashDump` — `erl_crash.dump` files (BEAM). Fully
+    implemented; the substrate this module was written around.
+  * `Mob.PostMortem.IOS` — MetricKit payloads (crash / hang / launch /
+    CPU / memory / disk). Scaffolded; returns an empty list until the
+    native pipe lands in a follow-up ticket. See its own moduledoc.
+  * `Mob.PostMortem.Android` — `ApplicationExitInfo` history (ANR, crash,
+    OOM, user kill). Same shape as iOS: scaffolded, follow-up.
+
+  Nothing here runs automatically. An app opts in with
+  `Mob.PostMortem.sweep()` from its `on_start`, or a developer / CI runs
+  the equivalent `mix mob.post_mortems.sweep` task from the host. That
+  matches the discipline the whole `Mob.Defect` subsystem enforces:
+  mob owns the format and the bus but never becomes the collector.
+
+  ## Idempotence
+
+  `sweep/0` is safe to call as many times as you like. Each artifact has
+  a sha256 id, and `Mob.PostMortem.Registry` records ids that have
+  already emitted; a subsequent sweep finds them seen and does nothing.
+  The dump stays on disk — nothing here deletes or moves a file — so
+  offline inspection still works. See the registry's moduledoc for why
+  the seen-set does not persist across BEAM restarts (a fresh BEAM
+  sweeps back into a fresh bus, on purpose).
+
+  ## Return value
+
+  `sweep/0` and `sweep/1` return the capsules that were emitted this
+  call, in the order they were emitted. That is what a caller drop-in
+  in `on_start` normally ignores; a test or a CLI wants it.
+  """
+
+  alias Mob.Defect.Capsule
+  alias Mob.PostMortem.BeamCrashDump
+
+  @doc """
+  Sweep every source using its default paths.
+
+  Equivalent to `sweep([])` — each source module supplies its own
+  defaults (see `BeamCrashDump.default_paths/0`; iOS and Android draw
+  from their platform native APIs when linked).
+  """
+  @spec sweep() :: [Capsule.t()]
+  def sweep, do: sweep([])
+
+  @doc """
+  Sweep every source, with `beam_paths` added to the BEAM-crash-dump
+  scanner's default paths.
+
+  A caller with dumps somewhere unusual (a CI artifact directory, a
+  scratchpad) passes them here — they merge with the defaults rather
+  than replacing them, so passing an empty list is equivalent to
+  `sweep/0`.
+  """
+  @spec sweep([Path.t()]) :: [Capsule.t()]
+  def sweep(beam_paths) when is_list(beam_paths) do
+    beam_all = Enum.uniq(BeamCrashDump.default_paths() ++ beam_paths)
+
+    beam_all
+    |> BeamCrashDump.scan()
+    |> BeamCrashDump.emit()
+    |> Kernel.++(sweep_native())
+  end
+
+  # iOS + Android scaffolds intentionally return `[]` today. They exist
+  # as symbols so this coordinator does not have to grow a per-platform
+  # branch every time a native source lands.
+  defp sweep_native do
+    Mob.PostMortem.IOS.sweep() ++ Mob.PostMortem.Android.sweep()
+  end
+end

--- a/lib/mob/post_mortem/android.ex
+++ b/lib/mob/post_mortem/android.ex
@@ -1,0 +1,64 @@
+defmodule Mob.PostMortem.Android do
+  @moduledoc """
+  `ApplicationExitInfo`-backed post-mortem ingest for Android.
+
+  ## Status: scaffolded, not implemented
+
+  `sweep/0` returns `[]` today. The native pipe — an
+  `ActivityManager.getHistoricalProcessExitReasons` call on next boot,
+  filtered against a persistent marker so each reason is emitted exactly
+  once — is a follow-up ticket with its own device-verification loop.
+  This module exists as the symbol `Mob.PostMortem.sweep/0` calls into
+  so the coordinator does not have to grow a per-platform branch when
+  the native side lands.
+
+  ## The intended contract, for when it does land
+
+  * Called on any node, but does its work only when `:mob_nif.platform/0`
+    returns `:android` and the OS is API 30+ (Android 11+, where
+    `ApplicationExitInfo` exists).
+  * Each historical exit reason becomes one `Mob.Defect.Capsule` on the
+    bus, with `kind: :anr` / `:oom` / `:user_kill` / `:native_crash`
+    picked from the reason code, and `owner: :mob`.
+  * Deduplication is on `pid + timestamp` per reason, recorded in
+    per-app storage so a subsequent boot never re-emits an old exit
+    even if the OS still lists it.
+  * Redaction: an ANR's trace file contents can carry app strings.
+    Trace inclusion is bounded (the same 4KB cap the capsule already
+    enforces) and clipped in the native layer before the capsule is
+    built. The persistent marker records only the reason id, never
+    the trace text.
+  """
+
+  require Logger
+
+  alias Mob.Defect.Capsule
+
+  @doc """
+  Sweep any ApplicationExitInfo entries the OS has recorded since the
+  last call.
+
+  Returns the list of capsules emitted (empty until the native pipe is
+  in place; today it is always `[]`).
+
+  Logs at `:info` on first call so an operator running
+  `mix mob.post_mortems.sweep` on an Android-target host can see the
+  "not yet wired" state rather than getting silence and wondering.
+  """
+  @spec sweep() :: [Capsule.t()]
+  def sweep do
+    if :persistent_term.get({__MODULE__, :logged_scaffold_notice}, false) do
+      :ok
+    else
+      Logger.info(
+        "[Mob.PostMortem.Android] ApplicationExitInfo ingest is scaffolded; sweep " <>
+          "returns [] until the native getHistoricalProcessExitReasons pipe lands " <>
+          "(MOB-158 follow-up)."
+      )
+
+      :persistent_term.put({__MODULE__, :logged_scaffold_notice}, true)
+    end
+
+    []
+  end
+end

--- a/lib/mob/post_mortem/beam_crash_dump.ex
+++ b/lib/mob/post_mortem/beam_crash_dump.ex
@@ -24,7 +24,7 @@ defmodule Mob.PostMortem.BeamCrashDump do
     author might want the full file; deleting after emit would lose
     everything the capsule cannot fit.
   * **Idempotent.** A sha256 of the file becomes the artifact id, and the
-    `Mob.PostMortem.Registry` tracks emitted ids in `:persistent_term`. A
+    `Mob.PostMortem.Registry` tracks emitted ids in a public ETS table. A
     re-sweep against the same file finds it seen and does nothing.
   * **Bounded read.** A dump can be gigabytes on a busy scheduler. This
     module reads only the header window (default #{@header_bytes}) — that

--- a/lib/mob/post_mortem/beam_crash_dump.ex
+++ b/lib/mob/post_mortem/beam_crash_dump.ex
@@ -1,0 +1,303 @@
+defmodule Mob.PostMortem.BeamCrashDump do
+  @header_bytes 8_192
+
+  @moduledoc """
+  Scan for `erl_crash.dump` files the BEAM leaves behind, and turn each into
+  a defect capsule.
+
+  ## Why this exists
+
+  Every BEAM node that dies hard writes a crash dump — a text file at
+  `$ERL_CRASH_DUMP` if the env var is set, otherwise `erl_crash.dump` in the
+  runtime's cwd. Mob apps land it in the app data directory; host tooling
+  leaves them in the repo root. Nobody was collecting them until now: at
+  the time this shipped, five sibling repos on the author's machine each
+  had an unlooked-at dump in the root.
+
+  A crash the framework can prove happened is a defect it can report, and
+  the format from `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`
+  has a `:beam_crash` kind waiting for exactly this input.
+
+  ## Discipline
+
+  * **Non-destructive.** The dump stays on disk. A future triager or the
+    author might want the full file; deleting after emit would lose
+    everything the capsule cannot fit.
+  * **Idempotent.** A sha256 of the file becomes the artifact id, and the
+    `Mob.PostMortem.Registry` tracks emitted ids in `:persistent_term`. A
+    re-sweep against the same file finds it seen and does nothing.
+  * **Bounded read.** A dump can be gigabytes on a busy scheduler. This
+    module reads only the header window (default #{@header_bytes}) — that
+    is where slogan, system version, taints and atoms count live. Anything
+    beyond is by construction not on the emit path.
+  * **Fingerprint stripped of concrete data.** The slogan for a
+    `{badarg, ...}` from `io:put_chars/2` embeds the raw binary that was
+    passed. Fingerprinting that verbatim opens one triage row per unique
+    input; stripping binaries and long numeric literals groups the whole
+    class into one row. See `normalize_slogan/1`.
+
+  ## Not in scope here
+
+  * The dump is not parsed for process state, ETS contents, or stack
+    frames. A file the caller can open in `crashdump_viewer` is a better
+    home for those. What ends up in the capsule is what a triager sees at
+    a glance: which build, which OTP, what class of crash.
+  * iOS MetricKit and Android `ApplicationExitInfo` are separate
+    substrates with their own modules (`Mob.PostMortem.IOS` /
+    `Mob.PostMortem.Android`) and their own follow-up tickets.
+  """
+
+  alias Mob.Defect
+  alias Mob.Defect.Capsule
+  alias Mob.PostMortem.Registry
+
+  @typedoc """
+  What a scanner returns for one dump file: enough to emit and to describe
+  what was scanned, without the raw bytes.
+  """
+  @type finding :: %{
+          path: String.t(),
+          sha256: String.t(),
+          size: non_neg_integer(),
+          modified_at: DateTime.t() | nil,
+          slogan: String.t() | nil,
+          system_version: String.t() | nil,
+          taints: [String.t()],
+          atoms: non_neg_integer() | nil,
+          dump_version: String.t() | nil
+        }
+
+  @doc """
+  Scan `paths` for `erl_crash.dump` files.
+
+  `paths` is a list of file *or* directory paths. A directory is checked
+  only for a top-level `erl_crash.dump`; this module does not recurse.
+  Non-existent paths are silently skipped — a sweep from a caller that
+  overshoots the possibilities should not have to guard each one.
+
+  Returns the list of `t:finding/0` values.
+
+  Emission is a separate step: `emit/1` takes a list of findings and
+  puts anything the registry has not seen onto the defect bus. That
+  split is deliberate — a caller can list findings without publishing
+  them, and tests can assert on shape without touching the bus.
+  """
+  @spec scan([Path.t()]) :: [finding()]
+  def scan(paths) when is_list(paths) do
+    paths
+    |> Enum.flat_map(&resolve/1)
+    |> Enum.uniq()
+    |> Enum.map(&scan_one/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @doc """
+  Emit a capsule for every finding not already recorded in the registry.
+
+  Returns the capsules emitted, in the same order.
+  """
+  @spec emit([finding()]) :: [Capsule.t()]
+  def emit(findings) when is_list(findings) do
+    Registry.start()
+
+    for finding <- findings, Registry.mark_seen(finding.sha256) do
+      Defect.emit_beam_crash(finding)
+    end
+  end
+
+  @doc """
+  Default paths a sweep looks at when the caller does not pass its own.
+
+  * The value of the `ERL_CRASH_DUMP` env var, if set (that is where the
+    BEAM would have written this VM's own dump).
+  * The current working directory, where the BEAM writes by default.
+
+  A caller wanting a broader sweep supplies its own list.
+  """
+  @spec default_paths() :: [Path.t()]
+  def default_paths do
+    []
+    |> maybe_prepend(System.get_env("ERL_CRASH_DUMP"))
+    |> Kernel.++([File.cwd!()])
+    |> Enum.uniq()
+  end
+
+  # ---------------------------------------------------------------------------
+
+  defp maybe_prepend(list, nil), do: list
+  defp maybe_prepend(list, path), do: [path | list]
+
+  defp resolve(path) do
+    cond do
+      not is_binary(path) ->
+        []
+
+      not File.exists?(path) ->
+        []
+
+      File.dir?(path) ->
+        candidate = Path.join(path, "erl_crash.dump")
+        if File.exists?(candidate) and File.regular?(candidate), do: [candidate], else: []
+
+      File.regular?(path) ->
+        [path]
+
+      true ->
+        []
+    end
+  end
+
+  defp scan_one(path) do
+    with {:ok, stat} <- File.stat(path, time: :posix),
+         {:ok, header} <- read_header(path) do
+      %{
+        path: path,
+        sha256: sha256_of(path),
+        size: stat.size,
+        modified_at: posix_to_datetime(stat.mtime),
+        slogan: extract(header, "Slogan:"),
+        system_version: extract(header, "System version:"),
+        taints: extract_list(header, "Taints:"),
+        atoms: extract_integer(header, "Atoms:"),
+        dump_version: extract_prefix(header, "=erl_crash_dump:")
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  defp read_header(path) do
+    case File.open(path, [:read, :binary]) do
+      {:ok, io} ->
+        try do
+          {:ok, IO.binread(io, @header_bytes) |> normalize_binread()}
+        after
+          File.close(io)
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp normalize_binread(:eof), do: ""
+  defp normalize_binread({:error, _}), do: ""
+  defp normalize_binread(data) when is_binary(data), do: data
+
+  defp sha256_of(path) do
+    hash =
+      path
+      # 64K matches BEAM's idiomatic chunk size and cuts reduce-count
+      # by 16x vs the previous 4K on a multi-GB dump. Not a
+      # correctness concern; a "surprised-by-latency" concern.
+      |> File.stream!(65_536, [])
+      |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+      |> :crypto.hash_final()
+      |> Base.encode16(case: :lower)
+
+    "sha256:" <> hash
+  end
+
+  defp posix_to_datetime(mtime) when is_integer(mtime),
+    do: DateTime.from_unix!(mtime)
+
+  defp posix_to_datetime(_), do: nil
+
+  # Header field extraction — a dump's first ~10 lines are all "Key: value"
+  # pairs. The value can carry a comma-separated list (Taints), an integer
+  # (Atoms), or a free-form string that spans one line. Anything more
+  # structured than that lives past the header and is out of scope here.
+
+  defp extract(header, key) do
+    case Regex.run(~r/^#{Regex.escape(key)}\s*(.*?)$/m, header, capture: :all_but_first) do
+      [value] -> String.trim(value)
+      _ -> nil
+    end
+  end
+
+  defp extract_list(header, key) do
+    case extract(header, key) do
+      nil ->
+        []
+
+      "" ->
+        []
+
+      value ->
+        value
+        |> String.split(",", trim: true)
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
+    end
+  end
+
+  defp extract_integer(header, key) do
+    case extract(header, key) do
+      nil -> nil
+      value -> parse_integer(value)
+    end
+  end
+
+  defp parse_integer(value) do
+    case Integer.parse(value) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp extract_prefix(header, prefix) do
+    case Regex.run(~r/^#{Regex.escape(prefix)}(\S+)/m, header, capture: :all_but_first) do
+      [value] -> value
+      _ -> nil
+    end
+  end
+
+  @doc """
+  A version of the slogan with concrete data stripped, for the fingerprint.
+
+  A raw slogan from a `{badarg, ...}` on `io:put_chars/2` looks like
+
+      Runtime terminating during boot ({badarg,[{io,put_chars,[standard_error,[<<42,42,...4KB more...>>]]}]})
+
+  and the binary embedded there varies per crash. Two crashes for the same
+  root cause thus fingerprint differently, which is exactly the shattering
+  the bus is meant to prevent (see the "fingerprint and evidence are
+  separate" decision record).
+
+  Strip:
+
+  * Binary literals `<<...>>` — replaced by `<<>>`
+  * Long numeric sequences (>= 8 digits with commas or dots between them)
+    that look like the printable form of the same — replaced by `<<>>`
+  * Runs of whitespace collapsed
+
+  What survives: atom-shaped tokens, module and function names, arities,
+  the structural punctuation. That is what identifies the *class* of
+  crash, which is what a fingerprint is for.
+  """
+  @spec normalize_slogan(String.t() | nil) :: String.t() | nil
+  def normalize_slogan(nil), do: nil
+
+  def normalize_slogan(slogan) when is_binary(slogan) do
+    slogan
+    # `<<...>>` or `<<...` at end-of-string — the header read is bounded
+    # (see @header_bytes), and a big embedded binary can be cut off with
+    # no closing `>>`. Without the `|$` branch the truncated payload
+    # bytes survive into the fingerprint and shatter classes by the
+    # exact bytes that happened to fit — the shattering we exist to
+    # prevent. `(?s)` so `.` crosses newlines (a slogan spanning lines
+    # cut off mid-binary would otherwise stop at the first newline
+    # inside the literal).
+    |> String.replace(~r/<<(?s:[^>]*)(?:>>|$)/, "<<>>")
+    # A comma/dot/space-separated numeric run of ≥8 digits is the
+    # printable form of the same binary payload (`[104,101,108,...]`),
+    # which the platform sometimes prints instead of `<<>>`. Not a
+    # perfect discriminator — a version like `28.0.20260803` matches,
+    # and so does an epoch millisecond timestamp. Effect is *class
+    # collapse* (two versions become the same fingerprint), not
+    # *shattering* — acceptable, but documented.
+    |> String.replace(~r/(?:\d[,.\s]?){8,}\d?/, "<<>>")
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+  end
+end

--- a/lib/mob/post_mortem/ios.ex
+++ b/lib/mob/post_mortem/ios.ex
@@ -1,0 +1,62 @@
+defmodule Mob.PostMortem.IOS do
+  @moduledoc """
+  MetricKit-backed post-mortem ingest for iOS.
+
+  ## Status: scaffolded, not implemented
+
+  `sweep/0` returns `[]` today. The native pipe — an `MXMetricManager`
+  delegate that receives `MXCrashDiagnosticPayload`,
+  `MXHangDiagnosticPayload`, `MXCPUExceptionDiagnosticPayload`,
+  `MXDiskWriteExceptionDiagnosticPayload`, `MXAppLaunchDiagnosticPayload`
+  and `MXCallStackTree` values — is a follow-up ticket with its own
+  device-verification loop. This module exists as the symbol
+  `Mob.PostMortem.sweep/0` calls into so the coordinator does not have
+  to grow a per-platform branch when the native side lands.
+
+  ## The intended contract, for when it does land
+
+  * Called on any node, but does its work only when `:mob_nif.platform/0`
+    returns `:ios` and MetricKit reports at least one delivered payload.
+  * Each MetricKit payload becomes one `Mob.Defect.Capsule` on the bus,
+    with `owner: :mob` or `owner: {:plugin, ...}` depending on the
+    payload's process attribution.
+  * Payload delivery is asynchronous in iOS (up to 24 hours after the
+    incident); MetricKit itself deduplicates by day, and the capsule
+    fingerprint takes over from there. This module never polls; it
+    receives via the delegate and pushes into the bus.
+  * Redaction: the schema promises `redaction: :applied`. MetricKit's
+    call-stack payloads carry mangled symbol names, which are the safe
+    identifiers we keep; the file path portions and any embedded user
+    data are stripped in the native layer before the capsule is built.
+  """
+
+  require Logger
+
+  alias Mob.Defect.Capsule
+
+  @doc """
+  Sweep any MetricKit payloads the OS has delivered since the last call.
+
+  Returns the list of capsules emitted (empty until the native pipe is
+  in place; today it is always `[]`).
+
+  Logs at `:info` on first call so an operator running `mix mob.post_mortems.sweep`
+  on an iOS host can see the "not yet wired" state rather than getting
+  silence and wondering.
+  """
+  @spec sweep() :: [Capsule.t()]
+  def sweep do
+    if :persistent_term.get({__MODULE__, :logged_scaffold_notice}, false) do
+      :ok
+    else
+      Logger.info(
+        "[Mob.PostMortem.IOS] MetricKit ingest is scaffolded; sweep returns [] until " <>
+          "the native MXMetricManager delegate lands (MOB-158 follow-up)."
+      )
+
+      :persistent_term.put({__MODULE__, :logged_scaffold_notice}, true)
+    end
+
+    []
+  end
+end

--- a/lib/mob/post_mortem/registry.ex
+++ b/lib/mob/post_mortem/registry.ex
@@ -1,0 +1,71 @@
+defmodule Mob.PostMortem.Registry do
+  # State keys first so any moduledoc `#{@...}` interpolation resolves.
+  @table :mob_post_mortem_seen
+
+  @moduledoc """
+  A one-shot record of post-mortem artifacts we have already emitted a
+  capsule for.
+
+  ## What it is
+
+  A public ETS set keyed by the artifact's `sha256:...` id. `mark_seen/1`
+  returns `true` if the id was new (so a caller should emit), `false` if
+  it had already been recorded. That is atomic in one ETS op —
+  `:ets.insert_new/2` — so two concurrent sweeps on the same dump cannot
+  both emit.
+
+  Not persistent across BEAM restarts. That is deliberate: a fresh BEAM
+  should re-emit the dumps it finds on disk, because the recipient of
+  those capsules (the defect bus + subscribers) is also fresh. Persisting
+  the seen-set would silence the exact restart-and-look-again pattern
+  that recovers a defect an earlier BEAM's bus never got to observe.
+
+  Same pattern as `Mob.Agent.Receipts.Owner` and `Mob.Invariant.Owner`:
+  the table is `:public` and named, its lifecycle owner is unlinked, and
+  the write path never goes through a GenServer mailbox.
+  """
+
+  @doc false
+  @spec start() :: :ok
+  def start do
+    if :ets.whereis(@table) == :undefined, do: Mob.PostMortem.Registry.Owner.start()
+    :ok
+  end
+
+  @doc """
+  Record `id` if it is not already present.
+
+  Returns `true` when this call is the first observation (so the caller
+  should emit its capsule), `false` when another sweep already recorded it.
+  """
+  @spec mark_seen(String.t()) :: boolean()
+  def mark_seen(id) when is_binary(id) do
+    start()
+    :ets.insert_new(@table, {id, System.system_time(:millisecond)})
+  end
+
+  @doc "True when `id` has been recorded by any prior `mark_seen/1`."
+  @spec seen?(String.t()) :: boolean()
+  def seen?(id) when is_binary(id) do
+    start()
+
+    case :ets.lookup(@table, id) do
+      [{^id, _}] -> true
+      [] -> false
+    end
+  end
+
+  @doc "How many artifact ids are currently recorded."
+  @spec count() :: non_neg_integer()
+  def count do
+    start()
+    :ets.info(@table, :size)
+  end
+
+  @doc false
+  @spec reset() :: :ok
+  def reset do
+    if :ets.whereis(@table) != :undefined, do: :ets.delete_all_objects(@table)
+    :ok
+  end
+end

--- a/lib/mob/post_mortem/registry/owner.ex
+++ b/lib/mob/post_mortem/registry/owner.ex
@@ -1,0 +1,40 @@
+defmodule Mob.PostMortem.Registry.Owner do
+  @moduledoc """
+  Owns the ETS table `Mob.PostMortem.Registry` writes to.
+
+  Same reason `Mob.Agent.Receipts.Owner` / `Mob.Invariant.Owner` /
+  `Mob.Defect.Bus.Owner` exist: an ETS table dies with its creator, and
+  the registry needs to outlive the caller that first sweeps. Unlinked,
+  so a sweeping process's exit does not take the registry down.
+  """
+
+  use GenServer
+
+  @table :mob_post_mortem_seen
+
+  @doc false
+  @spec start() :: {:ok, pid()}
+  def start do
+    case GenServer.start(__MODULE__, [], name: __MODULE__) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+    end
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    # The sibling owners (`Mob.Invariant.Owner`, `Mob.Defect.Bus.Owner`,
+    # `Mob.Agent.Receipts.Owner`) publish per-owner state to
+    # `:persistent_term` **before** creating the table, so a second
+    # process racing on the "does the table exist" check does not read
+    # from a not-yet-set key. This registry stores no persistent_term
+    # state — its only durable artifact is the ETS set itself — so the
+    # ordering does not apply here. Table creation alone is the whole
+    # init, and no window exists to guard.
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:set, :public, :named_table, {:write_concurrency, true}])
+    end
+
+    {:ok, %{}}
+  end
+end

--- a/test/mob/post_mortem/beam_crash_dump_test.exs
+++ b/test/mob/post_mortem/beam_crash_dump_test.exs
@@ -1,0 +1,256 @@
+defmodule Mob.PostMortem.BeamCrashDumpTest do
+  # Bus + registry are process-global; async: false so a class row from one
+  # test cannot answer another.
+  use ExUnit.Case, async: false
+
+  alias Mob.Defect.Bus
+  alias Mob.PostMortem.BeamCrashDump
+  alias Mob.PostMortem.Registry
+
+  # A realistic 8-line dump header. Anything below the first blank-ish
+  # section is irrelevant to this module; the scanner never reads past
+  # its bounded window.
+  @sample_dump """
+  =erl_crash_dump:0.5
+  Tue Sep  1 14:06:22 2026
+  Slogan: Runtime terminating during boot ({badarg,[{io,put_chars,[standard_error,[<<42,42,32,40,69,88,73,84>>]]}]})
+  System version: Erlang/OTP 29 [erts-17.0] [source] [64-bit] [smp:12:12] [jit]
+  Taints: crypto,asn1
+  Atoms: 35424
+  Calling Thread: scheduler:5
+  =scheduler:1
+  Scheduler Sleep Info Flags: SLEEPING
+  """
+
+  setup do
+    Bus.start()
+    Bus.reset()
+    Registry.start()
+    Registry.reset()
+    :ok
+  end
+
+  defp write_dump(dir, name, contents) do
+    path = Path.join(dir, name)
+    File.write!(path, contents)
+    path
+  end
+
+  describe "normalize_slogan/1" do
+    test "strips a binary literal — the crash class survives, the payload does not" do
+      raw = "Runtime terminating ({badarg,[{io,put_chars,[<<42,42,42>>]}]})"
+      normalized = BeamCrashDump.normalize_slogan(raw)
+
+      # The class-defining shape is preserved
+      assert normalized =~ "badarg"
+      assert normalized =~ "put_chars"
+      # The binary payload is not
+      refute normalized =~ "42,42,42"
+      assert normalized =~ "<<>>"
+    end
+
+    test "strips a long numeric sequence (>= 8 digits with commas)" do
+      raw = "boot ({badarg,[[104,101,108,108,111,32,119,111,114,108,100]]})"
+      normalized = BeamCrashDump.normalize_slogan(raw)
+      refute normalized =~ "104,101,108"
+    end
+
+    test "collapses whitespace" do
+      raw = "Kernel  pid   terminated    (application_controller)"
+      normalized = BeamCrashDump.normalize_slogan(raw)
+      assert normalized == "Kernel pid terminated (application_controller)"
+    end
+
+    test "nil in, nil out" do
+      assert BeamCrashDump.normalize_slogan(nil) == nil
+    end
+
+    test "two crashes of the same class with different embedded binaries normalize identically" do
+      a = "({badarg,[{io,put_chars,[<<1,2,3,4>>]}]})"
+      b = "({badarg,[{io,put_chars,[<<99,99,99,99>>]}]})"
+      assert BeamCrashDump.normalize_slogan(a) == BeamCrashDump.normalize_slogan(b)
+    end
+
+    test "a binary literal truncated at end of string still strips" do
+      # A slogan cut off inside `<<...>>` has no closing `>>`. Without the
+      # end-of-string branch in the strip pattern, the concrete bytes
+      # would leak into the fingerprint and shatter same-class crashes
+      # by the exact bytes that fit under @header_bytes.
+      truncated_a = "({badarg,[{io,put_chars,[<<1,2,3,4,5,6,7,8"
+      truncated_b = "({badarg,[{io,put_chars,[<<99,99,99,99,99,99,99,99"
+
+      norm_a = BeamCrashDump.normalize_slogan(truncated_a)
+      norm_b = BeamCrashDump.normalize_slogan(truncated_b)
+
+      assert norm_a == norm_b
+      refute norm_a =~ "1,2,3,4"
+      refute norm_b =~ "99,99"
+      assert norm_a =~ "<<>>"
+    end
+  end
+
+  describe "scan/1" do
+    setup do
+      tmp =
+        Path.join(System.tmp_dir!(), "beam_crash_dump_test_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+      {:ok, tmp: tmp}
+    end
+
+    test "extracts header fields from a real-shaped dump", %{tmp: tmp} do
+      write_dump(tmp, "erl_crash.dump", @sample_dump)
+
+      [finding] = BeamCrashDump.scan([tmp])
+
+      assert finding.path == Path.join(tmp, "erl_crash.dump")
+      assert String.starts_with?(finding.sha256, "sha256:")
+      assert finding.size == byte_size(@sample_dump)
+      assert %DateTime{} = finding.modified_at
+      assert finding.slogan =~ "Runtime terminating during boot"
+      assert finding.system_version =~ "Erlang/OTP 29"
+      assert finding.taints == ["crypto", "asn1"]
+      assert finding.atoms == 35_424
+      assert finding.dump_version == "0.5"
+    end
+
+    test "accepts a file path directly, not just a directory", %{tmp: tmp} do
+      path = write_dump(tmp, "erl_crash.dump", @sample_dump)
+      [finding] = BeamCrashDump.scan([path])
+      assert finding.path == path
+    end
+
+    test "returns [] for a non-existent path" do
+      assert BeamCrashDump.scan(["/nonexistent/path/erl_crash.dump"]) == []
+    end
+
+    test "returns [] for a directory with no dump file", %{tmp: tmp} do
+      assert BeamCrashDump.scan([tmp]) == []
+    end
+
+    test "does not recurse into subdirectories", %{tmp: tmp} do
+      # A dump sitting one level deep is not our concern; the caller
+      # decides which directories to sweep.
+      sub = Path.join(tmp, "deeper")
+      File.mkdir_p!(sub)
+      write_dump(sub, "erl_crash.dump", @sample_dump)
+
+      assert BeamCrashDump.scan([tmp]) == []
+    end
+
+    test "deduplicates identical paths passed twice", %{tmp: tmp} do
+      write_dump(tmp, "erl_crash.dump", @sample_dump)
+      assert length(BeamCrashDump.scan([tmp, tmp])) == 1
+    end
+
+    test "computes a distinct sha256 for two different dumps", %{tmp: tmp} do
+      a = write_dump(tmp, "erl_crash.dump", @sample_dump)
+      b_dir = Path.join(tmp, "other")
+      File.mkdir_p!(b_dir)
+      b = write_dump(b_dir, "erl_crash.dump", @sample_dump <> "extra byte")
+
+      [fa] = BeamCrashDump.scan([a])
+      [fb] = BeamCrashDump.scan([b])
+
+      assert fa.sha256 != fb.sha256
+    end
+  end
+
+  describe "emit/1" do
+    setup do
+      tmp =
+        Path.join(System.tmp_dir!(), "beam_crash_dump_emit_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+      {:ok, tmp: tmp}
+    end
+
+    test "puts a capsule on the bus with normalized-slogan fingerprint key", %{tmp: tmp} do
+      Bus.subscribe()
+      write_dump(tmp, "erl_crash.dump", @sample_dump)
+
+      [capsule] = tmp |> List.wrap() |> BeamCrashDump.scan() |> BeamCrashDump.emit()
+
+      assert capsule.kind == :beam_crash
+      assert capsule.owner == :mob
+      # Evidence carries the raw slogan for a human triager
+      assert capsule.evidence.slogan =~ "Runtime terminating"
+      # Fingerprint key is normalized — binary stripped
+      # (verify by rebuilding the same finding with a different embedded
+      # binary; the two capsules must fingerprint identically)
+      assert_receive {:mob_defect, ^capsule}, 500
+    end
+
+    test "is idempotent — a second emit of the same finding is a no-op", %{tmp: tmp} do
+      write_dump(tmp, "erl_crash.dump", @sample_dump)
+      findings = BeamCrashDump.scan([tmp])
+
+      first = BeamCrashDump.emit(findings)
+      second = BeamCrashDump.emit(findings)
+
+      assert length(first) == 1
+      assert second == []
+    end
+
+    test "the dump file is not moved or deleted", %{tmp: tmp} do
+      path = write_dump(tmp, "erl_crash.dump", @sample_dump)
+      tmp |> List.wrap() |> BeamCrashDump.scan() |> BeamCrashDump.emit()
+
+      assert File.exists?(path)
+      assert File.read!(path) == @sample_dump
+    end
+
+    test "the emit picks a :fatal severity for a Runtime-terminating-during-boot slogan", %{
+      tmp: tmp
+    } do
+      # The fixture's slogan starts with `Runtime terminating during boot`.
+      # A boot-time crash means the BEAM never actually came up, which is
+      # a page-someone-now severity. Reverting the slogan match in
+      # `severity_from_slogan/1` sends it back to :critical and this
+      # assertion breaks.
+      write_dump(tmp, "erl_crash.dump", @sample_dump)
+      [capsule] = tmp |> List.wrap() |> BeamCrashDump.scan() |> BeamCrashDump.emit()
+      assert capsule.severity == :fatal
+    end
+
+    test "two dumps with slogans that normalize identically share a fingerprint", %{tmp: tmp} do
+      dump_a = String.replace(@sample_dump, "<<42,42,32,40,69,88,73,84>>", "<<1,2,3,4>>")
+      dump_b = String.replace(@sample_dump, "<<42,42,32,40,69,88,73,84>>", "<<99,99,99,99>>")
+
+      a = write_dump(tmp, "erl_crash.dump", dump_a)
+
+      b_dir = Path.join(tmp, "other")
+      File.mkdir_p!(b_dir)
+      b = write_dump(b_dir, "erl_crash.dump", dump_b)
+
+      [fa] = BeamCrashDump.scan([a])
+      [fb] = BeamCrashDump.scan([b])
+
+      # Distinct files (different sha256), so both emit
+      [cap_a] = BeamCrashDump.emit([fa])
+      [cap_b] = BeamCrashDump.emit([fb])
+
+      # But they group by fingerprint — the normalized slogan is the same
+      assert cap_a.fingerprint == cap_b.fingerprint
+    end
+  end
+
+  describe "default_paths/0" do
+    test "includes cwd" do
+      assert File.cwd!() in BeamCrashDump.default_paths()
+    end
+
+    test "prepends ERL_CRASH_DUMP when set" do
+      System.put_env("ERL_CRASH_DUMP", "/tmp/some_dump_path")
+
+      try do
+        paths = BeamCrashDump.default_paths()
+        assert "/tmp/some_dump_path" in paths
+      after
+        System.delete_env("ERL_CRASH_DUMP")
+      end
+    end
+  end
+end

--- a/test/mob/post_mortem/registry_test.exs
+++ b/test/mob/post_mortem/registry_test.exs
@@ -1,0 +1,47 @@
+defmodule Mob.PostMortem.RegistryTest do
+  # ETS + persistent_term global; async: false.
+  use ExUnit.Case, async: false
+
+  alias Mob.PostMortem.Registry
+
+  setup do
+    Registry.start()
+    Registry.reset()
+    :ok
+  end
+
+  test "mark_seen/1 returns true on first observation, false on repeat" do
+    assert Registry.mark_seen("sha256:abc") == true
+    assert Registry.mark_seen("sha256:abc") == false
+  end
+
+  test "seen?/1 reflects mark_seen state" do
+    refute Registry.seen?("sha256:xyz")
+    Registry.mark_seen("sha256:xyz")
+    assert Registry.seen?("sha256:xyz")
+  end
+
+  test "count/0 tracks distinct ids" do
+    assert Registry.count() == 0
+    Registry.mark_seen("sha256:a")
+    Registry.mark_seen("sha256:b")
+    Registry.mark_seen("sha256:a")
+    assert Registry.count() == 2
+  end
+
+  test "concurrent mark_seen/1 on the same id: exactly one caller wins" do
+    id = "sha256:concurrent"
+    workers = 20
+
+    results =
+      1..workers
+      |> Enum.map(fn _ -> Task.async(fn -> Registry.mark_seen(id) end) end)
+      |> Enum.map(&Task.await(&1, 1_000))
+
+    # Exactly one true, the rest false — the `:ets.insert_new/2` claim is
+    # atomic across concurrent writers. Without atomicity a race could
+    # produce two trues and the caller would emit twice for one artifact.
+    assert Enum.count(results, & &1) == 1
+    assert Enum.count(results, &(&1 == false)) == workers - 1
+  end
+end

--- a/test/mob/post_mortem_test.exs
+++ b/test/mob/post_mortem_test.exs
@@ -1,0 +1,77 @@
+defmodule Mob.PostMortemTest do
+  use ExUnit.Case, async: false
+
+  alias Mob.Defect.Bus
+  alias Mob.PostMortem
+  alias Mob.PostMortem.Registry
+
+  @sample_dump """
+  =erl_crash_dump:0.5
+  Tue Sep  1 14:06:22 2026
+  Slogan: Kernel pid terminated (application_controller)
+  System version: Erlang/OTP 29 [erts-17.0] [source] [64-bit] [smp:12:12] [jit]
+  Taints: crypto
+  Atoms: 12000
+  Calling Thread: scheduler:1
+  """
+
+  setup do
+    Bus.start()
+    Bus.reset()
+    Registry.start()
+    Registry.reset()
+    {:ok, _} = Bus.subscribe()
+    :ok
+  end
+
+  test "sweep/1 finds a dump in a caller-supplied path and emits a capsule" do
+    tmp = Path.join(System.tmp_dir!(), "post_mortem_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf!(tmp) end)
+
+    expected_path = Path.join(tmp, "erl_crash.dump")
+    File.write!(expected_path, @sample_dump)
+
+    # `sweep/1` merges default_paths (which include cwd) with the caller's
+    # paths, so a stray `erl_crash.dump` in cwd would produce extra
+    # capsules and break an unfiltered `[capsule] = capsules` match.
+    # Filter to just the dump this test wrote — that isolates the
+    # assertion from any environmental contamination.
+    capsules =
+      [tmp]
+      |> PostMortem.sweep()
+      |> Enum.filter(&(&1.evidence.path == expected_path))
+
+    assert [capsule] = capsules
+    assert capsule.kind == :beam_crash
+    assert capsule.owner == :mob
+    # "Kernel pid terminated" is one of the fatal-severity strings
+    assert capsule.severity == :fatal
+    assert capsule.evidence.slogan =~ "application_controller"
+
+    assert_receive {:mob_defect, ^capsule}, 500
+  end
+
+  test "sweep/0 is idempotent: a second call with the same on-disk state emits nothing new" do
+    # We do not control whether cwd has any dumps under it. Assert only
+    # that calling sweep/0 twice in a row cannot produce a strict superset
+    # the second time.
+    first = PostMortem.sweep()
+    second = PostMortem.sweep()
+
+    first_ids = MapSet.new(first, & &1.id)
+    second_ids = MapSet.new(second, & &1.id)
+
+    assert MapSet.disjoint?(first_ids, second_ids),
+           "the second sweep must not re-emit anything the first already did"
+
+    assert second == []
+  end
+
+  test "iOS and Android scaffolds contribute [] and do not error" do
+    # Direct call to prove the coordinator's fanout to native modules is
+    # tolerant of their empty answers.
+    assert Mob.PostMortem.IOS.sweep() == []
+    assert Mob.PostMortem.Android.sweep() == []
+  end
+end


### PR DESCRIPTION
MOB-158 phase 1: the framework picks up the crash dumps the BEAM leaves behind on disk and turns each into a `Mob.Defect.Capsule` on `Mob.Defect.Bus`. The two native sources (iOS MetricKit, Android `ApplicationExitInfo`) are **scaffolded** — their symbols exist so the coordinator does not have to grow a per-platform branch when they land; the real native pipes are separate follow-ups.

## What ships

- **`Mob.PostMortem`** — top-level. `sweep/0`, `sweep/1` scan configured paths, emit capsules for anything new.
- **`Mob.PostMortem.BeamCrashDump`** — scans `erl_crash.dump`, reads a bounded 8 KB header (slogan / system_version / taints / atoms / dump_version), computes sha256 for artifact identity, never touches the dump body. Dumps stay on disk for offline `crashdump_viewer` inspection.
- **`Mob.PostMortem.Registry`** (+ `Owner`) — public ETS set of already-emitted sha256 ids. `mark_seen/1` uses `:ets.insert_new/2` for atomicity so two concurrent sweeps cannot both emit. Explicitly not persistent across BEAM restarts — a fresh BEAM sweeps back into a fresh bus.
- **`Mob.PostMortem.IOS`** and **`Mob.PostMortem.Android`** — scaffolds. Log once at `:info` about the "not yet wired" state, return `[]`.
- **`Mob.Defect.emit_beam_crash/1`** — builds a `:beam_crash` capsule with the normalized-slogan fingerprint key and severity picked from the slogan (allocator panics + boot-time crashes are `:fatal`, an explicit `normal` exit is `:info`, everything else is `:critical`).

## Discipline

- **No auto-sweep.** Apps opt in from their `on_start`, developers/CI use IEx. Same rule as `Mob.Defect.Sinks.Dev`.
- **No delete, no move.** The dump stays on disk for external triage.
- **Idempotent.** A re-sweep against the same on-disk state emits nothing new.
- **Fingerprint stripped of concrete data.** A `{badarg, ...}` from `io:put_chars/2` embeds the raw binary that was passed; the fingerprint strips binary literals (including ones truncated by the 8 KB header cut-off) and long numeric runs so two crashes of the same class share a triage row.

## Adversarial review before commit

Verdict: SOUND WITH FIXES. Two real issues, both applied and covered by revert-verified tests:

1. **Truncated `<<...>>` at end of the 8 KB header window** would leak bytes into the fingerprint because the strip regex required a closing `>>`. Fixed to accept the unclosed-at-end case; new test proves two same-class truncated crashes now fingerprint identically.
2. **Sweep test could pick up an unrelated stray `erl_crash.dump` in cwd** (the author's machine had five). Test now filters capsules by the specific temp path it wrote.

Nitpicks folded in: severity heuristic extended to allocator variants (`ets_alloc`, `sl_alloc`, `driver_alloc`, `fix_alloc`, `std_alloc`) plus `Runtime terminating during boot`; sha256 stream chunk 4 KB → 64 KB; `Registry.Owner` carries a comment explaining why the sibling "state before tables" ordering does not apply.

## Gates

- `mix test`: 1763 pass (was 1736 + 27 new), 0 fail
- `mix format --check-formatted`: clean
- `mix credo --strict`: 0 issues (206 source files)
- `mix compile --warnings-as-errors`: clean

## Not in this PR (follow-up tickets)

- iOS MetricKit ingest — an `MXMetricManager` delegate that receives crash / hang / launch-time / CPU / memory / disk-write payloads and emits capsules. Native ObjC + device verification. ~1 day.
- Android `ApplicationExitInfo` ingest — `ActivityManager.getHistoricalProcessExitReasons` pull-on-next-boot with a persistent marker so each reason emits exactly once. JNI + device verification. ~1 day.

Closes phase 1 of [MOB-158](https://linear.app/mobframework/issue/MOB-158). Ticket stays open for the two native halves.
