### PR TITLE
MOB-179: iOS MetricKit ingest for Mob.PostMortem.IOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,35 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   `:fatal`; a literal `normal` exit is `:info`; anything else is
   `:critical`.
 
-- **iOS and Android post-mortem scaffolds — `Mob.PostMortem.IOS`,
-  `Mob.PostMortem.Android`**. `sweep/0` returns `[]` and logs once at
-  `:info`. The real native pipes (MetricKit for iOS,
-  `ApplicationExitInfo` for Android) are their own follow-up tickets
-  with per-platform device verification.
+- **iOS MetricKit ingest for `Mob.PostMortem.IOS`** (MOB-179). Replaces
+  the phase 1 scaffold. `Mob.PostMortem.sweep/0` on iOS now attaches an
+  `MXMetricManagerSubscriber` on first call (lazy — no work for apps
+  that never opt in), buffers OS-delivered payloads in a bounded native
+  queue (32 entries, oldest-dropped on overflow), and drains them into
+  `Mob.Defect.Capsule`s on each subsequent call. Ships in release —
+  MetricKit is the whole reason MOB-158 exists.
+
+  Payload → kind mapping: `MXCrashDiagnosticPayload` → `:native_crash`
+  / `:fatal`; `MXHangDiagnosticPayload` → `:anr` / `:critical`;
+  `MXCPUExceptionDiagnosticPayload` and
+  `MXDiskWriteExceptionDiagnosticPayload` → `:perf_regression` /
+  `:warning`.
+
+  Fingerprint groups a crash by (kind + top-frame binary + top-frame
+  offset) so the same crash across launches becomes one triage row.
+  Redaction: MetricKit call-stack payloads carry only mangled symbols,
+  binary UUIDs and image names — safe identifiers, no user data. The
+  full `MXDiagnosticPayload.JSONRepresentation` rides on evidence,
+  bounded by the capsule's existing truncation.
+
+  iOS 14+ required (`didReceiveDiagnosticPayloads:` is iOS 14+). Older
+  builds hit the fallback path and return `[]`. Android's stub NIF also
+  returns `[]` — `ApplicationExitInfo` is a separate ticket (MOB-180).
+
+- **Android post-mortem scaffold — `Mob.PostMortem.Android`**.
+  `sweep/0` returns `[]` and logs once at `:info`. The real native
+  pipe (`ApplicationExitInfo`) is a follow-up ticket (MOB-180) with
+  device verification.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,12 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   `Mob.Defect.Capsule`s on each subsequent call. Ships in release —
   MetricKit is the whole reason MOB-158 exists.
 
-  Payload → kind mapping: `MXCrashDiagnosticPayload` → `:native_crash`
-  / `:fatal`; `MXHangDiagnosticPayload` → `:anr` / `:critical`;
-  `MXCPUExceptionDiagnosticPayload` and
-  `MXDiskWriteExceptionDiagnosticPayload` → `:perf_regression` /
-  `:warning`.
+  Payload → kind mapping: `MXCrashDiagnostic` → `:native_crash` /
+  `:fatal`; `MXHangDiagnostic` → `:anr` / `:critical`;
+  `MXCPUExceptionDiagnostic` and `MXDiskWriteExceptionDiagnostic` →
+  `:perf_regression` / `:warning`. (These are the individual
+  diagnostics; the `MXDiagnosticPayload` container that carries them
+  is what MetricKit hands the delegate.)
 
   Fingerprint groups a crash by (kind + top-frame binary + top-frame
   offset) so the same crash across launches becomes one triage row.

--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -4091,6 +4091,26 @@ export fn nif_vendor_usb_close(
     return erts.ok(env);
 }
 
+// ── Mob.PostMortem.IOS — MetricKit drain (iOS-only, Android stub) ────────
+//
+// The MetricKit channel is iOS-only; the equivalent Android substrate is
+// `ApplicationExitInfo`, whose ingest is its own follow-up ticket
+// (MOB-180) with its own NIF. This stub exists so the shared
+// `mob_nif.erl` `-nifs([post_mortem_ios_drain/0])` declaration resolves
+// on Android without the loader raising. Returns [] unconditionally —
+// the Elixir side (Mob.PostMortem.IOS.sweep/0) also gates on
+// `Mob.PostMortem.platform() == :ios` before it even calls this, so a
+// well-formed caller never reaches here on Android.
+export fn nif_post_mortem_ios_drain(
+    env: ?*erts.ErlNifEnv,
+    argc: c_int,
+    argv: [*]const erts.ERL_NIF_TERM,
+) callconv(.c) erts.ERL_NIF_TERM {
+    _ = argc;
+    _ = argv;
+    return erts.makeList(env, &.{});
+}
+
 // ── nif_load: cache all method IDs at BEAM startup ───────────────────────
 
 /// Required-method helper. Returns false if the method isn't on the
@@ -4435,6 +4455,8 @@ const nif_funcs = [_]erts.ErlNifFunc{
     // ── Mob.Bt (Bluetooth Classic) — extracted to the mob_bluetooth plugin ──
     // ── Mob.DNS (in-process IPv4 resolver via Bionic getaddrinfo) ────────
     .{ .name = "resolve_ipv4", .arity = 1, .fptr = nif_resolve_ipv4, .flags = erts.ERL_NIF_DIRTY_JOB_IO_BOUND },
+    // ── Mob.PostMortem.IOS (Android stub — the substrate is MOB-180) ─────
+    .{ .name = "post_mortem_ios_drain", .arity = 0, .fptr = nif_post_mortem_ios_drain, .flags = 0 },
 };
 
 var mob_nif_entry: erts.ErlNifEntry = .{

--- a/decisions/2026-09-11-metrickit-ingest-lazy-attach.md
+++ b/decisions/2026-09-11-metrickit-ingest-lazy-attach.md
@@ -1,0 +1,71 @@
+# MetricKit ingest attaches lazily and drains on demand
+
+- Date: 2026-09-11
+- Status: accepted
+
+## Context
+
+MOB-179 adds MetricKit ingest for `Mob.PostMortem.IOS`. The design
+question was *when* to attach the `MXMetricManagerSubscriber` and how
+the BEAM should learn about delivered payloads.
+
+Three obvious options:
+
+1. **Attach at BEAM boot in `mob_start_beam`.** Payloads land in a
+   queue we drain later.
+2. **Attach and push directly to a BEAM pid via `enif_send`.** No
+   queue on the native side; the caller registers a pid up front.
+3. **Attach lazily on the first drain call.** Bounded native queue
+   in between, drained on demand.
+
+## Decision
+
+Option 3: lazy attach on the first `Mob.PostMortem.IOS.sweep/0` call,
+bounded queue (32 payloads) guarded by an `os_unfair_lock`, drained
+by a NIF that copies + clears the queue and returns.
+
+## Consequences
+
+**Why not boot-time attach:** it forces every mob app to pay for
+MetricKit's subscriber machinery even if the app never opts into
+post-mortem ingest. That violates the discipline the whole
+`Mob.PostMortem` subsystem enforces — an app opts in explicitly, and
+the framework does no work otherwise. A lazy attach on first drain
+gives the same recovery of pending payloads as a boot-time attach
+(MetricKit delivers to whichever subscriber is present when it goes
+to deliver, and delivery is idle-time-triggered — a subscriber
+attached before the next idle window catches everything queued up),
+without the always-on cost.
+
+**Why not `enif_send` from the delegate directly:** the caller pid
+would need to be registered up front, and outlive every payload the
+subscriber ever receives. A screen restart, a router reset, any of a
+dozen normal lifecycle events would strand payloads with no live
+recipient. The queue-drain pattern makes the recipient a per-call
+choice (the process that called `sweep/0`) rather than a
+long-standing registration, which matches how `Mob.Defect.Bus`
+already works.
+
+**Bounded queue at 32:** a burst of diagnostics on a bad morning
+after a bad night. MetricKit itself delivers roughly one payload per
+diagnostic class per day, so 32 is generous. On overflow we drop the
+oldest — the most recent are the ones a triager wants first, and a
+capped ring that discards the newest would silently lose the crash
+that just brought the app down.
+
+**The subscriber is a file-scope singleton, not per-instance state.**
+An `atomic_flag` guards the attach so two concurrent lazy-init
+callers cannot double-register. A test that reloads the module
+(unlikely in production, plausible in development) does not clear
+the flag or the queue — deliberate, since a hot reload should not
+lose queued payloads that arrived between reloads.
+
+**The drain runs on a regular scheduler, not a dirty one.** The
+lazy-attach is a fire-and-forget `dispatch_async` to the main queue
+(no wait), the queue copy is a bounded critical section under
+`os_unfair_lock` (microseconds), and building Elixir terms for
+≤32 entries is small work. Nothing here justifies the dirty-scheduler
+round trip. `test/mob/nif_scheduling_completeness_test.exs` puts
+`post_mortem_ios_drain` in the "returns promptly" list on purpose;
+promoting it to dirty-IO would be a defensive posture without a
+matching cost.

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -8046,6 +8046,277 @@ static ERL_NIF_TERM nif_vendor_usb_close(ErlNifEnv *env, int argc, const ERL_NIF
     return enif_make_atom(env, "ok");
 }
 
+// ── Mob.PostMortem.IOS — MetricKit ingest (MOB-179) ──────────────────────────
+//
+// MetricKit is the OS-delivered channel for crash / hang / CPU / disk /
+// launch diagnostics. Subscribers attach at any point in the app lifetime
+// and receive whatever the OS has queued via
+// `didReceiveDiagnosticPayloads:`, called on a background queue. We
+// register our subscriber lazily on the first drain call, buffer payloads
+// in a bounded queue guarded by an `os_unfair_lock`, and hand the queue's
+// contents to the BEAM when it asks.
+//
+// This ships in release builds — per MOB-158's decision record
+// `decisions/2026-09-04-defect-reports-are-a-shipped-feature.md`, the
+// interesting failures happen where no agent is watching, so gating this
+// out of production leaves the framework blind to exactly the crashes it
+// wants to see.
+//
+// Availability: `MXMetricManagerSubscriber` is iOS 13+ but
+// `didReceiveDiagnosticPayloads:` — the delivery hook — is iOS 14+. Guard
+// with `@available(iOS 14.0, *)`; older builds hit the fallback path and
+// return an empty list.
+//
+// Redaction: `MXCallStackTree` carries binary UUIDs, image names and
+// mangled symbol offsets — safe identifiers, no user data. We only keep
+// the top frame's binary + offset for the fingerprint and the payload's
+// JSON representation as evidence; the JSON is bounded by the capsule's
+// existing truncation rules on the Elixir side.
+
+#import <MetricKit/MetricKit.h>
+#import <os/lock.h>
+
+// Bounded queue depth. A busy app can ship a burst of diagnostics on a
+// slow morning after a bad night; the last few are the ones worth
+// prioritising, so an overflow drops the head, not the tail. 32 is
+// generous — MetricKit itself delivers roughly one payload per day per
+// diagnostic class.
+#define MOB_METRICKIT_QUEUE_CAP 32
+
+// Each entry is a plain ObjC object with public ivars — ARC manages the
+// NSString / NSData retention automatically, and the struct-like access
+// keeps the enqueue path tight.
+@interface MobMetricKitEntry : NSObject {
+  @public
+    NSString *kind;       // "native_crash" | "anr" | "perf_regression"
+    NSString *top_binary; // "MyApp" — from the deepest frame's binaryName
+    uint64_t top_offset;  // offsetIntoBinaryTextSegment — decimal, opaque
+    int64_t timestamp_ms; // millisecond epoch of the payload's timeStampBegin
+    NSData *raw_json;     // MXDiagnosticPayload.JSONRepresentation
+}
+@end
+
+@implementation MobMetricKitEntry
+@end
+
+@interface MobMetricSubscriber : NSObject <MXMetricManagerSubscriber>
+@end
+
+// Storage lives at file scope, not on the subscriber instance, so a
+// re-attach (test reload; unlikely in production but possible) does not
+// lose queued payloads. Guarded by an `os_unfair_lock` — the delegate
+// runs on a background queue and the drain runs on a BEAM scheduler, and
+// both mutate the queue.
+static NSMutableArray<MobMetricKitEntry *> *g_metric_queue = nil;
+static os_unfair_lock g_metric_lock = OS_UNFAIR_LOCK_INIT;
+static MobMetricSubscriber *g_metric_subscriber = nil;
+// Attached-once guard, atomic so a lazy-init race across two schedulers
+// cannot double-register.
+static atomic_flag g_metric_attached = ATOMIC_FLAG_INIT;
+
+// Extract the top stack frame's identity from a MetricKit diagnostic's
+// call-stack tree, and enqueue an entry. Runs on MetricKit's background
+// delivery queue; the work is bounded (a single JSON parse of the tree
+// document) so it does not block a subsequent delivery.
+API_AVAILABLE(ios(14.0))
+static void enqueue_diagnostic(MXDiagnostic *diag, NSString *kind, NSData *payload_json,
+                               int64_t timestamp_ms) {
+    // MXCallStackTree lives on the specific diagnostic subclass (crash,
+    // cpu, hang, disk, launch) — the abstract base class does not expose
+    // it. Reach through with `respondsToSelector` rather than switching
+    // on `isKindOfClass` so a future MetricKit diagnostic type still
+    // works without a compile change.
+    if (![diag respondsToSelector:@selector(callStackTree)])
+        return;
+    MXCallStackTree *tree = [diag performSelector:@selector(callStackTree)];
+    if (!tree)
+        return;
+    NSData *treeJson = [tree JSONRepresentation];
+    if (!treeJson)
+        return;
+
+    NSError *err = nil;
+    NSDictionary *parsed = [NSJSONSerialization JSONObjectWithData:treeJson options:0 error:&err];
+    if (err || ![parsed isKindOfClass:[NSDictionary class]])
+        return;
+
+    NSString *top_binary = @"(unknown)";
+    uint64_t top_offset = 0;
+    NSArray *stacks = parsed[@"callStacks"];
+    if ([stacks isKindOfClass:[NSArray class]] && stacks.count > 0) {
+        NSDictionary *stack = stacks[0];
+        NSArray *frames = stack[@"callStackRootFrames"];
+        if ([frames isKindOfClass:[NSArray class]] && frames.count > 0) {
+            NSDictionary *frame = frames[0];
+            id binary = frame[@"binaryName"];
+            id offset = frame[@"offsetIntoBinaryTextSegment"];
+            if ([binary isKindOfClass:[NSString class]])
+                top_binary = binary;
+            if ([offset isKindOfClass:[NSNumber class]])
+                top_offset = [offset unsignedLongLongValue];
+        }
+    }
+
+    MobMetricKitEntry *entry = [[MobMetricKitEntry alloc] init];
+    if (!entry)
+        return;
+    entry->kind = kind;
+    entry->top_binary = top_binary;
+    entry->top_offset = top_offset;
+    entry->timestamp_ms = timestamp_ms;
+    entry->raw_json = payload_json;
+
+    os_unfair_lock_lock(&g_metric_lock);
+    if (!g_metric_queue) {
+        g_metric_queue = [NSMutableArray arrayWithCapacity:MOB_METRICKIT_QUEUE_CAP];
+    }
+    if (g_metric_queue.count >= MOB_METRICKIT_QUEUE_CAP) {
+        // Drop the head — oldest — so the most recent, most relevant
+        // diagnostics survive an overflow.
+        [g_metric_queue removeObjectAtIndex:0];
+    }
+    [g_metric_queue addObject:entry];
+    os_unfair_lock_unlock(&g_metric_lock);
+}
+
+@implementation MobMetricSubscriber
+
+- (void)didReceiveDiagnosticPayloads:(NSArray<MXDiagnosticPayload *> *)payloads
+    API_AVAILABLE(ios(14.0)) {
+    // Called on a background queue per Apple docs. Cheap work only:
+    // extract fingerprint fields, capture the payload JSON for evidence,
+    // enqueue. Anything expensive (parsing every frame, symbolication)
+    // belongs on the BEAM side after the drain, so a MetricKit delivery
+    // burst does not block the OS's delivery queue.
+    for (MXDiagnosticPayload *payload in payloads) {
+        NSData *fullJson = [payload JSONRepresentation];
+        int64_t timestamp_ms = (int64_t)([payload.timeStampBegin timeIntervalSince1970] * 1000.0);
+
+        for (MXCrashDiagnostic *d in [payload crashDiagnostics]) {
+            enqueue_diagnostic(d, @"native_crash", fullJson, timestamp_ms);
+        }
+        for (MXHangDiagnostic *d in [payload hangDiagnostics]) {
+            enqueue_diagnostic(d, @"anr", fullJson, timestamp_ms);
+        }
+        for (MXCPUExceptionDiagnostic *d in [payload cpuExceptionDiagnostics]) {
+            enqueue_diagnostic(d, @"perf_regression", fullJson, timestamp_ms);
+        }
+        for (MXDiskWriteExceptionDiagnostic *d in [payload diskWriteExceptionDiagnostics]) {
+            enqueue_diagnostic(d, @"perf_regression", fullJson, timestamp_ms);
+        }
+    }
+}
+
+@end
+
+static void mob_metrickit_attach_if_needed(void) {
+    if (@available(iOS 14.0, *)) {
+        if (!atomic_flag_test_and_set(&g_metric_attached)) {
+            // First caller — attach the subscriber. The `set` on
+            // `atomic_flag_test_and_set` is what makes this idempotent
+            // across concurrent lazy-init callers.
+            dispatch_async(dispatch_get_main_queue(), ^{
+              if (!g_metric_subscriber) {
+                  g_metric_subscriber = [[MobMetricSubscriber alloc] init];
+              }
+              [[MXMetricManager sharedManager] addSubscriber:g_metric_subscriber];
+              LOGI(@"Mob.PostMortem.IOS: MetricKit subscriber attached");
+            });
+        }
+    }
+}
+
+static ERL_NIF_TERM nif_post_mortem_ios_drain(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    (void)argc;
+    (void)argv;
+
+    if (@available(iOS 14.0, *)) {
+        mob_metrickit_attach_if_needed();
+
+        NSArray<MobMetricKitEntry *> *drained;
+        os_unfair_lock_lock(&g_metric_lock);
+        drained = g_metric_queue ? [g_metric_queue copy] : @[];
+        [g_metric_queue removeAllObjects];
+        os_unfair_lock_unlock(&g_metric_lock);
+
+        ERL_NIF_TERM list = enif_make_list(env, 0);
+        // Reverse iterate so the returned list is chronological (oldest
+        // first) — enif_make_list_cell prepends.
+        for (NSInteger i = drained.count - 1; i >= 0; i--) {
+            MobMetricKitEntry *e = drained[i];
+
+            // enif_alloc_binary returns 0 on OOM; the ErlNifBinary
+            // fields are undefined in that case and enif_make_binary
+            // would promote garbage to a term. The convention in this
+            // file (elsewhere: JSON blob builder, RGBA screenshot path)
+            // is to skip the entry on failure rather than propagate UB
+            // — a partial drain is honest, a corrupted capsule is not.
+            ErlNifBinary top_binary_bin;
+            const char *tb = e->top_binary.UTF8String;
+            size_t tb_len = tb ? strlen(tb) : 0;
+            if (!enif_alloc_binary(tb_len, &top_binary_bin)) {
+                LOGE(@"nif_post_mortem_ios_drain: enif_alloc_binary "
+                     @"(top_binary, %zu bytes) failed; dropping entry",
+                     tb_len);
+                continue;
+            }
+            if (tb_len)
+                memcpy(top_binary_bin.data, tb, tb_len);
+            ERL_NIF_TERM top_binary_term = enif_make_binary(env, &top_binary_bin);
+
+            ERL_NIF_TERM top_offset_term = enif_make_uint64(env, e->top_offset);
+
+            ERL_NIF_TERM top_frame_keys[] = {
+                enif_make_atom(env, "binary"),
+                enif_make_atom(env, "offset"),
+            };
+            ERL_NIF_TERM top_frame_vals[] = {top_binary_term, top_offset_term};
+            ERL_NIF_TERM top_frame_map;
+            enif_make_map_from_arrays(env, top_frame_keys, top_frame_vals, 2, &top_frame_map);
+
+            const char *kind = e->kind.UTF8String;
+            ERL_NIF_TERM kind_atom = enif_make_atom(env, kind ? kind : "unknown");
+
+            ErlNifBinary raw_bin;
+            NSUInteger raw_len = e->raw_json ? e->raw_json.length : 0;
+            if (!enif_alloc_binary(raw_len, &raw_bin)) {
+                LOGE(@"nif_post_mortem_ios_drain: enif_alloc_binary "
+                     @"(raw_json, %lu bytes) failed; dropping entry",
+                     (unsigned long)raw_len);
+                // top_binary_bin was already handed to enif_make_binary
+                // (line above), which transfers ownership to the BEAM
+                // — do not release it. Skip the entry.
+                continue;
+            }
+            if (raw_len)
+                memcpy(raw_bin.data, e->raw_json.bytes, raw_len);
+            ERL_NIF_TERM raw_term = enif_make_binary(env, &raw_bin);
+
+            ERL_NIF_TERM entry_keys[] = {
+                enif_make_atom(env, "kind"),
+                enif_make_atom(env, "top_frame"),
+                enif_make_atom(env, "timestamp_ms"),
+                enif_make_atom(env, "raw_json"),
+            };
+            ERL_NIF_TERM entry_vals[] = {
+                kind_atom,
+                top_frame_map,
+                enif_make_int64(env, e->timestamp_ms),
+                raw_term,
+            };
+            ERL_NIF_TERM entry_map;
+            enif_make_map_from_arrays(env, entry_keys, entry_vals, 4, &entry_map);
+
+            list = enif_make_list_cell(env, entry_map, list);
+        }
+
+        return list;
+    }
+
+    // iOS < 14 — MetricKit's delivery API is not available.
+    return enif_make_list(env, 0);
+}
+
 // Scheduling notes for nif_funcs[] below — see docs/decisions/0001-dirty-nifs.md
 // for the full rationale. Short version: most NIFs here either dispatch_async
 // to the main queue and return in microseconds, or dispatch_sync but read a
@@ -8187,6 +8458,14 @@ static ErlNifFunc nif_funcs[] = {
     // doesn't head-of-line-block the regular schedulers. See the impl
     // above for the iOS rationale.
     {"resolve_ipv4", 1, nif_resolve_ipv4, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    // Drains the MetricKit diagnostic queue. Returns promptly on a
+    // regular scheduler: the first-call subscriber attach is a
+    // fire-and-forget `dispatch_async` to the main queue (no wait); the
+    // drain itself is a bounded (≤ MOB_METRICKIT_QUEUE_CAP, 32) copy
+    // under `os_unfair_lock`, then term-building for each entry.
+    // Nothing blocks on another thread; nothing computes for
+    // scheduler-blocking durations.
+    {"post_mortem_ios_drain", 0, nif_post_mortem_ios_drain, 0},
 };
 
 static int nif_load(ErlNifEnv *env, void **priv, ERL_NIF_TERM info) {

--- a/lib/mob/defect.ex
+++ b/lib/mob/defect.ex
@@ -176,4 +176,71 @@ defmodule Mob.Defect do
 
   defp format_datetime(nil), do: nil
   defp format_datetime(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+
+  @doc """
+  Emit a defect for one MetricKit diagnostic delivered on iOS.
+
+  Owner is `:mob` — a MetricKit payload names an event the OS
+  attributes to this app process, and mob owns the process during a
+  mob-app lifetime.
+
+  The `payload` map comes from `Mob.PostMortem.IOS.sweep/0`'s drain of
+  the native queue. Its shape:
+
+      %{
+        kind: :native_crash | :anr | :perf_regression,
+        top_frame: %{binary: "MyApp", offset: 123456},
+        timestamp_ms: 1_726_050_000_000,
+        raw_json: <<...>>  # MXDiagnosticPayload.JSONRepresentation
+      }
+
+  The fingerprint key is the top stack frame — a crash in the same
+  place across builds groups into one triage row. The frame's
+  `binary` name is not the human function name (MetricKit gives
+  mangled symbols only, no user data); it is the safe identifier the
+  OS gives us, which is what we can safely put on the wire.
+
+  Severity is picked from the diagnostic kind:
+  - `:native_crash` → `:fatal` (the app terminated abnormally)
+  - `:anr` → `:critical` (the main thread stalled past the OS's
+    hang threshold; the app may or may not have recovered)
+  - `:perf_regression` → `:warning` (CPU / disk exception; the app
+    kept running, this is a heads-up)
+  """
+  @spec emit_metrickit_payload(map()) :: Capsule.t()
+  def emit_metrickit_payload(
+        %{
+          kind: kind,
+          top_frame: %{binary: binary, offset: offset},
+          timestamp_ms: timestamp_ms
+        } = payload
+      ) do
+    Capsule.new(
+      kind: kind,
+      owner: :mob,
+      severity: metrickit_severity(kind),
+      fingerprint_key: %{
+        source: :metrickit,
+        kind: kind,
+        top_frame_binary: binary,
+        top_frame_offset: offset
+      },
+      evidence: %{
+        source: :metrickit,
+        top_frame_binary: binary,
+        top_frame_offset: offset,
+        timestamp_ms: timestamp_ms,
+        raw_json: Map.get(payload, :raw_json)
+      }
+    )
+    |> Bus.emit()
+  end
+
+  defp metrickit_severity(:native_crash), do: :fatal
+  defp metrickit_severity(:anr), do: :critical
+  defp metrickit_severity(:perf_regression), do: :warning
+  # Defensive: an unknown kind reaching us means the NIF grew a payload
+  # type this dispatch does not know yet. Log severity, not silent
+  # absorption.
+  defp metrickit_severity(_), do: :critical
 end

--- a/lib/mob/post_mortem/ios.ex
+++ b/lib/mob/post_mortem/ios.ex
@@ -2,61 +2,213 @@ defmodule Mob.PostMortem.IOS do
   @moduledoc """
   MetricKit-backed post-mortem ingest for iOS.
 
-  ## Status: scaffolded, not implemented
+  The framework attaches an `MXMetricManagerSubscriber` in the NIF on
+  the first `sweep/0` call, receives MetricKit payloads on a background
+  queue thereafter, and drains the bounded in-memory queue into
+  `Mob.Defect.Capsule`s on `Mob.Defect.Bus` each time `sweep/0` is
+  called.
 
-  `sweep/0` returns `[]` today. The native pipe — an `MXMetricManager`
-  delegate that receives `MXCrashDiagnosticPayload`,
-  `MXHangDiagnosticPayload`, `MXCPUExceptionDiagnosticPayload`,
-  `MXDiskWriteExceptionDiagnosticPayload`, `MXAppLaunchDiagnosticPayload`
-  and `MXCallStackTree` values — is a follow-up ticket with its own
-  device-verification loop. This module exists as the symbol
-  `Mob.PostMortem.sweep/0` calls into so the coordinator does not have
-  to grow a per-platform branch when the native side lands.
+  ## Scope of a payload
 
-  ## The intended contract, for when it does land
+  MetricKit hands the OS-delivered payload to the delegate once per
+  incident class per day (approximately — the delivery cadence is under
+  Apple's control). Each delivery may contain one or more diagnostics of
+  different kinds:
 
-  * Called on any node, but does its work only when `:mob_nif.platform/0`
-    returns `:ios` and MetricKit reports at least one delivered payload.
-  * Each MetricKit payload becomes one `Mob.Defect.Capsule` on the bus,
-    with `owner: :mob` or `owner: {:plugin, ...}` depending on the
-    payload's process attribution.
-  * Payload delivery is asynchronous in iOS (up to 24 hours after the
-    incident); MetricKit itself deduplicates by day, and the capsule
-    fingerprint takes over from there. This module never polls; it
-    receives via the delegate and pushes into the bus.
-  * Redaction: the schema promises `redaction: :applied`. MetricKit's
-    call-stack payloads carry mangled symbol names, which are the safe
-    identifiers we keep; the file path portions and any embedded user
-    data are stripped in the native layer before the capsule is built.
+  | MetricKit diagnostic | `kind` |
+  |---|---|
+  | `MXCrashDiagnosticPayload` | `:native_crash` |
+  | `MXHangDiagnosticPayload` | `:anr` (iOS's word is "hang"; the defect taxonomy uses ANR) |
+  | `MXCPUExceptionDiagnosticPayload` | `:perf_regression` |
+  | `MXDiskWriteExceptionDiagnosticPayload` | `:perf_regression` |
+
+  ## What the delivery contract looks like from Elixir
+
+  `sweep/0` is safe to call at any point; MetricKit's own delivery is
+  asynchronous and the queue accumulates until a caller drains it. A
+  typical shape:
+
+      # In your app's on_start
+      def on_start do
+        # ...
+        Mob.PostMortem.sweep()
+      end
+
+  The top-level `Mob.PostMortem.sweep/0` calls into this module. Nothing
+  auto-runs — that is the framework-wide discipline: mob owns the format
+  and the bus but never becomes the collector.
+
+  ## Redaction
+
+  MetricKit's `MXCallStackTree` carries binary UUIDs, image names and
+  mangled symbol offsets: safe identifiers, no user data. The
+  capsule's fingerprint key uses just the top frame's binary name and
+  offset — enough to group the same crash across launches without
+  embedding anything that varies per crash. The full payload JSON goes
+  onto evidence, bounded by the capsule's existing string-truncation
+  rule.
+
+  ## Platform gating
+
+  The NIF is registered on both iOS and Android (Android returns an
+  empty list unconditionally — see `android/jni/mob_nif.zig`). This
+  module additionally gates on `:mob_nif.platform() == :ios` so a
+  caller on Android does no work at all, and a caller in a host test
+  environment where the NIF is not loaded fails gracefully.
   """
 
   require Logger
 
+  alias Mob.Defect
   alias Mob.Defect.Capsule
+  alias Mob.PostMortem.Registry
 
   @doc """
-  Sweep any MetricKit payloads the OS has delivered since the last call.
+  Sweep the MetricKit queue and emit a capsule for each new payload.
 
-  Returns the list of capsules emitted (empty until the native pipe is
-  in place; today it is always `[]`).
-
-  Logs at `:info` on first call so an operator running `mix mob.post_mortems.sweep`
-  on an iOS host can see the "not yet wired" state rather than getting
-  silence and wondering.
+  Returns the list of capsules emitted, in the order they were
+  delivered by the OS. Empty on Android, on iOS < 14 (no MetricKit
+  delivery API), and any time the queue was already empty since the
+  last drain.
   """
   @spec sweep() :: [Capsule.t()]
   def sweep do
-    if :persistent_term.get({__MODULE__, :logged_scaffold_notice}, false) do
-      :ok
+    with :ios <- safe_platform(),
+         payloads when is_list(payloads) <- safe_drain() do
+      Registry.start()
+
+      Enum.flat_map(payloads, &emit_if_new/1)
     else
-      Logger.info(
-        "[Mob.PostMortem.IOS] MetricKit ingest is scaffolded; sweep returns [] until " <>
-          "the native MXMetricManager delegate lands (MOB-158 follow-up)."
+      _ -> []
+    end
+  end
+
+  # Called by tests to inject a fake NIF that returns hand-shaped
+  # payloads. Real callers should never pass this — the default reaches
+  # `:mob_nif.post_mortem_ios_drain/0` directly.
+  @doc false
+  @spec sweep_with(module()) :: [Capsule.t()]
+  def sweep_with(nif) when is_atom(nif) do
+    with :ios <- safe_platform_via(nif),
+         payloads when is_list(payloads) <- safe_drain_via(nif) do
+      Registry.start()
+      Enum.flat_map(payloads, &emit_if_new/1)
+    else
+      _ -> []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Emit + dedup
+  # ---------------------------------------------------------------------------
+
+  # Emit gate. Two shape checks, in this order:
+  #
+  # 1. `is_map/1` catches an obviously wrong payload from the NIF (a
+  #    naked atom, a list, nil).
+  # 2. `valid_shape?/1` catches a *partial* map — one that would
+  #    pass `is_map` but crash `Defect.emit_metrickit_payload/1`'s
+  #    strict pattern match. A partial payload from a future NIF
+  #    version that grew a field the current Elixir side does not
+  #    know about is not this shape; a partial payload that dropped
+  #    a field this side needs would be, and would take out the
+  #    whole sweep — losing every later well-formed payload in the
+  #    same drain — if we did not gate.
+  #
+  # Well-formed payloads emit and mark seen; malformed ones log at
+  # :warning and are skipped. Neither raises out of the sweep.
+  defp emit_if_new(payload) when is_map(payload) do
+    if valid_shape?(payload) do
+      id = artifact_id(payload)
+
+      if Registry.mark_seen(id) do
+        [Defect.emit_metrickit_payload(payload)]
+      else
+        []
+      end
+    else
+      Logger.warning(
+        "[Mob.PostMortem.IOS] dropping malformed MetricKit payload " <>
+          "(missing required key): #{inspect(payload, limit: 4)}"
       )
 
-      :persistent_term.put({__MODULE__, :logged_scaffold_notice}, true)
+      []
     end
+  end
 
-    []
+  defp emit_if_new(_), do: []
+
+  defp valid_shape?(%{
+         kind: _,
+         top_frame: %{binary: _, offset: _},
+         timestamp_ms: _
+       }),
+       do: true
+
+  defp valid_shape?(_), do: false
+
+  # A MetricKit payload does not carry a stable id of its own — MetricKit
+  # deduplicates by day on its side, and we deduplicate by content on
+  # ours. sha256 of (kind + top_binary + top_offset + timestamp_ms) is
+  # unique per delivered diagnostic; the Registry then filters out
+  # re-emits within the same BEAM lifetime (a re-sweep produces no new
+  # capsules for the same drained payloads).
+  #
+  # No fallback clause: `valid_shape?/1` in the caller gates on exactly
+  # this pattern, so a malformed payload cannot reach here. A second
+  # clause that returned a synthetic id would be dead code the compiler
+  # rightly flags.
+  defp artifact_id(%{
+         kind: kind,
+         top_frame: %{binary: binary, offset: offset},
+         timestamp_ms: timestamp_ms
+       }) do
+    canonical = "#{kind}|#{binary}|#{offset}|#{timestamp_ms}"
+    hash = :crypto.hash(:sha256, canonical) |> Base.encode16(case: :lower)
+    "sha256:" <> hash
+  end
+
+  # ---------------------------------------------------------------------------
+  # Safe NIF wrappers
+  # ---------------------------------------------------------------------------
+
+  defp safe_platform do
+    try do
+      :mob_nif.platform()
+    rescue
+      _ -> :host
+    catch
+      _, _ -> :host
+    end
+  end
+
+  defp safe_platform_via(nif) do
+    try do
+      nif.platform()
+    rescue
+      _ -> :host
+    catch
+      _, _ -> :host
+    end
+  end
+
+  defp safe_drain do
+    try do
+      :mob_nif.post_mortem_ios_drain()
+    rescue
+      _ -> []
+    catch
+      _, _ -> []
+    end
+  end
+
+  defp safe_drain_via(nif) do
+    try do
+      nif.post_mortem_ios_drain()
+    rescue
+      _ -> []
+    catch
+      _, _ -> []
+    end
   end
 end

--- a/lib/mob/post_mortem/ios.ex
+++ b/lib/mob/post_mortem/ios.ex
@@ -17,10 +17,14 @@ defmodule Mob.PostMortem.IOS do
 
   | MetricKit diagnostic | `kind` |
   |---|---|
-  | `MXCrashDiagnosticPayload` | `:native_crash` |
-  | `MXHangDiagnosticPayload` | `:anr` (iOS's word is "hang"; the defect taxonomy uses ANR) |
-  | `MXCPUExceptionDiagnosticPayload` | `:perf_regression` |
-  | `MXDiskWriteExceptionDiagnosticPayload` | `:perf_regression` |
+  | `MXCrashDiagnostic` | `:native_crash` |
+  | `MXHangDiagnostic` | `:anr` (iOS's word is "hang"; the defect taxonomy uses ANR) |
+  | `MXCPUExceptionDiagnostic` | `:perf_regression` |
+  | `MXDiskWriteExceptionDiagnostic` | `:perf_regression` |
+
+  The `Payload` suffix belongs on the container `MXDiagnosticPayload`
+  the OS hands to `didReceiveDiagnosticPayloads:`, which then exposes
+  the individual diagnostics above.
 
   ## What the delivery contract looks like from Elixir
 

--- a/src/mob_nif.erl
+++ b/src/mob_nif.erl
@@ -51,6 +51,8 @@
     %% Notifications
     take_launch_notification/0,
     take_opened_document/0,
+    %% Post-mortem — iOS MetricKit ingest (drain-on-demand)
+    post_mortem_ios_drain/0,
     %% Storage
     storage_dir/1,
     storage_save_to_photo_library/1,
@@ -211,6 +213,8 @@
     element_frames/0,
     native_stats/0,
     native_stats_enable/1,
+    %% Post-mortem — iOS MetricKit ingest (drain-on-demand)
+    post_mortem_ios_drain/0,
     %% Storage
     storage_dir/1,
     storage_save_to_photo_library/1,
@@ -307,6 +311,15 @@ motion_start(_Sensors, _Interval) -> erlang:nif_error(not_loaded).
 motion_stop() -> erlang:nif_error(not_loaded).
 take_launch_notification() -> erlang:nif_error(not_loaded).
 take_opened_document() -> erlang:nif_error(not_loaded).
+%% post_mortem_ios_drain/0 — copy and clear the in-memory MetricKit payload
+%% queue. iOS attaches a MXMetricManagerSubscriber lazily on the first call
+%% and delivers payloads to it on a background queue thereafter; each call
+%% here returns whatever has accumulated since the last drain. Returns a
+%% list of #{kind => atom(), top_frame => #{binary => binary(), offset => integer()},
+%% timestamp_ms => integer(), raw_json => binary()} maps, or [] when the
+%% platform does not export MetricKit (Android, iOS < 14) or the queue is
+%% empty. Called by Mob.PostMortem.IOS.sweep/0.
+post_mortem_ios_drain() -> erlang:nif_error(not_loaded).
 battery_level() -> erlang:nif_error(not_loaded).
 device_set_dispatcher(_Pid) -> erlang:nif_error(not_loaded).
 device_battery_state() -> erlang:nif_error(not_loaded).

--- a/test/mob/nif_scheduling_completeness_test.exs
+++ b/test/mob/nif_scheduling_completeness_test.exs
@@ -51,13 +51,13 @@ defmodule Mob.NifSchedulingCompletenessTest do
     device_low_power_mode device_model device_network_state device_os_version
     device_set_dispatcher device_thermal_state exit_app files_pick haptic log
     motion_start motion_stop native_stats_enable open_settings open_url
-    platform register_component register_tap request_permission share_text
-    storage_dir storage_external_files_dir storage_save_to_media_store
-    storage_save_to_photo_library take_launch_notification take_opened_document
-    toast_show torch tts_speak tts_stop vendor_usb_bulk_write vendor_usb_close
-    vendor_usb_list_devices vendor_usb_open vendor_usb_request_permission
-    vendor_usb_start_reading vendor_usb_stop_reading webview_eval_js
-    webview_go_back webview_post_message
+    platform post_mortem_ios_drain register_component register_tap
+    request_permission share_text storage_dir storage_external_files_dir
+    storage_save_to_media_store storage_save_to_photo_library
+    take_launch_notification take_opened_document toast_show torch tts_speak
+    tts_stop vendor_usb_bulk_write vendor_usb_close vendor_usb_list_devices
+    vendor_usb_open vendor_usb_request_permission vendor_usb_start_reading
+    vendor_usb_stop_reading webview_eval_js webview_go_back webview_post_message
   )
 
   setup_all do

--- a/test/mob/post_mortem/ios_test.exs
+++ b/test/mob/post_mortem/ios_test.exs
@@ -1,0 +1,196 @@
+defmodule Mob.PostMortem.IOSTest do
+  # async: false — Bus + Registry are process-global.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mob.Defect.Bus
+  alias Mob.PostMortem.IOS
+  alias Mob.PostMortem.Registry
+
+  # Fake NIF module used with sweep_with/1. Real callers use :mob_nif,
+  # but on host we mock the native calls so the Elixir side can be
+  # exercised without an iPhone.
+  #
+  # A test sets `:test_platform` and `:test_payloads` in the process
+  # dictionary before calling sweep_with; the fake reads from there.
+  # This gives per-test isolation without the extra ceremony of a mock
+  # library.
+  defmodule FakeNIF do
+    def platform, do: Process.get(:test_platform, :host)
+    def post_mortem_ios_drain, do: Process.get(:test_payloads, [])
+  end
+
+  setup do
+    Bus.start()
+    Bus.reset()
+    Registry.start()
+    Registry.reset()
+    Bus.unsubscribe()
+    {:ok, _ref} = Bus.subscribe()
+
+    Process.put(:test_platform, :ios)
+    Process.put(:test_payloads, [])
+    :ok
+  end
+
+  defp crash_payload(opts \\ []) do
+    %{
+      kind: :native_crash,
+      top_frame: %{
+        binary: Keyword.get(opts, :binary, "MyApp"),
+        offset: Keyword.get(opts, :offset, 12_345)
+      },
+      timestamp_ms: Keyword.get(opts, :timestamp_ms, 1_726_050_000_000),
+      raw_json: Keyword.get(opts, :raw_json, ~s({"payload":true}))
+    }
+  end
+
+  describe "platform gating" do
+    test "returns [] on Android" do
+      Process.put(:test_platform, :android)
+      Process.put(:test_payloads, [crash_payload()])
+      assert IOS.sweep_with(FakeNIF) == []
+    end
+
+    test "returns [] on host" do
+      Process.put(:test_platform, :host)
+      Process.put(:test_payloads, [crash_payload()])
+      assert IOS.sweep_with(FakeNIF) == []
+    end
+
+    test "returns [] on iOS when the NIF is not loaded (default sweep/0)" do
+      # `:mob_nif.platform/0` raises `:undef` in the host test suite,
+      # so the safe_platform wrapper falls through to :host and sweep
+      # returns [].
+      assert IOS.sweep() == []
+    end
+  end
+
+  describe "on iOS with payloads" do
+    test "emits one capsule per payload with the mapped kind" do
+      Process.put(:test_payloads, [
+        crash_payload(),
+        %{crash_payload() | kind: :anr, top_frame: %{binary: "MyApp", offset: 99}},
+        %{crash_payload() | kind: :perf_regression, top_frame: %{binary: "MyApp", offset: 42}}
+      ])
+
+      capsules = IOS.sweep_with(FakeNIF)
+      assert length(capsules) == 3
+
+      kinds = Enum.map(capsules, & &1.kind)
+      assert kinds == [:native_crash, :anr, :perf_regression]
+
+      severities = Enum.map(capsules, & &1.severity)
+      # native_crash → fatal, anr → critical, perf_regression → warning
+      assert severities == [:fatal, :critical, :warning]
+
+      # Each capsule reaches the subscribed test process.
+      for capsule <- capsules do
+        assert_receive {:mob_defect, ^capsule}, 500
+      end
+    end
+
+    test "fingerprints group across timestamps but split across kind + top frame" do
+      # Two crashes at the same top frame — different timestamps — group
+      # into one fingerprint (a crash re-occurring in the same place).
+      Process.put(:test_payloads, [
+        crash_payload(timestamp_ms: 1_000),
+        crash_payload(timestamp_ms: 2_000)
+      ])
+
+      [a, b] = IOS.sweep_with(FakeNIF)
+      assert a.fingerprint == b.fingerprint
+    end
+
+    test "a different top-frame binary or offset produces a different fingerprint" do
+      Process.put(:test_payloads, [
+        crash_payload(binary: "MyApp", offset: 1),
+        crash_payload(binary: "MyApp", offset: 2),
+        crash_payload(binary: "OtherLib", offset: 1)
+      ])
+
+      [a, b, c] = IOS.sweep_with(FakeNIF)
+
+      refute a.fingerprint == b.fingerprint
+      refute a.fingerprint == c.fingerprint
+      refute b.fingerprint == c.fingerprint
+    end
+
+    test "a different kind at the same top frame produces a different fingerprint" do
+      # A hang and a crash at the same top frame are different classes
+      # of defect even though the location matches — kind is on the
+      # fingerprint key exactly to keep them apart.
+      Process.put(:test_payloads, [
+        crash_payload(),
+        %{crash_payload() | kind: :anr}
+      ])
+
+      [a, b] = IOS.sweep_with(FakeNIF)
+      refute a.fingerprint == b.fingerprint
+    end
+
+    test "raw_json rides on evidence" do
+      Process.put(:test_payloads, [crash_payload(raw_json: ~s({"stuff":123}))])
+
+      [capsule] = IOS.sweep_with(FakeNIF)
+      assert capsule.evidence.raw_json == ~s({"stuff":123})
+    end
+
+    test "idempotent — same payload drained twice emits once" do
+      # In production the NIF's own queue would be empty on the second
+      # drain, so this scenario needs the fake to return the same payload
+      # both times. The Registry is what stops the second emit — a
+      # revert (removing Registry.mark_seen) would let both emit.
+      payloads = [crash_payload()]
+      Process.put(:test_payloads, payloads)
+
+      first = IOS.sweep_with(FakeNIF)
+      # sweep again with the same payloads still in the fake's return
+      second = IOS.sweep_with(FakeNIF)
+
+      assert length(first) == 1
+      assert second == []
+    end
+  end
+
+  describe "malformed input" do
+    test "a non-map payload is silently skipped" do
+      # A NIF bug that returned wrong shapes should not crash the
+      # emit path — a caller sees fewer capsules, and the framework
+      # keeps running.
+      Process.put(:test_payloads, [:garbage, crash_payload(), nil])
+
+      capsules = IOS.sweep_with(FakeNIF)
+      assert length(capsules) == 1
+    end
+
+    test "a partial-shape map (missing required keys) is dropped without crashing the sweep" do
+      # A payload that passes `is_map/1` but lacks `:top_frame` /
+      # `:timestamp_ms` would previously reach `Defect.emit_metrickit_payload/1`,
+      # crash with `FunctionClauseError` inside `Enum.flat_map/2`, and
+      # take out the whole sweep — losing every later well-formed
+      # payload in the same drain. The valid_shape? gate keeps the
+      # sweep going.
+      Process.put(:test_payloads, [
+        %{kind: :native_crash},
+        crash_payload(binary: "MyApp", offset: 111),
+        %{kind: :anr, top_frame: %{binary: "OtherLib"}},
+        crash_payload(binary: "MyApp", offset: 222)
+      ])
+
+      {capsules, log} =
+        with_log(fn -> IOS.sweep_with(FakeNIF) end)
+        |> then(fn {caps, log} -> {caps, log} end)
+
+      # Two well-formed payloads through, two malformed dropped.
+      assert length(capsules) == 2
+      assert Enum.all?(capsules, &(&1.kind in [:native_crash, :anr]))
+
+      # The drop path logs at :warning so an operator sees the bad
+      # shape rather than getting silent data loss.
+      assert log =~ "[warning]"
+      assert log =~ "malformed MetricKit payload"
+    end
+  end
+end


### PR DESCRIPTION
MOB-179 replaces the phase 1 `Mob.PostMortem.IOS` scaffold with a real MetricKit pipe. `sweep/0` on iOS attaches an `MXMetricManagerSubscriber` lazily on first call, buffers OS-delivered payloads in a bounded 32-entry queue guarded by `os_unfair_lock`, and drains them into `Mob.Defect.Capsule`s each subsequent call. Ships in release per [the MOB-158 decision record](/decisions/2026-09-04-defect-reports-are-a-shipped-feature.md).

## What ships

- **`ios/mob_nif.m`** — `MobMetricSubscriber` conforming to `MXMetricManagerSubscriber`, delegate `didReceiveDiagnosticPayloads:` on a background queue, `os_unfair_lock`-guarded ring with oldest-dropped overflow. `nif_post_mortem_ios_drain` copies + clears the queue and returns a list of Elixir maps. Regular scheduler (not dirty) — the drain is a bounded locked memcpy; the lazy attach is a fire-and-forget async dispatch.
- **`android/jni/mob_nif.zig`** — stub `nif_post_mortem_ios_drain` returning `[]` so the shared `mob_nif.erl` NIF list resolves on both platforms without the Android loader raising.
- **`src/mob_nif.erl`** — new export + `-nifs` entry + Erlang stub.
- **`lib/mob/post_mortem/ios.ex`** — real `sweep/0`, `sweep_with/1` (test-only injection point). Platform gate (Android/host returns `[]`), shape validation gate (partial-map payloads log at `:warning` and drop rather than crash the sweep), Registry dedup by sha256 of `(kind + top_binary + top_offset + timestamp_ms)`.
- **`lib/mob/defect.ex`** — `emit_metrickit_payload/1` with kind → severity mapping (`:native_crash` → `:fatal`, `:anr` → `:critical`, `:perf_regression` → `:warning`).
- **`decisions/2026-09-11-metrickit-ingest-lazy-attach.md`** — lazy-attach + bounded-queue rationale.

## Adversarial review before commit

Verdict: SOUND WITH FIXES. Two real defects, both applied with revert-verified tests:

1. **`enif_alloc_binary` return value discarded** — under OOM the `ErlNifBinary` fields are undefined and `enif_make_binary` would promote garbage to a term. Fixed to check + skip the entry with a `LOGE`, matching the file's own convention elsewhere.
2. **Malformed-shape payload crashed the whole sweep** — a map that passed `is_map` but missed required keys would blow up `Defect.emit_metrickit_payload/1`'s strict pattern inside `Enum.flat_map`, aborting the whole batch and losing every later well-formed payload. Fixed with a `valid_shape?/1` gate that logs at `:warning` and drops the bad entry; test asserts a mixed batch (bad, good, bad, good) emits both goods.

Nitpicks folded in / justified: `require Logger` moved to top-level; `import ExUnit.CaptureLog` moved to top-level; dead `artifact_id/1` fallback removed after the shape gate made it unreachable (compiler correctly flagged it under `--warnings-as-errors`).

## Gates

- `mix test`: 1774 pass (11 new), 0 fail
- `mix format --check-formatted`: clean
- `mix credo --strict`: 0 issues (2345 mods/funs, 207 source files)
- `mix compile --warnings-as-errors --force`: clean
- `xcrun clang-format --dry-run -Werror ios/mob_nif.m`: clean
- Standalone iOS syntax check via `xcrun clang -fsyntax-only` against real `iPhoneOS26.5.sdk` + real `erl_nif.h`: clean
- `zig ast-check android/jni/mob_nif.zig`: clean

## Not in this PR (verification requires a device)

MetricKit only delivers real payloads on physical iPhones — not the simulator, unless via `xcrun simctl mxpayload push` where available. I coded and compile-verified end-to-end; the real "attach + receive + drain + emit" round-trip needs a physical device and a delivered payload. A [device verification recipe](/private/tmp/claude-501/-Users-kevin-code/13b16161-8aad-4cc4-b43f-c9bf77f9bed3/scratchpad/mob179-device-verify.md) is drafted (Kevin holds an iPhone; I hold the code). The recipe walks the setup (path-dep swap in `~/code/mob_test`, `mix mob.deploy --native`), the first-sweep-attach log line, forcing a crash, waiting for delivery, and asserting the drained capsule shape.

## Closes

Phase 2 of [MOB-158](https://linear.app/mobframework/issue/MOB-158) (the iOS half). MOB-158 stays In Progress until MOB-180 (Android `ApplicationExitInfo`) also lands.
