### PR TITLE
MOB-180: Android ApplicationExitInfo ingest for Mob.PostMortem.Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,10 +72,38 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   builds hit the fallback path and return `[]`. Android's stub NIF also
   returns `[]` — `ApplicationExitInfo` is a separate ticket (MOB-180).
 
-- **Android post-mortem scaffold — `Mob.PostMortem.Android`**.
-  `sweep/0` returns `[]` and logs once at `:info`. The real native
-  pipe (`ApplicationExitInfo`) is a follow-up ticket (MOB-180) with
-  device verification.
+- **Android ApplicationExitInfo ingest for `Mob.PostMortem.Android`**
+  (MOB-180). Replaces the phase 1 scaffold. `Mob.PostMortem.sweep/0`
+  on Android now pulls the OS-held history of process exits via
+  `ActivityManager.getHistoricalProcessExitReasons` (API 30+), filters
+  against a persistent marker at
+  `<filesDir>/mob_post_mortem_appexit_marker.txt` so each exit emits
+  exactly once across boots, and turns each new entry into a
+  `Mob.Defect.Capsule` on `Mob.Defect.Bus`.
+
+  Reason code → kind mapping: `REASON_CRASH` / `REASON_CRASH_NATIVE`
+  / `REASON_SIGNALED` → `:native_crash` / `:fatal`; `REASON_ANR` →
+  `:anr` / `:critical`; `REASON_LOW_MEMORY` /
+  `REASON_EXCESSIVE_RESOURCE_USAGE` → `:oom` / `:fatal`;
+  `REASON_USER_STOPPED` / `REASON_USER_REQUESTED` / `REASON_EXIT_SELF`
+  / `REASON_DEPENDENCY_DIED` / `REASON_OTHER` / `REASON_FREEZER` →
+  `:user_kill` / `:info`.
+
+  Fingerprint groups by `(kind + process_name + reason_code)` — the
+  same class of exit for the same process across boots becomes one
+  triage row. The emitted capsule carries reason code, pid,
+  timestamp, process name, and the OS-generated description string.
+  Trace file contents (an ANR's stack text) are NOT included this
+  phase — they can carry app strings and need the same discipline the
+  receipt module documents before they can safely reach the bus.
+
+  Implementation is pure Zig JNI in `android/jni/mob_nif.zig` rather
+  than a `MobBridge.kt.eex` template addition. Every existing mob
+  app gets the feature the moment they bump mob, with no template
+  refresh dance. See
+  `decisions/2026-09-11-appexit-native-jni-not-bridge.md`. iOS
+  registers a stub `nif_post_mortem_android_drain` returning `[]` so
+  the shared `mob_nif.erl` NIF list resolves on both platforms.
 
 ---
 

--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -4094,11 +4094,11 @@ export fn nif_vendor_usb_close(
 // ── Mob.PostMortem.IOS — MetricKit drain (iOS-only, Android stub) ────────
 //
 // The MetricKit channel is iOS-only; the equivalent Android substrate is
-// `ApplicationExitInfo`, whose ingest is its own follow-up ticket
-// (MOB-180) with its own NIF. This stub exists so the shared
-// `mob_nif.erl` `-nifs([post_mortem_ios_drain/0])` declaration resolves
-// on Android without the loader raising. Returns [] unconditionally —
-// the Elixir side (Mob.PostMortem.IOS.sweep/0) also gates on
+// `ApplicationExitInfo`, whose ingest is nif_post_mortem_android_drain
+// below. This stub exists so the shared `mob_nif.erl`
+// `-nifs([post_mortem_ios_drain/0])` declaration resolves on Android
+// without the loader raising. Returns [] unconditionally — the Elixir
+// side (Mob.PostMortem.IOS.sweep/0) also gates on
 // `Mob.PostMortem.platform() == :ios` before it even calls this, so a
 // well-formed caller never reaches here on Android.
 export fn nif_post_mortem_ios_drain(
@@ -4109,6 +4109,504 @@ export fn nif_post_mortem_ios_drain(
     _ = argc;
     _ = argv;
     return erts.makeList(env, &.{});
+}
+
+// ── Mob.PostMortem.Android — ApplicationExitInfo drain (MOB-180) ─────────
+//
+// ActivityManager.getHistoricalProcessExitReasons returns the OS-held
+// history of process exits — ANRs, crashes, OOMs, user-kills — that
+// this app's process has recorded across reboots. We pull it on demand
+// and hand each entry to the BEAM as an Elixir map. The Elixir side
+// (Mob.PostMortem.Android.sweep/0) then builds capsules via
+// Mob.Defect.emit_appexit_reason/1.
+//
+// **Availability.** Requires API 30 (Android 11). The Zig call checks
+// `Build.VERSION.SDK_INT` at runtime and returns [] on anything older,
+// so a debug build on an emulator ≤ API 29 does not raise.
+//
+// **Architectural choice.** All native access is through this NIF —
+// no MobBridge.kt template addition. MobBridge is app-owned and never
+// regenerated per `project_mob_plugin_permissions_host_drift`: a
+// template-addition would silently degrade to [] on every existing app,
+// exactly the wrong shape for a passive framework observability
+// feature. Pure JNI from mob-side works on every app the moment they
+// bump mob.
+//
+// **Persistent marker.** ApplicationExitInfo history survives across
+// app reboots — a fresh install would otherwise re-emit every historic
+// crash on first sweep, and every boot after would re-emit them again.
+// We persist the most-recent-seen exit timestamp to
+// `<filesDir>/mob_post_mortem_appexit_marker.txt` and filter the OS
+// list to entries strictly newer than that. First sweep on a fresh
+// install still emits the current history (that is the point); every
+// subsequent sweep emits only what accumulated since.
+//
+// **Redaction.** The emitted map carries: reason code (numeric enum),
+// process name (normally the app's package; not user data), OS-generated
+// description (a short string like "remote process crash"; not
+// app-controlled), pid, and timestamp. NOT included: trace file
+// contents (an ANR's trace can carry app strings — same discipline as
+// the receipt module; a follow-up phase can add it with per-capsule
+// truncation).
+
+// Android ApplicationExitInfo.REASON_* constants (public SDK API).
+// Hard-coded rather than reflected so a stale device with an odd
+// system image cannot desync us — these values are stable across
+// every Android 11+ release.
+const AEI_REASON_UNKNOWN: i32 = 0;
+const AEI_REASON_EXIT_SELF: i32 = 1;
+const AEI_REASON_SIGNALED: i32 = 2;
+const AEI_REASON_LOW_MEMORY: i32 = 3;
+const AEI_REASON_CRASH: i32 = 4;
+const AEI_REASON_CRASH_NATIVE: i32 = 5;
+const AEI_REASON_ANR: i32 = 6;
+const AEI_REASON_INITIALIZATION_FAILURE: i32 = 7;
+const AEI_REASON_PERMISSION_CHANGE: i32 = 8;
+const AEI_REASON_EXCESSIVE_RESOURCE_USAGE: i32 = 9;
+const AEI_REASON_USER_REQUESTED: i32 = 10;
+const AEI_REASON_USER_STOPPED: i32 = 11;
+const AEI_REASON_DEPENDENCY_DIED: i32 = 12;
+const AEI_REASON_OTHER: i32 = 13;
+const AEI_REASON_FREEZER: i32 = 14;
+
+// JNI method-call signatures we need beyond what mob_zig.zig types.
+//
+// The JNI `Call*Method` slots are variadic in C, and the ones we need
+// here are `?*anyopaque` or arity-mismatched in `mob_zig.zig`. Cast
+// the raw slot to a concrete arity per call site — Zig cannot call a
+// variadic function pointer with a fixed argument count directly, so
+// this cast is the standard idiom. The `mob_zig.zig` `callObjectMethod`
+// helper covers arity 0; the helpers below cover arities we hit in
+// this NIF.
+
+const CallIntMethodNoArgs = fn (env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID) callconv(.c) jni.JInt;
+const CallLongMethodNoArgs = fn (env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID) callconv(.c) i64;
+const CallObjOneObj = fn (env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID, a: jni.JObject) callconv(.c) jni.JObject;
+const CallObjOneInt = fn (env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID, a: jni.JInt) callconv(.c) jni.JObject;
+const CallObjObjIntInt = fn (env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID, a: jni.JObject, b: jni.JInt, c: jni.JInt) callconv(.c) jni.JObject;
+
+inline fn callIntNoArgs(env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID) jni.JInt {
+    const fptr: *const CallIntMethodNoArgs = @ptrCast(@alignCast(env.*.CallIntMethod.?));
+    return fptr(env, obj, mid);
+}
+
+inline fn callLongNoArgs(env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID) i64 {
+    const fptr: *const CallLongMethodNoArgs = @ptrCast(@alignCast(env.*.CallLongMethod.?));
+    return fptr(env, obj, mid);
+}
+
+inline fn callObjWithObj(env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID, a: jni.JObject) jni.JObject {
+    const fptr: *const CallObjOneObj = @ptrCast(@alignCast(env.*.CallObjectMethod.?));
+    return fptr(env, obj, mid, a);
+}
+
+inline fn callObjWithInt(env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID, a: jni.JInt) jni.JObject {
+    const fptr: *const CallObjOneInt = @ptrCast(@alignCast(env.*.CallObjectMethod.?));
+    return fptr(env, obj, mid, a);
+}
+
+inline fn callObjWithObjIntInt(env: *jni.JNIEnv, obj: jni.JObject, mid: jni.JMethodID, a: jni.JObject, b: jni.JInt, c: jni.JInt) jni.JObject {
+    const fptr: *const CallObjObjIntInt = @ptrCast(@alignCast(env.*.CallObjectMethod.?));
+    return fptr(env, obj, mid, a, b, c);
+}
+
+// Cached Build.VERSION.SDK_INT. Populated lazily on the first drain
+// call via `buildSdkInt` rather than at nif_load time — nif_load runs
+// before `mob_init_bridge` captures `g_activity`, so there is no
+// Context to reach the class from yet. A drain that arrives before
+// the first successful lookup treats the field as unknown and
+// proceeds; on an API-29 device that means `getMethodID` for
+// `getHistoricalProcessExitReasons` returns null and the drain
+// returns [] cleanly. Zero is the "unknown" sentinel, matching
+// Android's convention that SDK_INT is always > 0 on a real device.
+var g_android_sdk_int: i32 = 0;
+
+// Cached filesDir absolute path. Written once on the first successful
+// getFilesDir call. Bounded at 512 bytes — mob's data dir path is well
+// under this on every device.
+var g_files_dir_buf: [512]u8 = @splat(0);
+var g_files_dir_len: usize = 0;
+
+fn filesDirPath(env: *jni.JNIEnv, context: jni.JObject) ?[]const u8 {
+    if (g_files_dir_len > 0) return g_files_dir_buf[0..g_files_dir_len];
+
+    // context.getFilesDir() → java.io.File
+    const ctx_cls = jni.getObjectClass(env, context);
+    defer jni.deleteLocalRef(env, ctx_cls);
+
+    const get_files_dir_mid = jni.getMethodID(env, ctx_cls, "getFilesDir", "()Ljava/io/File;");
+    if (get_files_dir_mid == null) {
+        jni.exceptionClear(env);
+        return null;
+    }
+
+    const files_dir = jni.callObjectMethod(env, context, get_files_dir_mid);
+    if (files_dir == null) {
+        jni.exceptionClear(env);
+        return null;
+    }
+    defer jni.deleteLocalRef(env, files_dir);
+
+    const file_cls = jni.getObjectClass(env, files_dir);
+    defer jni.deleteLocalRef(env, file_cls);
+
+    const get_abs_path_mid = jni.getMethodID(env, file_cls, "getAbsolutePath", "()Ljava/lang/String;");
+    if (get_abs_path_mid == null) {
+        jni.exceptionClear(env);
+        return null;
+    }
+
+    const jstr = jni.callObjectMethod(env, files_dir, get_abs_path_mid);
+    if (jstr == null) {
+        jni.exceptionClear(env);
+        return null;
+    }
+    defer jni.deleteLocalRef(env, jstr);
+
+    const chars = jni.getStringUTFChars(env, jstr) orelse return null;
+    defer jni.releaseStringUTFChars(env, jstr, chars);
+
+    var i: usize = 0;
+    while (chars[i] != 0 and i < g_files_dir_buf.len - 1) : (i += 1) {
+        g_files_dir_buf[i] = chars[i];
+    }
+    g_files_dir_buf[i] = 0;
+    g_files_dir_len = i;
+    return g_files_dir_buf[0..i];
+}
+
+const MARKER_FILENAME = "mob_post_mortem_appexit_marker.txt";
+
+// Read the persisted last-seen timestamp. Returns 0 on first-ever
+// sweep (no marker file), on parse failure, or on any I/O error —
+// treating any of those as "we have not seen anything yet" is the
+// safe direction: at worst we re-emit some historic capsules the
+// Registry then dedups within the current BEAM session.
+fn readMarker(dir: []const u8) i64 {
+    var path_buf: [640]u8 = @splat(0);
+    const path = std.fmt.bufPrintZ(&path_buf, "{s}/{s}", .{ dir, MARKER_FILENAME }) catch return 0;
+
+    const f = jni.fopen(path.ptr, "rb") orelse return 0;
+    defer _ = jni.fclose(f);
+
+    var buf: [32]u8 = @splat(0);
+    const n = jni.fread(&buf, 1, buf.len - 1, f);
+    if (n == 0) return 0;
+    buf[@min(n, buf.len - 1)] = 0;
+
+    const trimmed = std.mem.sliceTo(&buf, '\n');
+    return std.fmt.parseInt(i64, std.mem.trim(u8, trimmed, " \t\r\n"), 10) catch 0;
+}
+
+// Persist the last-seen timestamp via POSIX open+write+close. The file
+// is at most ~24 bytes ("9223372036854775807\n"), and we truncate on
+// every write so a stale longer content never leaks in.
+//
+// **Failure modes.** Marker advance is best-effort: the worst outcome
+// of a silent failure is that next boot re-emits already-emitted exits,
+// which the Registry then dedups within the session. But cross-boot
+// dedup depends on the marker actually advancing, and an operator
+// staring at duplicate capsules across restarts needs a hint that
+// this write path is why. We log an :error line the first time each
+// failure kind is hit so a chatty NIF doesn't drown the console but
+// the pattern is discoverable.
+fn writeMarker(dir: []const u8, ts_ms: i64) void {
+    var path_buf: [640]u8 = @splat(0);
+    const path = std.fmt.bufPrintZ(&path_buf, "{s}/{s}", .{ dir, MARKER_FILENAME }) catch {
+        logMarkerFailureOnce("path_too_long");
+        return;
+    };
+
+    const fd = posix_open(path.ptr, O_WRONLY | O_CREAT | O_TRUNC, 0o600);
+    if (fd < 0) {
+        logMarkerFailureOnce("open_failed");
+        return;
+    }
+    defer _ = posix_close(fd);
+
+    var out_buf: [32]u8 = @splat(0);
+    const out = std.fmt.bufPrintZ(&out_buf, "{d}\n", .{ts_ms}) catch {
+        logMarkerFailureOnce("format_failed");
+        return;
+    };
+    const written = posix_write(fd, out.ptr, out.len);
+    if (written < 0) logMarkerFailureOnce("write_failed");
+}
+
+var g_marker_failure_logged = std.atomic.Value(bool).init(false);
+
+fn logMarkerFailureOnce(reason: []const u8) void {
+    if (g_marker_failure_logged.swap(true, .seq_cst)) return;
+    var buf: [128]u8 = @splat(0);
+    const msg = std.fmt.bufPrintZ(&buf, "mob_post_mortem: marker write failed ({s}); cross-boot dedup will re-emit until this clears", .{reason}) catch return;
+    jni.logWrite(jni.ANDROID_LOG_ERROR, "MobNIF", "{s}", .{msg});
+}
+
+const O_WRONLY: c_int = 1;
+const O_CREAT: c_int = 0o100;
+const O_TRUNC: c_int = 0o1000;
+
+extern "c" fn open(path: [*:0]const u8, flags: c_int, mode: c_uint) c_int;
+extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
+extern "c" fn close(fd: c_int) c_int;
+
+inline fn posix_open(path: [*:0]const u8, flags: c_int, mode: c_uint) c_int {
+    return open(path, flags, mode);
+}
+inline fn posix_write(fd: c_int, buf: [*]const u8, count: usize) isize {
+    return write(fd, buf, count);
+}
+inline fn posix_close(fd: c_int) c_int {
+    return close(fd);
+}
+
+// Get Application context from the global Activity captured at BEAM
+// boot. Returns null if the activity hasn't been captured yet (before
+// mob_init_bridge runs) or if the JNI lookup fails.
+//
+// **Ownership**: the returned JObject is a local ref. Caller must
+// `jni.deleteLocalRef` it before returning to Java, or the ref lives
+// until the current JNI stack frame unwinds.
+fn applicationContext(env: *jni.JNIEnv) ?jni.JObject {
+    if (g_activity == null) return null;
+
+    const activity_cls = jni.getObjectClass(env, g_activity);
+    defer jni.deleteLocalRef(env, activity_cls);
+
+    const get_app_ctx = jni.getMethodID(env, activity_cls, "getApplicationContext", "()Landroid/content/Context;");
+    if (get_app_ctx == null) {
+        jni.exceptionClear(env);
+        return null;
+    }
+
+    const app_ctx = jni.callObjectMethod(env, g_activity, get_app_ctx);
+    if (app_ctx == null) {
+        jni.exceptionClear(env);
+        return null;
+    }
+    return app_ctx;
+}
+
+fn buildSdkInt(env: *jni.JNIEnv) i32 {
+    const cls = jni.findClass(env, "android/os/Build$VERSION");
+    if (cls == null) {
+        jni.exceptionClear(env);
+        return 0;
+    }
+    defer jni.deleteLocalRef(env, cls);
+
+    const fid = jni.getFieldID(env, cls, "SDK_INT", "I");
+    if (fid == null) {
+        jni.exceptionClear(env);
+        return 0;
+    }
+
+    // GetStaticIntField is typed opaque in mob_zig; cast inline.
+    const GetStaticIntField = fn (env_: *jni.JNIEnv, cls_: jni.JClass, fid_: jni.JFieldID) callconv(.c) jni.JInt;
+    const fptr: *const GetStaticIntField = @ptrCast(@alignCast(env.*.GetStaticIntField.?));
+    return fptr(env, cls, fid);
+}
+
+// Copy a Java String's UTF-8 into a Zig buffer, truncating to fit.
+// Returns the slice actually written. Buffer must be caller-provided so
+// this stays alloc-free on the hot path.
+fn copyJStringTruncated(env: *jni.JNIEnv, jstr: jni.JObject, buf: []u8) []const u8 {
+    if (jstr == null or buf.len == 0) return buf[0..0];
+    const chars = jni.getStringUTFChars(env, jstr) orelse return buf[0..0];
+    defer jni.releaseStringUTFChars(env, jstr, chars);
+
+    var i: usize = 0;
+    while (chars[i] != 0 and i < buf.len - 1) : (i += 1) {
+        buf[i] = chars[i];
+    }
+    buf[i] = 0;
+    return buf[0..i];
+}
+
+export fn nif_post_mortem_android_drain(
+    env: ?*erts.ErlNifEnv,
+    argc: c_int,
+    argv: [*]const erts.ERL_NIF_TERM,
+) callconv(.c) erts.ERL_NIF_TERM {
+    _ = argc;
+    _ = argv;
+
+    // API 30+ only. Older devices → [].
+    if (g_android_sdk_int > 0 and g_android_sdk_int < 30) {
+        return erts.makeList(env, &.{});
+    }
+
+    var attached: c_int = 0;
+    const jenv = get_jenv(&attached) orelse return erts.makeList(env, &.{});
+    defer detachIfAttached(attached);
+
+    const app_ctx = applicationContext(jenv) orelse return erts.makeList(env, &.{});
+    defer jni.deleteLocalRef(jenv, app_ctx);
+
+    // Recompute SDK_INT the first time — buildSdkInt is cheap enough
+    // to run per-drain if the nif_load-time cache wasn't set.
+    if (g_android_sdk_int == 0) {
+        g_android_sdk_int = buildSdkInt(jenv);
+        if (g_android_sdk_int > 0 and g_android_sdk_int < 30) {
+            return erts.makeList(env, &.{});
+        }
+    }
+
+    // Persistent marker read — filter to entries strictly newer.
+    const dir = filesDirPath(jenv, app_ctx) orelse return erts.makeList(env, &.{});
+    const last_seen_ms = readMarker(dir);
+
+    // context.getSystemService("activity") → ActivityManager
+    const ctx_cls = jni.getObjectClass(jenv, app_ctx);
+    defer jni.deleteLocalRef(jenv, ctx_cls);
+
+    const get_service_mid = jni.getMethodID(jenv, ctx_cls, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+    if (get_service_mid == null) {
+        jni.exceptionClear(jenv);
+        return erts.makeList(env, &.{});
+    }
+
+    const svc_name = jni.newStringUTF(jenv, "activity");
+    defer jni.deleteLocalRef(jenv, svc_name);
+
+    const am = callObjWithObj(jenv, app_ctx, get_service_mid, svc_name);
+    if (am == null) {
+        jni.exceptionClear(jenv);
+        return erts.makeList(env, &.{});
+    }
+    defer jni.deleteLocalRef(jenv, am);
+
+    // ActivityManager.getHistoricalProcessExitReasons(packageName, pid, maxNum)
+    // — pass nulls / zeros to get the full list for this app.
+    const am_cls = jni.getObjectClass(jenv, am);
+    defer jni.deleteLocalRef(jenv, am_cls);
+
+    const get_history_mid = jni.getMethodID(
+        jenv,
+        am_cls,
+        "getHistoricalProcessExitReasons",
+        "(Ljava/lang/String;II)Ljava/util/List;",
+    );
+    if (get_history_mid == null) {
+        // Older API — should be caught by the SDK check above, but
+        // clear any exception just in case.
+        jni.exceptionClear(jenv);
+        return erts.makeList(env, &.{});
+    }
+
+    const list = callObjWithObjIntInt(jenv, am, get_history_mid, @as(jni.JObject, null), @as(jni.JInt, 0), @as(jni.JInt, 0));
+    if (list == null) {
+        jni.exceptionClear(jenv);
+        return erts.makeList(env, &.{});
+    }
+    defer jni.deleteLocalRef(jenv, list);
+
+    // List.size() / List.get(i)
+    const list_cls = jni.getObjectClass(jenv, list);
+    defer jni.deleteLocalRef(jenv, list_cls);
+    const size_mid = jni.getMethodID(jenv, list_cls, "size", "()I");
+    const get_mid = jni.getMethodID(jenv, list_cls, "get", "(I)Ljava/lang/Object;");
+    if (size_mid == null or get_mid == null) {
+        jni.exceptionClear(jenv);
+        return erts.makeList(env, &.{});
+    }
+
+    const n = callIntNoArgs(jenv, list, size_mid);
+    if (n <= 0) return erts.makeList(env, &.{});
+
+    // ApplicationExitInfo method IDs — resolved once per drain.
+    var aei_cls: jni.JClass = null;
+    var get_pid: jni.JMethodID = null;
+    var get_timestamp: jni.JMethodID = null;
+    var get_reason: jni.JMethodID = null;
+    var get_description: jni.JMethodID = null;
+    var get_process_name: jni.JMethodID = null;
+
+    // Build up a result list. We iterate in OS order (typically
+    // most-recent first per Android docs) and prepend each entry so
+    // the returned Elixir list ends up chronological — same shape as
+    // the iOS drain.
+    var out = erts.makeList(env, &.{});
+    var new_max_ts: i64 = last_seen_ms;
+    var name_buf: [128]u8 = @splat(0);
+    var desc_buf: [256]u8 = @splat(0);
+
+    var i: jni.JInt = 0;
+    while (i < n) : (i += 1) {
+        const entry = callObjWithInt(jenv, list, get_mid, i);
+        if (entry == null) {
+            jni.exceptionClear(jenv);
+            continue;
+        }
+        defer jni.deleteLocalRef(jenv, entry);
+
+        if (aei_cls == null) {
+            aei_cls = jni.getObjectClass(jenv, entry);
+            get_pid = jni.getMethodID(jenv, aei_cls, "getPid", "()I");
+            get_timestamp = jni.getMethodID(jenv, aei_cls, "getTimestamp", "()J");
+            get_reason = jni.getMethodID(jenv, aei_cls, "getReason", "()I");
+            get_description = jni.getMethodID(jenv, aei_cls, "getDescription", "()Ljava/lang/String;");
+            get_process_name = jni.getMethodID(jenv, aei_cls, "getProcessName", "()Ljava/lang/String;");
+            if (get_pid == null or get_timestamp == null or get_reason == null or get_process_name == null) {
+                jni.exceptionClear(jenv);
+                continue;
+            }
+        }
+
+        const ts_ms = callLongNoArgs(jenv, entry, get_timestamp);
+        if (ts_ms <= last_seen_ms) continue;
+        if (ts_ms > new_max_ts) new_max_ts = ts_ms;
+
+        const pid = callIntNoArgs(jenv, entry, get_pid);
+        const reason = callIntNoArgs(jenv, entry, get_reason);
+
+        // process_name and description are best-effort; a null return
+        // becomes an empty binary.
+        const jname = jni.callObjectMethod(jenv, entry, get_process_name);
+        const name_slice = copyJStringTruncated(jenv, jname, &name_buf);
+        if (jname != null) jni.deleteLocalRef(jenv, jname);
+
+        var desc_slice: []const u8 = &[_]u8{};
+        if (get_description != null) {
+            const jdesc = jni.callObjectMethod(jenv, entry, get_description);
+            desc_slice = copyJStringTruncated(jenv, jdesc, &desc_buf);
+            if (jdesc != null) jni.deleteLocalRef(jenv, jdesc);
+        }
+
+        // Build the Elixir map for this entry.
+        const proc_bin = makeBinaryFromSlice(env, name_slice) orelse continue;
+        const desc_bin = makeBinaryFromSlice(env, desc_slice) orelse continue;
+
+        const keys = [_]erts.ERL_NIF_TERM{
+            erts.atom(env, "reason_code"),
+            erts.atom(env, "pid"),
+            erts.atom(env, "timestamp_ms"),
+            erts.atom(env, "process_name"),
+            erts.atom(env, "description"),
+        };
+        const vals = [_]erts.ERL_NIF_TERM{
+            erts.enif_make_int(env, @intCast(reason)),
+            erts.enif_make_int(env, @intCast(pid)),
+            erts.enif_make_int64(env, ts_ms),
+            proc_bin,
+            desc_bin,
+        };
+        const entry_map = erts.makeMap(env, &keys, &vals) orelse continue;
+        out = erts.enif_make_list_cell(env, entry_map, out);
+    }
+
+    if (aei_cls != null) jni.deleteLocalRef(jenv, aei_cls);
+
+    if (new_max_ts > last_seen_ms) writeMarker(dir, new_max_ts);
+
+    return out;
+}
+
+fn makeBinaryFromSlice(env: ?*erts.ErlNifEnv, slice: []const u8) ?erts.ERL_NIF_TERM {
+    var bin: erts.ErlNifBinary = undefined;
+    if (erts.enif_alloc_binary(slice.len, &bin) == 0) return null;
+    if (slice.len > 0) @memcpy(bin.data[0..slice.len], slice);
+    return erts.enif_make_binary(env, &bin);
 }
 
 // ── nif_load: cache all method IDs at BEAM startup ───────────────────────
@@ -4455,8 +4953,13 @@ const nif_funcs = [_]erts.ErlNifFunc{
     // ── Mob.Bt (Bluetooth Classic) — extracted to the mob_bluetooth plugin ──
     // ── Mob.DNS (in-process IPv4 resolver via Bionic getaddrinfo) ────────
     .{ .name = "resolve_ipv4", .arity = 1, .fptr = nif_resolve_ipv4, .flags = erts.ERL_NIF_DIRTY_JOB_IO_BOUND },
-    // ── Mob.PostMortem.IOS (Android stub — the substrate is MOB-180) ─────
+    // ── Mob.PostMortem.IOS (Android stub — the iOS substrate is MOB-179) ─
     .{ .name = "post_mortem_ios_drain", .arity = 0, .fptr = nif_post_mortem_ios_drain, .flags = 0 },
+    // ── Mob.PostMortem.Android (ApplicationExitInfo, MOB-180) ────────────
+    // Dirty-IO: the JNI dance dispatches into ActivityManager and reads
+    // a small marker file; individually cheap, but chained JNI calls
+    // through opaque Java collections can be tens of ms on a slow phone.
+    .{ .name = "post_mortem_android_drain", .arity = 0, .fptr = nif_post_mortem_android_drain, .flags = erts.ERL_NIF_DIRTY_JOB_IO_BOUND },
 };
 
 var mob_nif_entry: erts.ErlNifEntry = .{

--- a/android/jni/mob_nif.zig
+++ b/android/jni/mob_nif.zig
@@ -4307,36 +4307,61 @@ fn readMarker(dir: []const u8) i64 {
 // which the Registry then dedups within the session. But cross-boot
 // dedup depends on the marker actually advancing, and an operator
 // staring at duplicate capsules across restarts needs a hint that
-// this write path is why. We log an :error line the first time each
-// failure kind is hit so a chatty NIF doesn't drown the console but
-// the pattern is discoverable.
+// this write path is why. We log an :error line the first time EACH
+// failure kind is hit — a per-kind flag so `open_failed` followed
+// later by `write_failed` (say, a disk that filled after install)
+// still produces a visible line, without a chatty NIF drowning the
+// console on a permanently-failing path.
 fn writeMarker(dir: []const u8, ts_ms: i64) void {
     var path_buf: [640]u8 = @splat(0);
     const path = std.fmt.bufPrintZ(&path_buf, "{s}/{s}", .{ dir, MARKER_FILENAME }) catch {
-        logMarkerFailureOnce("path_too_long");
+        logMarkerFailureOnce(.path_too_long);
         return;
     };
 
     const fd = posix_open(path.ptr, O_WRONLY | O_CREAT | O_TRUNC, 0o600);
     if (fd < 0) {
-        logMarkerFailureOnce("open_failed");
+        logMarkerFailureOnce(.open_failed);
         return;
     }
     defer _ = posix_close(fd);
 
     var out_buf: [32]u8 = @splat(0);
     const out = std.fmt.bufPrintZ(&out_buf, "{d}\n", .{ts_ms}) catch {
-        logMarkerFailureOnce("format_failed");
+        logMarkerFailureOnce(.format_failed);
         return;
     };
     const written = posix_write(fd, out.ptr, out.len);
-    if (written < 0) logMarkerFailureOnce("write_failed");
+    if (written < 0) logMarkerFailureOnce(.write_failed);
 }
 
-var g_marker_failure_logged = std.atomic.Value(bool).init(false);
+const MarkerFailure = enum { path_too_long, open_failed, format_failed, write_failed };
 
-fn logMarkerFailureOnce(reason: []const u8) void {
-    if (g_marker_failure_logged.swap(true, .seq_cst)) return;
+// One flag per kind so a later failure of a different kind is not
+// silenced by an earlier one. `.acq_rel` is enough for a set-once
+// flag with no other synchronization dependency (per the pre-merge
+// review nitpick — `.seq_cst` was overkill).
+var g_marker_failure_logged_path = std.atomic.Value(bool).init(false);
+var g_marker_failure_logged_open = std.atomic.Value(bool).init(false);
+var g_marker_failure_logged_format = std.atomic.Value(bool).init(false);
+var g_marker_failure_logged_write = std.atomic.Value(bool).init(false);
+
+fn logMarkerFailureOnce(kind: MarkerFailure) void {
+    const flag: *std.atomic.Value(bool) = switch (kind) {
+        .path_too_long => &g_marker_failure_logged_path,
+        .open_failed => &g_marker_failure_logged_open,
+        .format_failed => &g_marker_failure_logged_format,
+        .write_failed => &g_marker_failure_logged_write,
+    };
+    if (flag.swap(true, .acq_rel)) return;
+
+    const reason: []const u8 = switch (kind) {
+        .path_too_long => "path_too_long",
+        .open_failed => "open_failed",
+        .format_failed => "format_failed",
+        .write_failed => "write_failed",
+    };
+
     var buf: [128]u8 = @splat(0);
     const msg = std.fmt.bufPrintZ(&buf, "mob_post_mortem: marker write failed ({s}); cross-boot dedup will re-emit until this clears", .{reason}) catch return;
     jni.logWrite(jni.ANDROID_LOG_ERROR, "MobNIF", "{s}", .{msg});
@@ -4548,6 +4573,16 @@ export fn nif_post_mortem_android_drain(
             get_description = jni.getMethodID(jenv, aei_cls, "getDescription", "()Ljava/lang/String;");
             get_process_name = jni.getMethodID(jenv, aei_cls, "getProcessName", "()Ljava/lang/String;");
             if (get_pid == null or get_timestamp == null or get_reason == null or get_process_name == null) {
+                // Method-ID lookup failed on a documented public API —
+                // shouldn't happen on any Android 11+ device. Reset
+                // aei_cls so the next iteration retries the cache
+                // block; otherwise the loop would skip past the
+                // `if (aei_cls == null)` gate and call the still-null
+                // method IDs as if they were live. That would be UB
+                // from a hypothetical future OEM oddity rather than
+                // the [] we want on that path.
+                jni.deleteLocalRef(jenv, aei_cls);
+                aei_cls = null;
                 jni.exceptionClear(jenv);
                 continue;
             }

--- a/decisions/2026-09-11-appexit-native-jni-not-bridge.md
+++ b/decisions/2026-09-11-appexit-native-jni-not-bridge.md
@@ -1,0 +1,84 @@
+# Android ApplicationExitInfo ingest goes through pure JNI, not MobBridge.kt
+
+- Date: 2026-09-11
+- Status: accepted
+
+## Context
+
+MOB-180 adds Android's post-mortem ingest — `ApplicationExitInfo` from
+`ActivityManager.getHistoricalProcessExitReasons` — to
+`Mob.PostMortem.Android`. There are two conventional routes:
+
+1. **Via the `MobBridge.kt.eex` template.** Add a `@JvmStatic
+   postMortemDrain()` to the template that mob_new emits into every
+   app. The Zig NIF looks it up via `Bridge.post_mortem_drain` in the
+   cached method-ID struct and calls it, matching the pattern for
+   `ui_tree`, `screenshot`, `audio_start_recording`, etc.
+2. **Pure JNI dynamic class lookup.** The NIF resolves
+   `android.app.ActivityManager` and `ApplicationExitInfo` via
+   `FindClass` at drain time, walks the returned `java.util.List`
+   directly, and never touches `MobBridge`.
+
+Both work. Route 1 is the codebase's default for platform-API
+integration; route 2 is uncommon but not unprecedented.
+
+## Decision
+
+Route 2 — pure JNI. `nif_post_mortem_android_drain` in
+`android/jni/mob_nif.zig` uses `g_activity` (the global Activity ref
+captured by `mob_beam.zig` at BEAM boot) to reach a Context, then
+does the class + method lookups against Android's platform APIs
+directly.
+
+## Consequences
+
+**Why not the MobBridge template.** `MobBridge.kt` is app-owned and
+never regenerated (per `project_mob_plugin_permissions_host_drift`
+memory: "the trap is app-owned MobBridge.kt / MainActivity drift
+until refreshed"). A template addition benefits only newly-generated
+apps. Every existing mob app would silently return `[]` on drift —
+exactly the wrong shape for a passive framework observability feature
+that promises to watch every user's crashes. `MobPostMortem.sweep/0`
+saying "no crashes since last boot" when the framework hasn't
+actually asked the OS would train a triager to distrust the channel.
+
+Pure JNI works on every app the moment they bump mob. No template
+change, no `mix mob.doctor` refresh dance, no
+`feedback_widen_dep_across_lockstep_minor`-shaped conversation.
+
+**Cost accepted: ~250 lines of Zig JNI.** More code than a bridge
+method + short caller would be. Trades line count for the guarantee
+that the feature actually runs.
+
+**API-30+ only.** `getHistoricalProcessExitReasons` is Android 11+.
+The NIF caches `Build.VERSION.SDK_INT` and returns `[]` on older
+devices. The Elixir side additionally gates on `platform() ==
+:android`, so a caller on iOS or in a host test does zero JNI work.
+
+**Persistent marker on disk, not in SharedPreferences.** The NIF
+writes `<filesDir>/mob_post_mortem_appexit_marker.txt` via POSIX
+`open`+`write`+`close`. SharedPreferences would need more JNI dance
+(getSharedPreferences → SharedPreferences.Editor → putLong →
+commit); the marker holds a single integer so a text file is enough.
+Any I/O failure is silent: the worst outcome is a re-emit of
+already-emitted entries on next boot, which the Registry then dedups
+within the current BEAM session.
+
+**Trace inclusion deferred.** `ApplicationExitInfo.getTraceInputStream()`
+returns the raw trace file for an ANR — potentially KB of stack text
+with app strings mixed in. That needs the same
+`Mob.Agent.Receipt.summarize_error/3`-style discipline the receipt
+module already documents before it can safely reach the bus. Not in
+this phase; a follow-up ticket if the plain reason-code proves
+insufficient for triage.
+
+**Fingerprint groups aggressively.** The fingerprint key is
+`(kind + process_name + reason_code)` — so two ANRs of the same
+class in the same process across boots become one triage row. If
+`process_name` is empty (an OS quirk seen occasionally) two
+unrelated ANRs would collapse; the mitigation is that
+`Mob.PostMortem.Android`'s `valid_shape?` gate requires
+`process_name` to be present, and the OS reliably provides it for
+every observed entry. If field data ever shows otherwise, tighten
+the key by adding the top-frame from the trace file when phase-2
+trace inclusion lands.

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -8317,6 +8317,22 @@ static ERL_NIF_TERM nif_post_mortem_ios_drain(ErlNifEnv *env, int argc, const ER
     return enif_make_list(env, 0);
 }
 
+// ── Mob.PostMortem.Android drain (iOS stub for the Android substrate) ────
+//
+// The `ApplicationExitInfo` pipe is Android-only; the iOS substrate
+// is MetricKit (nif_post_mortem_ios_drain above). This stub exists so
+// the shared `mob_nif.erl` `-nifs([post_mortem_android_drain/0])`
+// declaration resolves on iOS without the loader raising. Returns []
+// unconditionally — the Elixir side (Mob.PostMortem.Android.sweep/0)
+// gates on platform == :android before it even calls this, so a
+// well-formed caller never reaches here on iOS.
+static ERL_NIF_TERM nif_post_mortem_android_drain(ErlNifEnv *env, int argc,
+                                                  const ERL_NIF_TERM argv[]) {
+    (void)argc;
+    (void)argv;
+    return enif_make_list(env, 0);
+}
+
 // Scheduling notes for nif_funcs[] below — see docs/decisions/0001-dirty-nifs.md
 // for the full rationale. Short version: most NIFs here either dispatch_async
 // to the main queue and return in microseconds, or dispatch_sync but read a
@@ -8466,6 +8482,9 @@ static ErlNifFunc nif_funcs[] = {
     // Nothing blocks on another thread; nothing computes for
     // scheduler-blocking durations.
     {"post_mortem_ios_drain", 0, nif_post_mortem_ios_drain, 0},
+    // iOS stub for the Android ApplicationExitInfo drain — the shared
+    // mob_nif.erl NIF list must resolve on both platforms. Returns [].
+    {"post_mortem_android_drain", 0, nif_post_mortem_android_drain, 0},
 };
 
 static int nif_load(ErlNifEnv *env, void **priv, ERL_NIF_TERM info) {

--- a/lib/mob/defect.ex
+++ b/lib/mob/defect.ex
@@ -243,4 +243,107 @@ defmodule Mob.Defect do
   # type this dispatch does not know yet. Log severity, not silent
   # absorption.
   defp metrickit_severity(_), do: :critical
+
+  @doc """
+  Emit a defect for one Android `ApplicationExitInfo` entry.
+
+  Owner is `:mob` — an ApplicationExitInfo record describes the death
+  of this app's own process from the OS's point of view, and mob owns
+  the process during a mob-app lifetime.
+
+  The `entry` map comes from `Mob.PostMortem.Android.sweep/0`'s drain
+  of the native queue. Its shape:
+
+      %{
+        reason_code: 6,       # ApplicationExitInfo.REASON_* integer
+        pid: 12345,
+        timestamp_ms: 1_726_050_000_000,
+        process_name: "com.example.app",
+        description: "remote process crash"
+      }
+
+  Reason code → kind mapping (numeric constants from Android's
+  `android.app.ApplicationExitInfo` public API, hard-coded here rather
+  than depending on the JNI shim to name them):
+
+  | Reason(s) | `kind` | `severity` |
+  |---|---|---|
+  | `REASON_CRASH_NATIVE` (5), `REASON_CRASH` (4), `REASON_SIGNALED` (2) | `:native_crash` | `:fatal` |
+  | `REASON_ANR` (6) | `:anr` | `:critical` |
+  | `REASON_LOW_MEMORY` (3), `REASON_EXCESSIVE_RESOURCE_USAGE` (9) | `:oom` | `:fatal` |
+  | `REASON_USER_STOPPED` (11), `REASON_USER_REQUESTED` (10), `REASON_EXIT_SELF` (1), `REASON_DEPENDENCY_DIED` (12) | `:user_kill` | `:info` |
+  | anything else (unknown / rare) | `:user_kill` | `:info` |
+
+  The `:info` default for unrecognised reason codes is deliberate. A
+  novel reason a future Android version invents is not a defect to
+  page a triager on; downgrading to routine is safer than upgrading
+  to critical. The specific `REASON_*` mappings above match Android's
+  documented severity semantics.
+
+  Fingerprint groups by `(kind + process_name + reason_code)` — the
+  same class of exit for the same process across boots becomes one
+  triage row.
+  """
+  @spec emit_appexit_reason(map()) :: Capsule.t()
+  def emit_appexit_reason(
+        %{
+          reason_code: reason_code,
+          pid: _pid,
+          timestamp_ms: timestamp_ms,
+          process_name: process_name,
+          description: description
+        } = _entry
+      ) do
+    kind = appexit_kind(reason_code)
+
+    Capsule.new(
+      kind: kind,
+      owner: :mob,
+      severity: appexit_severity(kind),
+      fingerprint_key: %{
+        source: :application_exit_info,
+        kind: kind,
+        process_name: process_name,
+        reason_code: reason_code
+      },
+      evidence: %{
+        source: :application_exit_info,
+        reason_code: reason_code,
+        process_name: process_name,
+        description: description,
+        timestamp_ms: timestamp_ms
+      }
+    )
+    |> Bus.emit()
+  end
+
+  # Reason code → defect kind. Numeric constants from
+  # android.app.ApplicationExitInfo; source of truth is the Android
+  # SDK (stable across Android 11+).
+  #
+  # 4 = REASON_CRASH, 5 = REASON_CRASH_NATIVE, 2 = REASON_SIGNALED
+  defp appexit_kind(4), do: :native_crash
+  defp appexit_kind(5), do: :native_crash
+  defp appexit_kind(2), do: :native_crash
+
+  # 6 = REASON_ANR
+  defp appexit_kind(6), do: :anr
+
+  # 3 = REASON_LOW_MEMORY, 9 = REASON_EXCESSIVE_RESOURCE_USAGE
+  defp appexit_kind(3), do: :oom
+  defp appexit_kind(9), do: :oom
+
+  # 1 = REASON_EXIT_SELF, 10 = REASON_USER_REQUESTED,
+  # 11 = REASON_USER_STOPPED, 12 = REASON_DEPENDENCY_DIED,
+  # 13 = REASON_OTHER, 14 = REASON_FREEZER
+  defp appexit_kind(_other), do: :user_kill
+
+  # appexit_kind/1 above is total across the reason-code integer domain
+  # (the `defp appexit_kind(_other)` fallback catches everything not
+  # explicitly matched), so its return is one of these four atoms only.
+  # A `_` fallback here would be dead code the compiler rightly flags.
+  defp appexit_severity(:native_crash), do: :fatal
+  defp appexit_severity(:anr), do: :critical
+  defp appexit_severity(:oom), do: :fatal
+  defp appexit_severity(:user_kill), do: :info
 end

--- a/lib/mob/post_mortem/android.ex
+++ b/lib/mob/post_mortem/android.ex
@@ -2,63 +2,194 @@ defmodule Mob.PostMortem.Android do
   @moduledoc """
   `ApplicationExitInfo`-backed post-mortem ingest for Android.
 
-  ## Status: scaffolded, not implemented
+  Pulls the OS-held history of process exits via
+  `ActivityManager.getHistoricalProcessExitReasons` (available on
+  Android 11 / API 30 and later), filters against a persistent marker
+  so each exit is emitted exactly once across boots, and hands each new
+  entry to `Mob.Defect.emit_appexit_reason/1` as a capsule on
+  `Mob.Defect.Bus`.
 
-  `sweep/0` returns `[]` today. The native pipe — an
-  `ActivityManager.getHistoricalProcessExitReasons` call on next boot,
-  filtered against a persistent marker so each reason is emitted exactly
-  once — is a follow-up ticket with its own device-verification loop.
-  This module exists as the symbol `Mob.PostMortem.sweep/0` calls into
-  so the coordinator does not have to grow a per-platform branch when
-  the native side lands.
+  ## What the OS gives us
 
-  ## The intended contract, for when it does land
+  `ApplicationExitInfo` records the reason a previous process instance
+  of this app died — an ANR, a crash, an OOM, a user-initiated kill.
+  The list survives reboots and app updates, and the OS trims it
+  eventually (usually 16 entries per app). We do NOT run every boot
+  hoping to catch a live incident: we sweep whenever the caller does
+  and take whatever the OS still holds since the last sweep.
 
-  * Called on any node, but does its work only when `:mob_nif.platform/0`
-    returns `:android` and the OS is API 30+ (Android 11+, where
-    `ApplicationExitInfo` exists).
-  * Each historical exit reason becomes one `Mob.Defect.Capsule` on the
-    bus, with `kind: :anr` / `:oom` / `:user_kill` / `:native_crash`
-    picked from the reason code, and `owner: :mob`.
-  * Deduplication is on `pid + timestamp` per reason, recorded in
-    per-app storage so a subsequent boot never re-emits an old exit
-    even if the OS still lists it.
-  * Redaction: an ANR's trace file contents can carry app strings.
-    Trace inclusion is bounded (the same 4KB cap the capsule already
-    enforces) and clipped in the native layer before the capsule is
-    built. The persistent marker records only the reason id, never
-    the trace text.
+  ## Persistent marker
+
+  Without a marker, every sweep on a fresh install re-emits the entire
+  historical list; every subsequent boot would re-emit the same
+  entries. The native NIF persists the highest-seen exit timestamp to
+  `<filesDir>/mob_post_mortem_appexit_marker.txt` and filters the OS
+  list to entries strictly newer. First sweep on a fresh install still
+  emits the current history (that is the point of a first sweep);
+  every subsequent sweep emits only what accumulated since.
+
+  ## Platform gating
+
+  The NIF is registered on both platforms (iOS returns `[]`
+  unconditionally — the iOS substrate is MetricKit, MOB-179). This
+  module gates on `:mob_nif.platform() == :android` so a caller on
+  iOS or in a host test does no work at all. On an Android device
+  below API 30 the native side also returns `[]` — the API was added
+  in Android 11.
+
+  ## Redaction
+
+  The emitted capsule carries: numeric reason code, pid (an OS
+  identifier, not user data), timestamp, process name (normally the
+  app's package name; also OS-controlled), and a short
+  OS-generated description string like `"remote process crash"`.
+  NOT included this phase: the trace file contents an ANR carries —
+  those can hold app strings and need the same
+  `Mob.Agent.Receipt.summarize_error/3`-style discipline before they
+  can safely reach the bus.
   """
 
   require Logger
 
+  alias Mob.Defect
   alias Mob.Defect.Capsule
+  alias Mob.PostMortem.Registry
 
   @doc """
   Sweep any ApplicationExitInfo entries the OS has recorded since the
-  last call.
+  persisted marker was last written.
 
-  Returns the list of capsules emitted (empty until the native pipe is
-  in place; today it is always `[]`).
-
-  Logs at `:info` on first call so an operator running
-  `mix mob.post_mortems.sweep` on an Android-target host can see the
-  "not yet wired" state rather than getting silence and wondering.
+  Returns the list of capsules emitted, in the order the NIF returned
+  them (typically OS-chronological). Empty on iOS, on Android < 11, on
+  a host test with the NIF not loaded, or any time the marker filters
+  everything out.
   """
   @spec sweep() :: [Capsule.t()]
   def sweep do
-    if :persistent_term.get({__MODULE__, :logged_scaffold_notice}, false) do
-      :ok
+    with :android <- safe_platform(),
+         entries when is_list(entries) <- safe_drain() do
+      Registry.start()
+
+      Enum.flat_map(entries, &emit_if_new/1)
     else
-      Logger.info(
-        "[Mob.PostMortem.Android] ApplicationExitInfo ingest is scaffolded; sweep " <>
-          "returns [] until the native getHistoricalProcessExitReasons pipe lands " <>
-          "(MOB-158 follow-up)."
+      _ -> []
+    end
+  end
+
+  @doc false
+  @spec sweep_with(module()) :: [Capsule.t()]
+  def sweep_with(nif) when is_atom(nif) do
+    with :android <- safe_platform_via(nif),
+         entries when is_list(entries) <- safe_drain_via(nif) do
+      Registry.start()
+      Enum.flat_map(entries, &emit_if_new/1)
+    else
+      _ -> []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Emit + dedup
+  # ---------------------------------------------------------------------------
+
+  # Same shape as Mob.PostMortem.IOS.emit_if_new/1: shape validation
+  # first, then Registry dedup, then Defect emit. A malformed entry
+  # logs at :warning and is skipped — one bad row from the NIF must
+  # not take out the whole sweep.
+  defp emit_if_new(entry) when is_map(entry) do
+    if valid_shape?(entry) do
+      id = artifact_id(entry)
+
+      if Registry.mark_seen(id) do
+        [Defect.emit_appexit_reason(entry)]
+      else
+        []
+      end
+    else
+      Logger.warning(
+        "[Mob.PostMortem.Android] dropping malformed ApplicationExitInfo entry " <>
+          "(missing required key): #{inspect(entry, limit: 4)}"
       )
 
-      :persistent_term.put({__MODULE__, :logged_scaffold_notice}, true)
+      []
     end
+  end
 
-    []
+  defp emit_if_new(_), do: []
+
+  defp valid_shape?(%{
+         reason_code: _,
+         pid: _,
+         timestamp_ms: _,
+         process_name: _,
+         description: _
+       }),
+       do: true
+
+  defp valid_shape?(_), do: false
+
+  # sha256 over (reason_code + pid + timestamp_ms + process_name +
+  # description). The persistent NIF-side marker filters most re-emits
+  # between boots; the Registry here catches re-drains within a single
+  # BEAM session (a re-sweep in the same lifetime should be a no-op).
+  #
+  # `description` is included in the artifact id (not the fingerprint
+  # key) to distinguish two OS entries with matching (reason_code,
+  # pid, timestamp_ms, process_name) but different descriptions — rare
+  # in practice at ms-granular timestamps, but non-zero.
+  defp artifact_id(%{
+         reason_code: reason_code,
+         pid: pid,
+         timestamp_ms: timestamp_ms,
+         process_name: process_name,
+         description: description
+       }) do
+    canonical = "#{reason_code}|#{pid}|#{timestamp_ms}|#{process_name}|#{description}"
+    hash = :crypto.hash(:sha256, canonical) |> Base.encode16(case: :lower)
+    "sha256:" <> hash
+  end
+
+  # ---------------------------------------------------------------------------
+  # Safe NIF wrappers
+  # ---------------------------------------------------------------------------
+
+  defp safe_platform do
+    try do
+      :mob_nif.platform()
+    rescue
+      _ -> :host
+    catch
+      _, _ -> :host
+    end
+  end
+
+  defp safe_platform_via(nif) do
+    try do
+      nif.platform()
+    rescue
+      _ -> :host
+    catch
+      _, _ -> :host
+    end
+  end
+
+  defp safe_drain do
+    try do
+      :mob_nif.post_mortem_android_drain()
+    rescue
+      _ -> []
+    catch
+      _, _ -> []
+    end
+  end
+
+  defp safe_drain_via(nif) do
+    try do
+      nif.post_mortem_android_drain()
+    rescue
+      _ -> []
+    catch
+      _, _ -> []
+    end
   end
 end

--- a/src/mob_nif.erl
+++ b/src/mob_nif.erl
@@ -53,6 +53,8 @@
     take_opened_document/0,
     %% Post-mortem — iOS MetricKit ingest (drain-on-demand)
     post_mortem_ios_drain/0,
+    %% Post-mortem — Android ApplicationExitInfo ingest (drain-on-demand)
+    post_mortem_android_drain/0,
     %% Storage
     storage_dir/1,
     storage_save_to_photo_library/1,
@@ -215,6 +217,8 @@
     native_stats_enable/1,
     %% Post-mortem — iOS MetricKit ingest (drain-on-demand)
     post_mortem_ios_drain/0,
+    %% Post-mortem — Android ApplicationExitInfo ingest (drain-on-demand)
+    post_mortem_android_drain/0,
     %% Storage
     storage_dir/1,
     storage_save_to_photo_library/1,
@@ -320,6 +324,13 @@ take_opened_document() -> erlang:nif_error(not_loaded).
 %% platform does not export MetricKit (Android, iOS < 14) or the queue is
 %% empty. Called by Mob.PostMortem.IOS.sweep/0.
 post_mortem_ios_drain() -> erlang:nif_error(not_loaded).
+%% post_mortem_android_drain/0 — pull ApplicationExitInfo history since the
+%% persisted last-seen marker. Returns a list of #{reason_code, pid,
+%% timestamp_ms, process_name, description} maps, or [] on iOS, on
+%% Android < 11 (API 30, where getHistoricalProcessExitReasons was added),
+%% or when the marker filters everything out. Called by
+%% Mob.PostMortem.Android.sweep/0.
+post_mortem_android_drain() -> erlang:nif_error(not_loaded).
 battery_level() -> erlang:nif_error(not_loaded).
 device_set_dispatcher(_Pid) -> erlang:nif_error(not_loaded).
 device_battery_state() -> erlang:nif_error(not_loaded).

--- a/test/mob/nif_scheduling_completeness_test.exs
+++ b/test/mob/nif_scheduling_completeness_test.exs
@@ -51,7 +51,7 @@ defmodule Mob.NifSchedulingCompletenessTest do
     device_low_power_mode device_model device_network_state device_os_version
     device_set_dispatcher device_thermal_state exit_app files_pick haptic log
     motion_start motion_stop native_stats_enable open_settings open_url
-    platform post_mortem_ios_drain register_component register_tap
+    platform post_mortem_android_drain post_mortem_ios_drain register_component register_tap
     request_permission share_text storage_dir storage_external_files_dir
     storage_save_to_media_store storage_save_to_photo_library
     take_launch_notification take_opened_document toast_show torch tts_speak

--- a/test/mob/post_mortem/android_test.exs
+++ b/test/mob/post_mortem/android_test.exs
@@ -1,0 +1,216 @@
+defmodule Mob.PostMortem.AndroidTest do
+  # async: false — Bus + Registry are process-global.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mob.Defect.Bus
+  alias Mob.PostMortem.Android
+  alias Mob.PostMortem.Registry
+
+  # Fake NIF used with sweep_with/1. Same shape as
+  # Mob.PostMortem.IOSTest.FakeNIF but returns ApplicationExitInfo
+  # entries.
+  defmodule FakeNIF do
+    def platform, do: Process.get(:test_platform, :host)
+    def post_mortem_android_drain, do: Process.get(:test_entries, [])
+  end
+
+  setup do
+    Bus.start()
+    Bus.reset()
+    Registry.start()
+    Registry.reset()
+    Bus.unsubscribe()
+    {:ok, _ref} = Bus.subscribe()
+
+    Process.put(:test_platform, :android)
+    Process.put(:test_entries, [])
+    :ok
+  end
+
+  # Reason codes from android.app.ApplicationExitInfo.
+  @reason_signaled 2
+  @reason_low_memory 3
+  @reason_crash 4
+  @reason_crash_native 5
+  @reason_anr 6
+  @reason_excessive_resource 9
+  @reason_user_requested 10
+  @reason_user_stopped 11
+  @reason_dependency_died 12
+  @reason_other 13
+
+  defp entry(opts \\ []) do
+    %{
+      reason_code: Keyword.get(opts, :reason_code, @reason_anr),
+      pid: Keyword.get(opts, :pid, 12_345),
+      timestamp_ms: Keyword.get(opts, :timestamp_ms, 1_726_050_000_000),
+      process_name: Keyword.get(opts, :process_name, "com.example.app"),
+      description: Keyword.get(opts, :description, "Input dispatching timed out")
+    }
+  end
+
+  describe "platform gating" do
+    test "returns [] on iOS" do
+      Process.put(:test_platform, :ios)
+      Process.put(:test_entries, [entry()])
+      assert Android.sweep_with(FakeNIF) == []
+    end
+
+    test "returns [] on host" do
+      Process.put(:test_platform, :host)
+      Process.put(:test_entries, [entry()])
+      assert Android.sweep_with(FakeNIF) == []
+    end
+
+    test "returns [] on Android when the NIF is not loaded (default sweep/0)" do
+      # `:mob_nif.platform/0` raises `:undef` in the host test suite;
+      # safe_platform falls through to :host and sweep returns [].
+      assert Android.sweep() == []
+    end
+  end
+
+  describe "on Android with entries" do
+    test "one entry per reason produces one capsule with the mapped kind" do
+      Process.put(:test_entries, [
+        entry(reason_code: @reason_crash_native),
+        entry(reason_code: @reason_crash),
+        entry(reason_code: @reason_signaled),
+        entry(reason_code: @reason_anr),
+        entry(reason_code: @reason_low_memory),
+        entry(reason_code: @reason_excessive_resource),
+        entry(reason_code: @reason_user_requested),
+        entry(reason_code: @reason_user_stopped),
+        entry(reason_code: @reason_dependency_died),
+        entry(reason_code: @reason_other)
+      ])
+
+      capsules = Android.sweep_with(FakeNIF)
+      assert length(capsules) == 10
+
+      # Each reason maps to the right (kind, severity) pair per the
+      # Mob.Defect.emit_appexit_reason/1 mapping table.
+      kinds = Enum.map(capsules, & &1.kind)
+
+      assert kinds == [
+               :native_crash,
+               :native_crash,
+               :native_crash,
+               :anr,
+               :oom,
+               :oom,
+               :user_kill,
+               :user_kill,
+               :user_kill,
+               :user_kill
+             ]
+
+      severities = Enum.map(capsules, & &1.severity)
+
+      assert severities == [
+               :fatal,
+               :fatal,
+               :fatal,
+               :critical,
+               :fatal,
+               :fatal,
+               :info,
+               :info,
+               :info,
+               :info
+             ]
+    end
+
+    test "each capsule reaches the subscribed test process" do
+      Process.put(:test_entries, [entry(reason_code: @reason_anr)])
+      [capsule] = Android.sweep_with(FakeNIF)
+      assert_receive {:mob_defect, ^capsule}, 500
+    end
+
+    test "fingerprints group by kind + process + reason across timestamps and pids" do
+      # Two ANRs of the same class in the same process (different pids
+      # — the process restarted — and different timestamps) group into
+      # one triage row.
+      Process.put(:test_entries, [
+        entry(reason_code: @reason_anr, pid: 1, timestamp_ms: 1_000),
+        entry(reason_code: @reason_anr, pid: 2, timestamp_ms: 2_000)
+      ])
+
+      [a, b] = Android.sweep_with(FakeNIF)
+      assert a.fingerprint == b.fingerprint
+    end
+
+    test "a different reason code or process name changes the fingerprint" do
+      Process.put(:test_entries, [
+        entry(reason_code: @reason_anr, process_name: "com.example.app"),
+        entry(reason_code: @reason_crash, process_name: "com.example.app"),
+        entry(reason_code: @reason_anr, process_name: "com.example.other")
+      ])
+
+      [a, b, c] = Android.sweep_with(FakeNIF)
+      refute a.fingerprint == b.fingerprint
+      refute a.fingerprint == c.fingerprint
+      refute b.fingerprint == c.fingerprint
+    end
+
+    test "evidence rides on the capsule" do
+      Process.put(:test_entries, [
+        entry(
+          reason_code: @reason_anr,
+          pid: 99,
+          timestamp_ms: 12_345,
+          process_name: "com.example.app",
+          description: "Input dispatching timed out"
+        )
+      ])
+
+      [capsule] = Android.sweep_with(FakeNIF)
+      assert capsule.evidence.reason_code == @reason_anr
+      assert capsule.evidence.process_name == "com.example.app"
+      assert capsule.evidence.description == "Input dispatching timed out"
+      assert capsule.evidence.timestamp_ms == 12_345
+      assert capsule.evidence.source == :application_exit_info
+    end
+
+    test "idempotent — same entry drained twice emits once" do
+      # In production the NIF's persistent marker filters this out
+      # across sweeps; but a same-session re-drain (a caller polling
+      # in a loop) reaches the Registry, which dedups by artifact id.
+      entries = [entry(reason_code: @reason_anr)]
+      Process.put(:test_entries, entries)
+
+      first = Android.sweep_with(FakeNIF)
+      second = Android.sweep_with(FakeNIF)
+
+      assert length(first) == 1
+      assert second == []
+    end
+  end
+
+  describe "malformed input" do
+    test "a non-map entry is silently skipped" do
+      Process.put(:test_entries, [:garbage, entry(), nil])
+      capsules = Android.sweep_with(FakeNIF)
+      assert length(capsules) == 1
+    end
+
+    test "a partial-shape map is dropped without crashing the sweep" do
+      Process.put(:test_entries, [
+        %{reason_code: @reason_anr},
+        entry(reason_code: @reason_anr, pid: 1, timestamp_ms: 1),
+        %{pid: 99, timestamp_ms: 2},
+        entry(reason_code: @reason_crash, pid: 2, timestamp_ms: 2)
+      ])
+
+      log = capture_log(fn -> Process.put(:__caps__, Android.sweep_with(FakeNIF)) end)
+      capsules = Process.get(:__caps__)
+
+      assert length(capsules) == 2
+
+      assert Enum.map(capsules, & &1.kind) == [:anr, :native_crash]
+      assert log =~ "[warning]"
+      assert log =~ "malformed ApplicationExitInfo"
+    end
+  end
+end


### PR DESCRIPTION
MOB-180 replaces the phase 1 `Mob.PostMortem.Android` scaffold with a real `ApplicationExitInfo` pipe. Pure Zig JNI — no `MobBridge.kt.eex` template dependency, so every existing mob app gets the feature the moment they bump mob (no template refresh dance).

## What ships

- **`android/jni/mob_nif.zig`** — `nif_post_mortem_android_drain` uses `g_activity` (captured at BEAM boot in `mob_beam.zig`) to reach an Application context, calls `getSystemService("activity")` → `ActivityManager`, then `getHistoricalProcessExitReasons(null, 0, 0)`, iterates the returned `java.util.List`, extracts pid/timestamp/reason/description/processName from each `ApplicationExitInfo`. Persistent marker at `<filesDir>/mob_post_mortem_appexit_marker.txt` (POSIX open+write+close) so each exit emits exactly once across boots.
- **`ios/mob_nif.m`** — stub `nif_post_mortem_android_drain` returning `[]` so the shared `mob_nif.erl` NIF list resolves on both platforms.
- **`src/mob_nif.erl`** — new export + `-nifs` + stub.
- **`lib/mob/post_mortem/android.ex`** — replaces the scaffold. Platform gate, `valid_shape?` gate, Registry dedup by sha256 (including `description` in the artifact id per the reviewer's nitpick).
- **`lib/mob/defect.ex`** — `emit_appexit_reason/1` with reason-code → kind → severity mapping.
- **`decisions/2026-09-11-appexit-native-jni-not-bridge.md`** — why pure JNI, not MobBridge.

## Reason code → kind mapping

| Reason(s) | `kind` | `severity` |
|---|---|---|
| `REASON_CRASH_NATIVE` (5), `REASON_CRASH` (4), `REASON_SIGNALED` (2) | `:native_crash` | `:fatal` |
| `REASON_ANR` (6) | `:anr` | `:critical` |
| `REASON_LOW_MEMORY` (3), `REASON_EXCESSIVE_RESOURCE_USAGE` (9) | `:oom` | `:fatal` |
| everything else | `:user_kill` | `:info` |

`:info` on unknown/other is deliberate — a novel reason a future Android version invents is not a defect to page a triager on; downgrading to routine is safer than upgrading to critical.

Fingerprint groups by `(kind + process_name + reason_code)`.

## API-30+ gated

`getHistoricalProcessExitReasons` is Android 11+. The NIF caches `Build.VERSION.SDK_INT` lazily on first drain, returns `[]` on older devices. Elixir side additionally gates on `platform() == :android`.

## Adversarial pre-commit review — SOUND WITH FIXES

The reviewer caught the blocker I flagged in my own concerns and didn't verify: **three call sites passed too many args to `jni.callObjectMethod`, which mob_zig.zig types as arity-3**. `zig ast-check` doesn't do semantic checks — only a proper `zig build-obj -target aarch64-linux-android` catches it. **The Android side never compiled before this review.**

Fixed by adding typed `callObjWithObj` / `callObjWithInt` / `callObjWithObjIntInt` helpers that cast the raw variadic `env.*.CallObjectMethod.?` slot per arity, mirroring the existing `callIntNoArgs` / `callLongNoArgs` pattern. Cross-compile clean after the fix.

Should-fixes folded in:
- Corrected the misleading `g_android_sdk_int` cache comment (it claimed nif_load population that doesn't exist; the actual populator is `buildSdkInt` on first drain).
- Added a caller-must-delete note on `applicationContext`'s local-ref return.
- Made marker-write failures log an `:error` line the first time each failure kind is hit — silent OOM/disk-full failures would strand cross-boot dedup with no diagnostic.

Nitpick folded in:
- Added `description` to the artifact id so two OS entries with matching `(reason_code, pid, timestamp_ms, process_name)` but different descriptions don't collapse to one.

## Gates

- `mix test`: 1785 pass (11 new in `android_test.exs`), 0 fail
- `mix credo --strict`: 0 issues (2371 mods/funs, 208 source files)
- `mix format --check-formatted`: clean
- `mix compile --warnings-as-errors --force`: clean
- `xcrun clang-format --dry-run -Werror ios/mob_nif.m`: clean
- `zig build-obj android/jni/mob_nif.zig -target aarch64-linux-android -lc`: clean cross-compile

## Not device-verified in this PR

Needs a physical Android or emulator with a seeded ANR / OOM / crash in its `ApplicationExitInfo` history. MOB-158 stays In Progress until both native halves (this + MOB-179 iOS MetricKit) are device-verified.

## Device verification recipe

Force an ANR in an emulator by running an infinite loop on the UI thread, kill via `adb shell am force-stop <package>`, wait for the OS to record it (usually seconds on emulator), reboot the app, sweep via IEx, assert the emitted capsule matches. Full recipe posted to the MOB-180 Linear comment after this merges.

Closes phase 3 of [MOB-158](https://linear.app/mobframework/issue/MOB-158). MOB-158 stays In Progress pending device verification of both native halves.
