### PR TITLE
Bump to 0.8.2 — post-mortem substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-09-11
+
 ### Added
 - **Post-mortem collection — `Mob.PostMortem` +
   `Mob.PostMortem.BeamCrashDump`** (MOB-158, phase 1). The framework

--- a/lib/mob/post_mortem.ex
+++ b/lib/mob/post_mortem.ex
@@ -5,19 +5,26 @@ defmodule Mob.PostMortem do
 
   Three sources, each in its own submodule:
 
-  * `Mob.PostMortem.BeamCrashDump` — `erl_crash.dump` files (BEAM). Fully
-    implemented; the substrate this module was written around.
+  * `Mob.PostMortem.BeamCrashDump` — `erl_crash.dump` files (BEAM).
+    Scans configured paths, reads a bounded 8 KB header, dedups by
+    sha256, emits `:beam_crash` capsules.
   * `Mob.PostMortem.IOS` — MetricKit payloads (crash / hang / launch /
-    CPU / memory / disk). Scaffolded; returns an empty list until the
-    native pipe lands in a follow-up ticket. See its own moduledoc.
-  * `Mob.PostMortem.Android` — `ApplicationExitInfo` history (ANR, crash,
-    OOM, user kill). Same shape as iOS: scaffolded, follow-up.
+    CPU / memory / disk). Attaches an `MXMetricManagerSubscriber`
+    lazily on first sweep, buffers OS-delivered payloads in a bounded
+    native queue, emits `:native_crash` / `:anr` / `:perf_regression`
+    capsules on drain.
+  * `Mob.PostMortem.Android` — `ApplicationExitInfo` history (ANR,
+    crash, OOM, user kill). Pulls the OS-held exit-reason list on
+    demand (API 30+), filters against a persistent marker so each
+    exit emits exactly once across boots, emits `:native_crash` /
+    `:anr` / `:oom` / `:user_kill` capsules.
 
-  Nothing here runs automatically. An app opts in with
-  `Mob.PostMortem.sweep()` from its `on_start`, or a developer / CI runs
-  the equivalent `mix mob.post_mortems.sweep` task from the host. That
-  matches the discipline the whole `Mob.Defect` subsystem enforces:
-  mob owns the format and the bus but never becomes the collector.
+  Nothing here runs automatically. An app opts in by calling
+  `Mob.PostMortem.sweep/0` from its `on_start`, and a developer or CI
+  calls the same function from an IEx session (there is no dedicated
+  Mix task — the whole surface is one function). That matches the
+  discipline the `Mob.Defect` subsystem enforces: mob owns the format
+  and the bus but never becomes the collector.
 
   ## Idempotence
 
@@ -68,9 +75,11 @@ defmodule Mob.PostMortem do
     |> Kernel.++(sweep_native())
   end
 
-  # iOS + Android scaffolds intentionally return `[]` today. They exist
-  # as symbols so this coordinator does not have to grow a per-platform
-  # branch every time a native source lands.
+  # Both platform modules gate on `:mob_nif.platform/0` internally, so
+  # each call is a no-op on the wrong platform (and on host, where the
+  # NIF is not loaded). The coordinator therefore does not need a
+  # per-platform branch — it just asks both. On iOS the Android drain
+  # returns [] and vice versa.
   defp sweep_native do
     Mob.PostMortem.IOS.sweep() ++ Mob.PostMortem.Android.sweep()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mob.MixProject do
   def project do
     [
       app: :mob,
-      version: "0.8.1",
+      version: "0.8.2",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
Cut mob 0.8.2 to Hex — patch bump for the whole `Mob.PostMortem` subsystem that landed as three PRs since 0.8.1:

- **#154** MOB-158 phase 1: `Mob.PostMortem` + `Mob.PostMortem.BeamCrashDump` scan `erl_crash.dump` files and emit `:beam_crash` capsules on `Mob.Defect.Bus`. Bounded 8 KB header read, sha256-keyed dedup, dumps stay on disk.
- **#155** MOB-179: `Mob.PostMortem.IOS` real MetricKit ingest via `MobMetricSubscriber` in `ios/mob_nif.m`. Lazy attach on first sweep, bounded 32-entry queue under `os_unfair_lock`, kind → severity mapping.
- **#156** MOB-180: `Mob.PostMortem.Android` real ApplicationExitInfo ingest via pure Zig JNI in `android/jni/mob_nif.zig`. API 30+ gated, POSIX file marker for cross-boot dedup.

Additive-only. `Mob.Defect.emit_invariant_violation/1` and `emit_divergence/2` are byte-identical to 0.8.1, so mob_dev master's pending MOB-159 phase 2 differential-emit caller stays API-safe.

## Release-review gate

Subagent reviewed `git diff 0.8.1..HEAD` before the bump — verdict RELEASE OK WITH FIXES. Verified:
- version-sanity — 0.8.2 not on Hex, `mix hex.info mob` shows 0.8.1 as latest
- shipping window matches CHANGELOG — every module the diff adds is enumerated in the `[0.8.2]` section
- cross-repo — mob_dev's pending phase-2 differential caller depends on `Mob.Defect.emit_divergence/2`, which is untouched in this release
- seam integrity — three PRs compose cleanly through `Mob.PostMortem.sweep/0`; both platform modules share identical shape (platform gate → safe_drain → Registry.mark_seen → Defect.emit_*)
- nine new public functions all have `@doc`
- `mix docs` produces zero new warnings

One fix applied: the `Mob.PostMortem` moduledoc still described iOS and Android as scaffolds (after PRs #155/#156 replaced them with real ingest), and referenced a non-existent `mix mob.post_mortems.sweep` task. Doc rewritten to match shipped state.

## Local preflight

- `mix format --check-formatted` clean
- `mix credo --strict` 0 issues (2371 mods/funs)
- `mix compile --warnings-as-errors --force` clean
- `mix test` 1785 pass, 0 fail
- Pre-push hook full-suite preflight (fires when mix.exs changes) green

## Trigger

Per RELEASE.md, the release workflow fires on a push to master modifying `mix.exs`. Merging this PR (squash) puts the bump commit on master and the workflow does tag → GitHub Release → `mix hex.publish --yes`, each step independently idempotent.
