### PR TITLE
MOB-181: honor fixed_width / fixed_height on iOS Column and Row

### DIFF
--- a/decisions/2026-09-11-column-row-fixed-dims-precedence.md
+++ b/decisions/2026-09-11-column-row-fixed-dims-precedence.md
@@ -1,0 +1,69 @@
+# iOS: fixed_width / fixed_height beat fill_* on Column and Row
+
+- Date: 2026-09-11
+- Status: accepted
+- Linear: MOB-181
+- GitHub: mob#110
+
+## Context
+
+`MobNodeView` on iOS previously ignored `fixed_width` and `fixed_height` on
+Column and Row entirely. Column always applied `.frame(maxWidth: .infinity,
+maxHeight: fillHeight ? .infinity : nil)` and Row only applied a
+`fill_width`-driven `.frame(maxWidth: .infinity)`. Android was already
+correct via `nodeModifier`.
+
+The Box case had the same class of bug and was fixed in #104 (iOS honor
+fixed-height boxes). Column and Row are the remaining two containers with
+the same shape. The issue thread (mob#110) called out a precedence question
+that #104 dodged because Box has no `fill_*` props: when a caller sets
+`fixed_width: 100, fill_width: true` on a row, which wins? iOS and Android
+have to decide the same way or a screen will render differently.
+
+## Decision
+
+**Fixed dims beat fill on iOS.** When both `fixed_width` and `fill_width` are
+set on a Row, `fixed_width` wins. Same rule for `fixed_height` vs
+`fill_height` on Column, and for `fixed_*` vs `layout_weight` on the flexing
+axis (see `MobLayoutWeight` below). Rationale:
+
+1. It's internally consistent with the Box #104 fix: fixed always wins on
+   iOS, no exceptions.
+2. SwiftUI applies chained `.frame` modifiers outside-in — an outer
+   `.frame(maxWidth: .infinity)` after an inner `.frame(width: 100)`
+   effectively hides the inner width. So the only way to make `fixed_width`
+   actually apply is to suppress the outer max frame when the axis is
+   pinned. That naturally makes fixed win.
+3. A caller who sets both is almost always leaning on `fixed` and left
+   `fill` in place; silently ignoring `fixed` was the bug being reported.
+
+**Where the rule is applied.** Three places on iOS emit an outer
+`.frame(maxWidth/maxHeight: .infinity)` around a container: the Column case
+(fill_height), the Row case (fill_width), and `MobLayoutWeight.body` (any
+node with a positive `layout_weight` on the parent's flex axis). All three
+now check the corresponding fixed dim before applying the max frame, so a
+`fixed_width` on a weighted Row child no longer expands to fill the parent
+either. Without the `MobLayoutWeight` half, "fixed always wins" would be
+false in that corner and the fix would be silently partial for flex layouts
+that use `layout_weight` — the dominant Compose analogue for rows/columns.
+
+Android's `nodeModifier` currently lets fill coerce fixed (fill wins). This
+is a real cross-platform divergence in the contradictory-props corner. We
+are NOT harmonising Android in this change — the issue is iOS ignoring
+fixed at all, which is the observable problem callers hit. A follow-up
+issue can revisit Android if we ever need parity in the both-set corner;
+today no production screen sets both.
+
+## Consequences
+
+- iOS Column, Row and `MobLayoutWeight` now respect `fixed_width` and
+  `fixed_height`; a `fixed_*` on the flexing axis wins over `fill_*` and
+  over `layout_weight`.
+- `fill_width` / `fill_height` remain the default behavior when no fixed dim
+  is set on the corresponding axis.
+- Contradictory-props corner: iOS returns the fixed dim, Android returns
+  the filled parent. Callers should not set both; if a future
+  cross-platform screen needs the both-set case, we harmonise then, not now.
+- Source-contract regression: `test/mob/native_column_row_layout_test.exs`
+  string-matches the Column, Row and `MobLayoutWeight` blocks so reverting
+  any of them fails the test.

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -306,12 +306,35 @@ struct MobNodeView: View {
                         MobNodeView(node: item.node, layoutWeightAxis: .vertical)
                     }
                 }
+                // MOB-181: honor fixed_width / fixed_height on columns.
+                // The inner .frame pins whichever fixed dim is set (nil for
+                // unset dims leaves the child's own size intact). The outer
+                // .frame keeps the default fill-width behavior and adds
+                // fill_height, but suppresses the outer growth on whichever
+                // axis is already pinned — otherwise a fixed dim would fight
+                // maxWidth/maxHeight: .infinity and read as ignored. Fixed
+                // beats fill on iOS for internal consistency (SwiftUI would
+                // apply the outer maxWidth after the inner width, effectively
+                // overriding it). See decisions/2026-09-11-column-row-fixed-dims-precedence.md.
+                // `MobLayoutWeight` below is also fixed-dim-aware so weight
+                // on the pinned axis is likewise suppressed.
+                //
                 // fill_height: true lets a column flex to fill its parent so children
-                // with Spacer() or fill_height of their own can pin to the bottom.
+                // with Spacer() or fill_height of their own can pin to the bottom
+                // (unless fixed_height is set, which wins for iOS consistency).
                 // Without maxHeight the VStack hugs its content vertically and a
                 // trailing footer sits directly below the last child instead of the
                 // parent's bottom edge.
-                .frame(maxWidth: .infinity, maxHeight: node.fillHeight ? .infinity : nil, alignment: .topLeading)
+                .frame(
+                    width: node.fixedWidth > 0 ? CGFloat(node.fixedWidth) : nil,
+                    height: node.fixedHeight > 0 ? CGFloat(node.fixedHeight) : nil,
+                    alignment: .topLeading
+                )
+                .frame(
+                    maxWidth: node.fixedWidth > 0 ? nil : .infinity,
+                    maxHeight: (node.fillHeight && node.fixedHeight <= 0) ? .infinity : nil,
+                    alignment: .topLeading
+                )
                 .padding(node.paddingEdgeInsets)
                 .background(node.backgroundColor.map { Color($0) } ?? Color.clear)
                 .ifLet(node.onTap) { view, tap in
@@ -333,6 +356,13 @@ struct MobNodeView: View {
                         MobNodeView(node: item.node, layoutWeightAxis: .horizontal)
                     }
                 }
+                // MOB-181: honor fixed_width / fixed_height on rows. Same
+                // shape as the column case above: inner .frame pins the
+                // fixed dims (nil leaves the child alone) and the fill_width
+                // outer frame is suppressed on the axis a fixed dim is
+                // already pinning. Fixed beats fill on iOS (see the column
+                // note above and the decision record).
+                //
                 // Without maxWidth: .infinity an HStack hugs its content.
                 // Flex Spacers inside then have nothing to expand into and
                 // centering tricks (spacer / content / spacer) collapse.
@@ -346,7 +376,12 @@ struct MobNodeView: View {
                 // rows each centred independently and read as ragged. The
                 // column case above already passes .topLeading for the same
                 // reason.
-                .ifLet(node.fillWidth ? () : nil) { view, _ in
+                .frame(
+                    width: node.fixedWidth > 0 ? CGFloat(node.fixedWidth) : nil,
+                    height: node.fixedHeight > 0 ? CGFloat(node.fixedHeight) : nil,
+                    alignment: .leading
+                )
+                .ifLet((node.fillWidth && node.fixedWidth <= 0) ? () : nil) { view, _ in
                     view.frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .padding(node.paddingEdgeInsets)
@@ -600,9 +635,22 @@ private struct MobLayoutWeight: ViewModifier {
         if node.layoutWeight > 0, let axis {
             switch axis {
             case .horizontal:
-                decorate(content.frame(maxWidth: .infinity, alignment: .leading))
+                // MOB-181: a fixed_width on the flexing axis wins over
+                // layout_weight for iOS internal consistency — otherwise
+                // this outer maxWidth: .infinity would hide the inner
+                // .frame(width:) applied by the container case, and the
+                // caller would see fixed_width silently ignored.
+                if node.fixedWidth > 0 {
+                    decorate(content)
+                } else {
+                    decorate(content.frame(maxWidth: .infinity, alignment: .leading))
+                }
             case .vertical:
-                decorate(content.frame(maxHeight: .infinity, alignment: .top))
+                if node.fixedHeight > 0 {
+                    decorate(content)
+                } else {
+                    decorate(content.frame(maxHeight: .infinity, alignment: .top))
+                }
             }
         } else {
             content

--- a/test/mob/native_column_row_layout_test.exs
+++ b/test/mob/native_column_row_layout_test.exs
@@ -1,0 +1,88 @@
+# These source-contract tests guard native SwiftUI behavior that Elixir cannot execute.
+# credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+defmodule Mob.NativeColumnRowLayoutTest do
+  use ExUnit.Case, async: true
+
+  @root Path.expand("../..", __DIR__)
+
+  # MOB-181. Column previously used `.frame(maxWidth: .infinity, maxHeight: ...)`
+  # unconditionally, so an author-supplied `fixed_width` / `fixed_height` on a
+  # column was silently overridden by the fill frame. The fix pins the fixed
+  # dims via an inner `.frame(width:height:)` and suppresses the outer max on
+  # whichever axis is already pinned. Anchored to the Column case's
+  # `MobEitherStack(...)` opener so a refactor that moves this block out of
+  # the Column case fails the test rather than passing on the same tokens
+  # somewhere else in the file.
+  test "iOS column applies fixed_width and fixed_height" do
+    source = File.read!(Path.join(@root, "ios/MobRootView.swift"))
+
+    assert source =~
+             "                MobEitherStack(lazy: lazyContainer, alignment: .leading) {"
+
+    assert source =~
+             "                .frame(\n" <>
+               "                    width: node.fixedWidth > 0 ? CGFloat(node.fixedWidth) : nil,\n" <>
+               "                    height: node.fixedHeight > 0 ? CGFloat(node.fixedHeight) : nil,\n" <>
+               "                    alignment: .topLeading\n" <>
+               "                )\n" <>
+               "                .frame(\n" <>
+               "                    maxWidth: node.fixedWidth > 0 ? nil : .infinity,\n" <>
+               "                    maxHeight: (node.fillHeight && node.fixedHeight <= 0) ? .infinity : nil,\n" <>
+               "                    alignment: .topLeading\n" <>
+               "                )"
+  end
+
+  # MOB-181. Row previously only honoured `fill_width` and ignored `fixed_width`
+  # / `fixed_height` entirely. The fix adds the same inner `.frame(width:height:)`
+  # gate as the column case and suppresses the fill_width outer frame when the
+  # width axis is already pinned. Anchored to the Row-case HStack opener above
+  # it.
+  test "iOS row applies fixed_width and fixed_height" do
+    source = File.read!(Path.join(@root, "ios/MobRootView.swift"))
+
+    assert source =~
+             "                HStack(alignment: alignment, spacing: 0) {"
+
+    assert source =~
+             "                .frame(\n" <>
+               "                    width: node.fixedWidth > 0 ? CGFloat(node.fixedWidth) : nil,\n" <>
+               "                    height: node.fixedHeight > 0 ? CGFloat(node.fixedHeight) : nil,\n" <>
+               "                    alignment: .leading\n" <>
+               "                )\n" <>
+               "                .ifLet((node.fillWidth && node.fixedWidth <= 0) ? () : nil) { view, _ in\n" <>
+               "                    view.frame(maxWidth: .infinity, alignment: .leading)\n" <>
+               "                }"
+  end
+
+  # MOB-181. `MobLayoutWeight` wraps every node with an axis-appropriate
+  # `.frame(maxWidth: .infinity, …)` when the node has a positive
+  # `layout_weight`. That outer frame is applied AFTER the container case's
+  # inner fixed-dim frame, which hides `fixed_width` (or `fixed_height`) on
+  # the flexing axis. The fix suppresses the weight-driven max frame when the
+  # pinned axis is already fixed, so `fixed` wins over `layout_weight` for
+  # iOS internal consistency.
+  test "iOS layout weight suppresses maxFrame on the pinned axis" do
+    source = File.read!(Path.join(@root, "ios/MobRootView.swift"))
+
+    assert source =~ "private struct MobLayoutWeight: ViewModifier {"
+
+    assert source =~
+             "            case .horizontal:\n" <>
+               "                // MOB-181: a fixed_width on the flexing axis wins over\n" <>
+               "                // layout_weight for iOS internal consistency — otherwise\n" <>
+               "                // this outer maxWidth: .infinity would hide the inner\n" <>
+               "                // .frame(width:) applied by the container case, and the\n" <>
+               "                // caller would see fixed_width silently ignored.\n" <>
+               "                if node.fixedWidth > 0 {\n" <>
+               "                    decorate(content)\n" <>
+               "                } else {\n" <>
+               "                    decorate(content.frame(maxWidth: .infinity, alignment: .leading))\n" <>
+               "                }\n" <>
+               "            case .vertical:\n" <>
+               "                if node.fixedHeight > 0 {\n" <>
+               "                    decorate(content)\n" <>
+               "                } else {\n" <>
+               "                    decorate(content.frame(maxHeight: .infinity, alignment: .top))\n" <>
+               "                }"
+  end
+end


### PR DESCRIPTION
## Summary

- iOS Column and Row previously ignored `fixed_width` / `fixed_height` entirely (Android was already correct via `nodeModifier`); this applies the same fix pattern that mob #104 used for Box.
- Suppress the outer `.frame(maxWidth/maxHeight: .infinity)` on whichever axis a fixed dim pins so SwiftUI's chained-frame semantics don't hide the inner `.frame(width:height:)`.
- Fix the third place iOS emits a max-frame around a container: `MobLayoutWeight`. Without this, `fixed_width` on a `layout_weight`-flexed row would still be silently overridden, making the fix partial for the dominant Compose analogue.
- Documented precedence (fixed dims beat fill on iOS) in `decisions/2026-09-11-column-row-fixed-dims-precedence.md`.

## Test plan

- [x] `test/mob/native_column_row_layout_test.exs` — source-contract regression asserting each of the three frame blocks (Column, Row, `MobLayoutWeight`). Anchored to the surrounding case opener so a refactor that moves the block can't pass on the same tokens elsewhere in the file.
- [x] Verified the tests fail on partial revert: reverting only the swift changes fails all three; reverting only `MobLayoutWeight` fails test 3.
- [x] `mix test` (1788 passed, 38 excluded) — full suite green on the worktree.
- [x] `mix credo --strict` — no new issues.
- [x] Adversarial pre-commit review by a fresh subagent applied should-fix findings.
- [ ] **Device verification pending** — I can't drive a physical device from here; iOS-sim device-verify (`Mob.Test.frame/2` on Column/Row/weighted-row screens with fixed dims set) is needed before merge, same as #104's post-merge validation. Follow-on note in Linear MOB-181.

Linear: MOB-181
GH: closes mob#110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezeu2FEZfRajeoL4ywEUDJ