### PR TITLE
MOB-47, MOB-48 — guides call the real Clipboard and Share APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Docs
+- **`guides/device_capabilities.md` — Clipboard and Share sections rewritten
+  to the real API** (MOB-47, MOB-48). The guide called
+  `Mob.Clipboard.write/2` and `Mob.Clipboard.read/1` (undefined; the real
+  API is `put/2` and `get/1`, and `get/1` is synchronous — no
+  `{:clipboard, :read, text}` message ever arrives). The Share section
+  called `Mob.Share.sheet(socket, text:, url:, title:)` with options that
+  don't exist; the real API is `Mob.Share.text(socket, binary)`.
+
 ## [0.8.2] - 2026-09-11
 
 ### Added

--- a/guides/device_capabilities.md
+++ b/guides/device_capabilities.md
@@ -64,36 +64,36 @@ iOS uses `UIImpactFeedbackGenerator` / `UINotificationFeedbackGenerator`. Androi
 
 ## Clipboard
 
+`Mob.Clipboard.get/1` dispatches to the main thread synchronously (same model as `safe_area/0`); no `handle_info` needed. `put/2` is fire-and-forget.
+
 ```elixir
 # Write to clipboard
 def handle_info({:tap, :copy}, socket) do
-  socket = Mob.Clipboard.write(socket, socket.assigns.code)
+  socket = Mob.Clipboard.put(socket, socket.assigns.code)
   {:noreply, socket}
 end
 
-# Read from clipboard — result arrives in handle_info
+# Read from clipboard — result returned synchronously
 def handle_info({:tap, :paste}, socket) do
-  socket = Mob.Clipboard.read(socket)
-  {:noreply, socket}
-end
-
-def handle_info({:clipboard, :read, text}, socket) do
-  {:noreply, Mob.Socket.assign(socket, :pasted_text, text)}
+  case Mob.Clipboard.get(socket) do
+    {:clipboard, :ok, text} -> {:noreply, Mob.Socket.assign(socket, :pasted_text, text)}
+    {:clipboard, :empty}    -> {:noreply, socket}
+  end
 end
 ```
 
 ## Share sheet
 
-Opens the platform's native share sheet (iOS: `UIActivityViewController`, Android: `ACTION_SEND`):
+Opens the platform's native share sheet (iOS: `UIActivityViewController`, Android: `ACTION_SEND` via `Intent.createChooser`). Fire-and-forget — no response arrives in the BEAM.
 
 ```elixir
 def handle_info({:tap, :share}, socket) do
-  socket = Mob.Share.sheet(socket, text: "Check out this app!", url: "https://example.com")
+  socket = Mob.Share.text(socket, "Check out this app! https://example.com")
   {:noreply, socket}
 end
 ```
 
-Options: `:text`, `:url`, `:title`
+Plain text only. URLs go inside the text; iOS auto-detects and offers URL-appropriate share targets. If you need multi-part sharing (title/url/image separately), file a ticket describing the use case.
 
 ## Camera
 


### PR DESCRIPTION
Docs-only fix for MOB-47 + MOB-48 (public-docs credibility pass).

`guides/device_capabilities.md` used undefined functions and wrong shapes that anyone copying the snippets hit as `UndefinedFunctionError` at the first tap.

## Clipboard (MOB-47)

| Old (broken) | New (real API) |
|---|---|
| `Mob.Clipboard.write(socket, text)` | `Mob.Clipboard.put(socket, text)` |
| `Mob.Clipboard.read(socket)` + `handle_info({:clipboard, :read, text}, socket)` | `Mob.Clipboard.get(socket)` returning `{:clipboard, :ok, text}` or `{:clipboard, :empty}` **synchronously** |

Source: `lib/mob/clipboard.ex:29,40` — `get/1` explicitly dispatches to main thread synchronously "same model as `safe_area/0`", so the async `handle_info` message the guide told people to write never arrives.

## Share sheet (MOB-48)

| Old (broken) | New (real API) |
|---|---|
| `Mob.Share.sheet(socket, text: "…", url: "…", title: "…")` | `Mob.Share.text(socket, binary)` |

Source: `lib/mob/share.ex:21` — single-string fire-and-forget. Added a note that iOS auto-detects URLs inside the text (offers URL-appropriate targets), and that a multi-part share (title/url/image separately) needs a ticket describing the use case.

## Gates

- `mix format --check-formatted`: clean
- `mix credo --strict`: 0 issues (2371 mods/funs)
- `mix compile --warnings-as-errors --force`: one pre-existing `Mob.WebView.post_message/2 is unused` hint; not from this change
- Docs-only; no test suite exercises the guide file

CHANGELOG entry lives with the change under `[Unreleased]`.

Closes MOB-47, MOB-48.