### PR TITLE
docs(components): document width / height on Column and Row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 ## [Unreleased]
 
 ### Docs
+- **`guides/components.md` — document `width` / `height` on `:column`
+  and `:row`** (follow-up to MOB-181 / PR #158). The attributes exist
+  and the native side maps them to `node.fixedWidth` /
+  `node.fixedHeight`, but they weren't listed in the Column and Row prop
+  tables (only `<Box>` and `<Image>` had them). Follow-up caller
+  guidance for the iOS precedence rule (fixed beats fill on the pinned
+  axis, including a `weight`-flexed child) added inline.
 - **`guides/device_capabilities.md` — Clipboard and Share sections rewritten
   to the real API** (MOB-47, MOB-48). The guide called
   `Mob.Clipboard.write/2` and `Mob.Clipboard.read/1` (undefined; the real

--- a/guides/components.md
+++ b/guides/components.md
@@ -169,9 +169,17 @@ Stacks children vertically.
 | `padding_top`, `padding_bottom`, `padding_left`, `padding_right` | number / token | Per-side padding |
 | `gap` | number / token | Space between children |
 | `background` | color | Background color |
+| `width` | number | Fixed width in dp/pt. Overrides `fill_width`. |
+| `height` | number | Fixed height in dp/pt. Overrides `fill_height`. |
 | `fill_width` | boolean | Stretch to fill available width (default `true`) |
 | `fill_height` | boolean | Stretch to fill available height |
 | `align` | `:start` / `:center` / `:end` | Cross-axis alignment of children |
+
+`width` and `height` win over `fill_*` on iOS for internal
+consistency (a chained outer `maxWidth: .infinity` would otherwise hide
+the inner fixed frame — see mob PR #158 / MOB-181). Setting `width`
+also pins a `weight`-flexed child on the parent's flex axis, so
+`<Column width={90} weight={1}>` inside a Row stays 90 wide.
 
 ### `:row`
 
@@ -182,6 +190,8 @@ Lays out children horizontally.
 | `padding` | number / token | Uniform padding |
 | `gap` | number / token | Space between children |
 | `background` | color | Background color |
+| `width` | number | Fixed width in dp/pt. Overrides `fill_width`. |
+| `height` | number | Fixed height in dp/pt. |
 | `fill_width` | boolean | Stretch to fill available width |
 | `align` | `:start` / `:center` / `:end` | Cross-axis alignment of children |
 


### PR DESCRIPTION
## Summary

Follow-up to MOB-181 / mob#158. The `width` / `height` attributes on `:column` and `:row` are supported on both platforms (native side maps them to `node.fixedWidth` / `node.fixedHeight`), but the prop tables in `guides/components.md` never listed them — only `<Box>` and `<Image>` had them documented. A first-time reader looking for how to size a column pins would guess `fixed_width`, hit a silent no-op, and give up. I did.

- Adds `width` and `height` rows to the Column and Row prop tables.
- Adds a short note that `width` / `height` beat `fill_*` on iOS (the precedence [decision from PR #158](https://github.com/GenericJam/mob/blob/master/decisions/2026-09-11-column-row-fixed-dims-precedence.md)), including the `weight`-flexed corner where a `<Column width={90} weight={1}>` inside a Row stays 90 wide.
- CHANGELOG entry under `[Unreleased]` — docs bullet, no code change.

## Test plan

- [x] Renders in `mix docs` (docs-only change, no code touched).
- [x] Reviewed prop-table format matches the neighbouring Box / Image tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezeu2FEZfRajeoL4ywEUDJ