### PR TITLE
MOB-188: ~MOB accepts app-declared tags via config :mob, :extra_tags; Canvas on the whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,23 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
 
 ## [Unreleased]
 
+### Added
+- **`config :mob, :extra_tags` — app-declared `~MOB` tags** (MOB-188). A
+  composite a UI kit registers at boot (`Mob.Composite.register/2`) was
+  invisible to the sigil's compile-time whitelist, so every `<MishkaChip />`
+  warned "not in the Mob tag whitelist" and the only silence was rewriting
+  `deps/mob/priv/tags` (which `mix deps.get` undid). The sigil now also accepts
+  tags listed under `config :mob, :extra_tags` (PascalCase strings or
+  snake_case atoms), read from the calling app's config at its compile time.
+  Companion to the mob_new change (same issue) that lists the vendored
+  Mishka Chelekom catalog's tags in a generated app's `config.exs`.
+
 ### Fixed
+- **`Canvas` added to the tag whitelist** on both platforms. `Mob.UI.canvas/1`
+  and both renderers have handled `:canvas` for some time, but the whitelist
+  never listed it, so `~MOB(<Canvas />)` warned and
+  `Mob.ScreenCase.assert_renderable/2` needed `extra: [:canvas]` on every
+  screen that draws.
 
 - **iOS: `Mob.Audio.start_recording/2` now honors `:format` and
   `:quality`** (MOB-52). The NIF received the encoded opts as a JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   `deps/mob/priv/tags` (which `mix deps.get` undid). The sigil now also accepts
   tags listed under `config :mob, :extra_tags` (PascalCase strings or
   snake_case atoms), read from the calling app's config at its compile time.
-  Companion to the mob_new change (same issue) that lists the vendored
-  Mishka Chelekom catalog's tags in a generated app's `config.exs`.
+  Companion to mob_new #68, which lists the vendored Mishka Chelekom
+  catalog's tags in a generated app's `config.exs`.
 
 ### Fixed
 - **`Canvas` added to the tag whitelist** on both platforms. `Mob.UI.canvas/1`

--- a/guides/components.md
+++ b/guides/components.md
@@ -838,8 +838,12 @@ your app registers and the warning goes away:
 
 ```elixir
 # config/config.exs
-config :mob, :extra_tags, ~w(Card LabeledButton)   # PascalCase strings, or [:card, ...]
+config :mob, :extra_tags, ~w(Card LabeledButton)   # PascalCase strings, [:card, ...], or [Card, ...]
 ```
+
+This whitelists the tag for the sigil only. `Mob.ScreenCase.assert_renderable/2`
+checks the *expanded* tree against the native whitelist, so expand composites
+first (`Mob.Composite.expand/2`) or pass the type via `extra:`.
 
 The list is read at each screen's compile time from the app's own config, so
 nothing in `deps/mob` is edited. Mix does not track that read: after editing

--- a/guides/components.md
+++ b/guides/components.md
@@ -822,21 +822,30 @@ Mob.Composite.register(:card, {MyApp.UI.Card, :expand})
 Mob.Composite.register(:labeled_button, {MyApp.UI.LabeledButton, :expand})
 ```
 
-**Expect a compile-time warning on a registered tag; it's harmless.**
+**Declare the tag in config so the sigil accepts it at compile time.**
 Registration happens at *runtime* (from `on_start/0` or a plugin manifest), so
-the `~MOB` macro can't see it while compiling a screen. Every custom tag
-therefore prints a warning the first time it's compiled:
+the `~MOB` macro can't see it while compiling a screen. Without a declaration
+every custom tag prints a warning the first time it's compiled:
 
 ```
 ~MOB: <Card> is not in the Mob tag whitelist — pass-through as :card
 ```
 
-That is informational, not an error. The sigil compiles `<Card>` to the atom
+That is informational, not an error — the sigil compiles `<Card>` to the atom
 `:card` and defers resolution to whatever expander is registered under that atom
-at render time. As long as you registered one in Step 2, the tag renders; the
-warning is just the compiler telling you it recognized a non-built-in tag and
-passed it through. (A genuinely unregistered tag renders nothing, which is the
-real "it doesn't work" symptom to look for.)
+at render time — but under `--warnings-as-errors` it is a wall. List the tags
+your app registers and the warning goes away:
+
+```elixir
+# config/config.exs
+config :mob, :extra_tags, ~w(Card LabeledButton)   # PascalCase strings, or [:card, ...]
+```
+
+The list is read at each screen's compile time from the app's own config, so
+nothing in `deps/mob` is edited. Mix does not track that read: after editing
+the list, `mix compile --force` (or touching the screens) recompiles modules
+that were already built. (A tag that is declared but never registered
+renders nothing, which is the real "it doesn't work" symptom to look for.)
 
 **Step 3 — use them in a screen.** Note there is no `self()` anywhere in this
 markup:

--- a/lib/mob/sigil.ex
+++ b/lib/mob/sigil.ex
@@ -545,6 +545,11 @@ defmodule Mob.Sigil do
     |> Enum.any?(&(normalize_tag(&1) == tag))
   end
 
-  defp normalize_tag(tag) when is_atom(tag), do: tag |> Atom.to_string() |> Macro.camelize()
+  # A bare alias (`MishkaChip`) is the atom `:"Elixir.MishkaChip"`; strip the
+  # prefix so that natural spelling names the same tag as the string form.
+  defp normalize_tag(tag) when is_atom(tag) do
+    tag |> Atom.to_string() |> String.replace_prefix("Elixir.", "") |> Macro.camelize()
+  end
+
   defp normalize_tag(tag) when is_binary(tag), do: Macro.camelize(tag)
 end

--- a/lib/mob/sigil.ex
+++ b/lib/mob/sigil.ex
@@ -80,6 +80,18 @@ defmodule Mob.Sigil do
   atom is derived by converting PascalCase to snake_case (e.g. `TabBar` →
   `:tab_bar`). This allows new native tags to be used before the whitelist is
   updated.
+
+  Composite tags an app registers at boot (`Mob.Composite.register/2`, or a UI
+  kit's own registry) are invisible to that compile-time check, so declare them
+  in config and the sigil accepts them silently:
+
+      # config/config.exs
+      config :mob, :extra_tags, ~w(MishkaChip MishkaDrawer)   # or [:mishka_chip, ...]
+
+  Read at each `~MOB` call site's compile time, so it lives in the app's own
+  config — no edit to mob's `priv/tags` files, which `mix deps.get` would undo.
+  Mix does not track the read, so after changing the list run `mix compile
+  --force` (or touch the screens) for already-compiled modules to pick it up.
   """
 
   # ── Whitelist ────────────────────────────────────────────────────────────────
@@ -498,7 +510,7 @@ defmodule Mob.Sigil do
   defp resolve_type(tag, caller) do
     atom = tag |> Macro.underscore() |> String.to_atom()
 
-    unless MapSet.member?(@known_tags.both, tag) do
+    unless MapSet.member?(@known_tags.both, tag) or extra_tag?(tag) do
       ios_only =
         MapSet.member?(@known_tags.ios, tag) and not MapSet.member?(@known_tags.android, tag)
 
@@ -517,4 +529,22 @@ defmodule Mob.Sigil do
 
     atom
   end
+
+  # `config :mob, :extra_tags` — composite tags the app registers at boot.
+  # Evaluated when the CALLER compiles (this runs inside the macro), which is
+  # when Mix has the app's config loaded. `Application.get_env`, not
+  # `compile_env`: the macro form raises inside a function body, and `~MOB`
+  # sits in `render/1`. The trade is that Mix does not track this read, so a
+  # config edit alone does not recompile the screens that used the sigil (see
+  # the moduledoc). Snake_case names are accepted as the same tag their
+  # PascalCase form would be; `Macro.camelize/1` is idempotent on PascalCase.
+  defp extra_tag?(tag) do
+    :mob
+    |> Application.get_env(:extra_tags, [])
+    |> List.wrap()
+    |> Enum.any?(&(normalize_tag(&1) == tag))
+  end
+
+  defp normalize_tag(tag) when is_atom(tag), do: tag |> Atom.to_string() |> Macro.camelize()
+  defp normalize_tag(tag) when is_binary(tag), do: Macro.camelize(tag)
 end

--- a/priv/tags/android.txt
+++ b/priv/tags/android.txt
@@ -6,6 +6,7 @@
 
 Box
 Button
+Canvas
 Column
 Divider
 Image

--- a/priv/tags/ios.txt
+++ b/priv/tags/ios.txt
@@ -5,6 +5,7 @@
 
 Box
 Button
+Canvas
 Column
 Divider
 Image

--- a/test/mob/sigil_test.exs
+++ b/test/mob/sigil_test.exs
@@ -530,7 +530,7 @@ defmodule Mob.SigilExtraTagsTest do
   import ExUnit.CaptureIO, only: [with_io: 2]
 
   setup do
-    Application.put_env(:mob, :extra_tags, ["AcmeGauge", :acme_dial, "acme_meter"])
+    Application.put_env(:mob, :extra_tags, ["AcmeGauge", :acme_dial, "acme_meter", AcmeScope])
     on_exit(fn -> Application.delete_env(:mob, :extra_tags) end)
   end
 
@@ -559,6 +559,12 @@ defmodule Mob.SigilExtraTagsTest do
     {node, warnings} = expand("~MOB(<AcmeMeter />)")
     assert node.type == :acme_meter
     refute warnings =~ "AcmeMeter"
+  end
+
+  test "a bare alias in :extra_tags names the same tag" do
+    {node, warnings} = expand("~MOB(<AcmeScope />)")
+    assert node.type == :acme_scope
+    refute warnings =~ "AcmeScope"
   end
 
   test "tags outside :extra_tags still warn" do

--- a/test/mob/sigil_test.exs
+++ b/test/mob/sigil_test.exs
@@ -6,6 +6,7 @@
 defmodule Mob.SigilTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO, only: [with_io: 2]
   import Mob.Sigil
 
   # ── self-closing: string attributes ─────────────────────────────────────────
@@ -253,10 +254,9 @@ defmodule Mob.SigilTest do
     end
 
     test "GpuView resolves to :gpu_view (and is on the iOS whitelist)" do
-      # If GpuView drops off priv/tags/ios.txt, the sigil emits a
-      # compile-time warning and the test breaks loudly via the stderr
-      # capture used elsewhere in this file. For the type atom alone,
-      # this just checks the snake_case conversion.
+      # If GpuView drops off priv/tags/ios.txt the sigil emits a compile-time
+      # warning (nothing here captures it). This only checks the snake_case
+      # conversion of the type atom.
       node = ~MOB(<GpuView />)
       assert node.type == :gpu_view
     end
@@ -288,14 +288,20 @@ defmodule Mob.SigilTest do
   # ── unknown tags pass through with warning ───────────────────────────────────
 
   describe "unknown tag pass-through" do
-    test "unknown tag produces a node with the derived type atom" do
+    test "unknown tag produces a node with the derived type atom, and warns" do
       # MapView is not in the whitelist — should warn but still compile
-      node = Code.eval_string(~S[
-        import Mob.Sigil
-        ~MOB(<MapView zoom={10} />)
-      ]) |> elem(0)
+      {node, warnings} =
+        with_io(:stderr, fn ->
+          Code.eval_string(~S[
+            import Mob.Sigil
+            ~MOB(<MapView zoom={10} />)
+          ])
+          |> elem(0)
+        end)
+
       assert node.type == :map_view
       assert node.props.zoom == 10
+      assert warnings =~ "~MOB: <MapView> is not in the Mob tag whitelist"
     end
   end
 
@@ -513,5 +519,57 @@ defmodule Mob.SigilTest do
         """])
       end
     end
+  end
+end
+
+# Separate module, async: false: these tests mutate the global app env, which
+# an async module must not do while other modules may expand the sigil.
+defmodule Mob.SigilExtraTagsTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO, only: [with_io: 2]
+
+  setup do
+    Application.put_env(:mob, :extra_tags, ["AcmeGauge", :acme_dial, "acme_meter"])
+    on_exit(fn -> Application.delete_env(:mob, :extra_tags) end)
+  end
+
+  # Expands `source` under the sigil, returning `{node, captured_stderr}` —
+  # IO.warn from the sigil lands on stderr, where the whitelist warning lives.
+  defp expand(source) do
+    with_io(:stderr, fn ->
+      Code.eval_string("import Mob.Sigil\n" <> source) |> elem(0)
+    end)
+  end
+
+  test "a PascalCase string in :extra_tags compiles without a warning" do
+    {node, warnings} = expand("~MOB(<AcmeGauge level={1} />)")
+    assert node.type == :acme_gauge
+    assert node.props.level == 1
+    refute warnings =~ "AcmeGauge"
+  end
+
+  test "a snake_case atom in :extra_tags names the same tag" do
+    {node, warnings} = expand("~MOB(<AcmeDial />)")
+    assert node.type == :acme_dial
+    refute warnings =~ "AcmeDial"
+  end
+
+  test "a snake_case string in :extra_tags names the same tag" do
+    {node, warnings} = expand("~MOB(<AcmeMeter />)")
+    assert node.type == :acme_meter
+    refute warnings =~ "AcmeMeter"
+  end
+
+  test "tags outside :extra_tags still warn" do
+    {_node, warnings} = expand("~MOB(<AcmeKnob />)")
+    assert warnings =~ "~MOB: <AcmeKnob> is not in the Mob tag whitelist"
+  end
+
+  test "a single value instead of a list is accepted" do
+    Application.put_env(:mob, :extra_tags, "AcmeGauge")
+    {node, warnings} = expand("~MOB(<AcmeGauge />)")
+    assert node.type == :acme_gauge
+    refute warnings =~ "AcmeGauge"
   end
 end


### PR DESCRIPTION
## What

- `Mob.Sigil`: `~MOB` also accepts tags listed under `config :mob, :extra_tags` (PascalCase strings or snake_case names), read from the calling app's config at its compile time. Composites a UI kit registers at boot (`Mob.Composite.register/2`) were invisible to the compile-time whitelist, so every `<MishkaChip />` warned and the only silence was rewriting `deps/mob/priv/tags`, which `mix deps.get` undid.
- `Canvas` added to both platform whitelists: `Mob.UI.canvas/1`, `mob_nif.m`, `MobRootView.swift` and the Android bridge template have handled `:canvas` for a while; only the list was stale, which is why `assert_renderable/2` needed `extra: [:canvas]` on every drawing screen.
- Tests (`Mob.SigilExtraTagsTest`, async: false because it mutates app env), guide text in `guides/components.md`, changelog.

## Why now

Companion to the mob_new change under MOB-188 that makes the generated default app the Mishka Chelekom showcase; its `config.exs` lists the vendored catalog's tags. Land this first, publish, then mob_new bumps its generated mob floor.

## Caveat

`Application.get_env`, not `compile_env` (the macro form raises inside a function body, and `~MOB` sits in `render/1`), so Mix does not track the read: after editing the list, `mix compile --force` recompiles already-built screens. Documented in the moduledoc and guide.

## Verification

- `mix test` 1791 passed; sigil tests fail with `or extra_tag?(tag)` removed (mutation-checked in review).
- End to end: a generated mob_new project pointing at this branch compiles with zero tag warnings (was 100+).
- Adversarial pre-commit review: SOUND; its should-fix items applied (changelog wording, `with_io/2` instead of a hand-rolled capture, async isolation, string camelize, `List.wrap`).

Linear: MOB-188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skG2QLaK9jFJBbJpW9VS8