### PR TITLE
MOB-54 — remove legacy bt_* declarations from mob core's mob_nif.erl

### DIFF
--- a/src/mob_nif.erl
+++ b/src/mob_nif.erl
@@ -121,23 +121,13 @@
     vendor_usb_start_reading/2,
     vendor_usb_stop_reading/1,
     vendor_usb_close/1,
-    %% Bluetooth Classic (Android; iOS returns :unsupported)
-    bt_list_paired/0,
-    bt_start_discovery/0,
-    bt_cancel_discovery/0,
-    bt_pair/1,
-    bt_unpair/1,
-    bt_disconnect/1,
-    bt_hfp_connect/1,
-    bt_hfp_subscribe_vendor_at/2,
-    bt_hfp_send_vendor_at/3,
-    bt_hfp_start_sco/1,
-    bt_hfp_stop_sco/1,
-    bt_hfp_send_audio/2,
-    bt_spp_connect/1,
-    bt_spp_write/2,
-    bt_hid_connect/1,
-    bt_hid_subscribe_raw/1,
+    %% Bluetooth Classic (bt_*) was moved to the mob_bluetooth plugin in
+    %% Wave 2. Callers should depend on {:mob_bluetooth, "~> ..."} and use
+    %% `MobBluetooth.*` — the erl declarations that used to live here were
+    %% removed in MOB-54 because they were never wired into iOS
+    %% `nif_funcs[]`, so `:mob_nif.bt_*(...)` calls raised `nif_error` at
+    %% runtime instead of the plugin surface's documented `:unsupported`
+    %% shape.
     %% DNS — see Mob.DNS and guides/dns_on_ios.md
     resolve_ipv4/1
 ]).
@@ -244,23 +234,10 @@
     vendor_usb_start_reading/2,
     vendor_usb_stop_reading/1,
     vendor_usb_close/1,
-    %% Bluetooth Classic
-    bt_list_paired/0,
-    bt_start_discovery/0,
-    bt_cancel_discovery/0,
-    bt_pair/1,
-    bt_unpair/1,
-    bt_disconnect/1,
-    bt_hfp_connect/1,
-    bt_hfp_subscribe_vendor_at/2,
-    bt_hfp_send_vendor_at/3,
-    bt_hfp_start_sco/1,
-    bt_hfp_stop_sco/1,
-    bt_hfp_send_audio/2,
-    bt_spp_connect/1,
-    bt_spp_write/2,
-    bt_hid_connect/1,
-    bt_hid_subscribe_raw/1,
+    %% Bluetooth Classic (bt_*) was moved to the mob_bluetooth plugin in
+    %% Wave 2 — see the -export note above. Removed from -nifs here so
+    %% load_nif no longer looks for symbols that don't exist in iOS
+    %% nif_funcs[]. MOB-54.
     %% DNS — in-process getaddrinfo so iOS apps bypass BEAM's
     %% broken inet_gethost path. See `Mob.DNS` for the Elixir
     %% wrapper and `guides/dns_on_ios.md` for the why.


### PR DESCRIPTION
The Bluetooth Classic surface (bt_list_paired/0, bt_pair/1, bt_hfp_*, bt_spp_*, bt_hid_*) was extracted into the **mob_bluetooth** plugin during Wave 2 of the plugin epic. The Erlang declarations in `src/mob_nif.erl` stayed behind — 16 functions listed in both `-export` (lines 125-140) and `-nifs` (lines 248-263) but with no corresponding entries in iOS `nif_funcs[]`.

Calling `:mob_nif.bt_*(...)` on mob-core-only apps raised `nif_error` at runtime (load_nif couldn't bind the missing symbol), which is a confusing signal — looks like a native fault when the real answer is "this whole surface moved; depend on mob_bluetooth and call `MobBluetooth.*`".

## Verification

- No mob-core module still calls these — `grep -rn "mob_nif.bt_\|:mob_nif.bt_" ~/code/mob/lib/` returns nothing.
- `MobBluetooth` (the plugin) declares its own module + NIFs independently — the legacy declarations here weren't wired to anything anyway.

## Fix

Delete the 32 legacy lines. Any caller still using the old surface gets a clean `UndefinedFunctionError` pointing at `:mob_nif.bt_list_paired/0` — much clearer diagnostic than `nif_error`, and it's the honest shape post-extraction.

Comment stubs in both blocks now point at the mob_bluetooth plugin as the successor surface, so anyone reading the file for archaeology purposes finds the pointer.

## Gates

- `mix test`: 1788 pass, 0 fail
- `mix erlfmt --check src/mob_nif.erl`: clean
- `mix credo --strict`: 0 issues
- `mix compile --warnings-as-errors --force`: clean (one pre-existing `Mob.WebView.post_message/2 is unused` hint unrelated)

Closes MOB-54.