### PR TITLE
MOB-190: :anchored node type on iOS — floating panel at the root, Android arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ Full module documentation: [hexdocs.pm/mob](https://hexdocs.pm/mob).
   snake_case atoms), read from the calling app's config at its compile time.
   Companion to mob_new #68, which lists the vendored Mishka Chelekom
   catalog's tags in a generated app's `config.exs`.
+- **`:anchored` node type on iOS** (MOB-190). Children `[anchor, panel]`: the
+  anchor renders in flow, the panel floats over the page at the root ZStack
+  (anchor preference + root overlay, so no `corner_radius` Box or Scroll on
+  the way up can clip it), placed by a verbatim port of the Android bridge's
+  `MobAnchoredPositionProvider` — `side` / `align` / `side_offset` /
+  `align_offset` / `panel_offset_*` / `flip` / `clamp` / `edge_padding` /
+  `panel_max_*`; `on_tap` on the node is the outside-tap dismiss request.
+  Before this `mob_nif.m` had no mapping for the type, so it fell to the
+  zero-initialised `MobNodeTypeColumn` and every Mishka Chelekom popover,
+  tooltip, menu, select and combobox stacked inline instead of floating.
+  `Anchored` joins `priv/tags/ios.txt`; the Android half lives in the
+  mob_new bridge template (MOB-189). Documented in `guides/components.md`.
 
 ### Fixed
 - **`Canvas` added to the tag whitelist** on both platforms. `Mob.UI.canvas/1`

--- a/decisions/2026-09-12-ios-anchored-is-a-root-overlay.md
+++ b/decisions/2026-09-12-ios-anchored-is-a-root-overlay.md
@@ -53,8 +53,16 @@ past swiftlint's 3000-line limit, and the generated `build.zig` globs every
 
 ## Consequences
 
-- Both platforms now agree on placement by construction. Any future change to
-  the arithmetic has to land in both files; do not "improve" one side.
+- Both platforms run the same arithmetic. Any future change to it has to land
+  in both files; do not "improve" one side. One input differs: Android tests
+  "anchor on screen" against the real display and clamps to the window, while
+  iOS uses the root container for both, and that container starts below the
+  status bar. An anchor scrolled up into the status-bar band is on screen to
+  Android and off screen to iOS, which then skips the clamp for it.
+- A screen parked behind a push (depth-1 retention) publishes no entries: the
+  view reads `mobScreenIsActive` and returns `[]` while inactive, the way
+  `MobSheetView` hides a parked sheet. Without that, a panel left open on the
+  outgoing screen would keep its dismiss scrim over the incoming one.
 - A panel inside a presented `:sheet` is not seen by the root host: sheets
   are presented in a separate window and their preferences do not propagate
   to the root ZStack. No Mishka component nests a popover in a sheet today;
@@ -63,5 +71,6 @@ past swiftlint's 3000-line limit, and the generated `build.zig` globs every
   at opacity 0 until measured. One frame, invisible, but a test that reads
   `element_frames` immediately after opening may see the pre-measure position.
 - `Anchored` is on `priv/tags/ios.txt` only until the Android bridge template
-  (mob_new, MOB-189) carries `MobAnchored`; the sigil reports it as iOS-only
-  until then, which is the truth.
+  (mob_new, MOB-189) carries `MobAnchored`. The sigil does not flag it as
+  iOS-only: its whitelist check tests the union of both files, so the
+  per-platform branches never fire (MOB-194).

--- a/decisions/2026-09-12-ios-anchored-is-a-root-overlay.md
+++ b/decisions/2026-09-12-ios-anchored-is-a-root-overlay.md
@@ -1,0 +1,67 @@
+# iOS `:anchored` panels are drawn at the root, positioned by the Android arithmetic
+
+- Date: 2026-09-12
+- Status: accepted
+- Issue: MOB-190 (part of MOB-188)
+
+## Context
+
+The Mishka Chelekom port introduced `:anchored`, a node whose first child is an
+in-flow trigger and whose second child is a panel that must float over the
+page (popover, tooltip, menu, select, combobox, tree select, context menu,
+preview card). Android renders the panel in its own window through
+`androidx.compose.ui.window.Popup`, placed by `MobAnchoredPositionProvider`,
+a transliteration of the web engines' `positionPopup()`.
+
+iOS had no such node type. `mob_nif.m` mapped unknown type strings to nothing,
+which left `nodeType` at its zero value, `MobNodeTypeColumn`, so every anchored
+node quietly rendered as a VStack of `[trigger, panel]`: the stacked accordion
+the type exists to replace. No error, no blank, and `Mob.ScreenCase`'s
+renderable set is the union of both platforms' whitelists, so a green unit
+suite could not see it.
+
+Three SwiftUI mechanisms were considered:
+
+1. `.overlay(alignment:)` plus `.offset` on the anchored node. Draws inside
+   the node's own subtree, so any ancestor with `corner_radius` (a clipping
+   Box) or a vertical `Scroll` clips it. That clipping is the measured
+   failure that made `:anchored` a node type rather than a positioned Box.
+2. `.popover(isPresented:attachmentAnchor:)`. Right name, wrong tool: on
+   iPhone it adapts to a sheet, brings its own arrow and dimming, and
+   dismisses itself on an outside tap. The BEAM owns open and closed here; a
+   window that closes on its own desynchronises from the screen's assign.
+3. An anchor preference collected at the root. The anchor child publishes
+   its bounds with `.anchorPreference(value: .bounds)`; `MobRootView`'s ZStack
+   resolves them through `.overlayPreferenceValue` and draws the panel there,
+   above every slot, Box and Scroll.
+
+## Decision
+
+Option 3. `MobAnchoredView` renders the anchor in flow and publishes an entry
+(owner node, panel node, bounds anchor). `MobAnchoredPanelHost`, attached to
+the root ZStack before `.ignoresSafeArea`, measures each panel once and places
+it with `MobAnchoredPosition.origin/5`, a line-for-line port of the Android
+provider: mirror side and align for RTL, flip the main axis only when the
+requested side has no room and the opposite one does, apply the raw nudge,
+then clamp to the window (edge padding plus the safe area) only while the
+anchor is on screen. `on_tap` on the node is the outside-tap dismiss request:
+a clear full-window shape under the panel reports it; nothing closes itself.
+
+The code lives in `ios/MobAnchored.swift`. `MobRootView.swift` was already
+past swiftlint's 3000-line limit, and the generated `build.zig` globs every
+`ios/*.swift`, so a new file costs nothing downstream.
+
+## Consequences
+
+- Both platforms now agree on placement by construction. Any future change to
+  the arithmetic has to land in both files; do not "improve" one side.
+- A panel inside a presented `:sheet` is not seen by the root host: sheets
+  are presented in a separate window and their preferences do not propagate
+  to the root ZStack. No Mishka component nests a popover in a sheet today;
+  when one does, the sheet content view needs its own host.
+- The first layout pass positions a zero-size panel, so the panel is drawn
+  at opacity 0 until measured. One frame, invisible, but a test that reads
+  `element_frames` immediately after opening may see the pre-measure position.
+- `Anchored` is on `priv/tags/ios.txt` only until the Android bridge template
+  (mob_new, MOB-189) carries `MobAnchored`; the sigil reports it as iOS-only
+  until then, which is the truth.

--- a/guides/components.md
+++ b/guides/components.md
@@ -613,6 +613,48 @@ content has been measured.
 
 See `Mob.UI.sheet/2` for the full option reference and validation rules.
 
+### `:anchored`
+
+A floating panel positioned relative to an in-flow anchor: the first child is
+the **anchor** (a popover's trigger) and renders in place; the second child is
+the **panel** and renders over the page, above every Box and Scroll between it
+and the screen root, so nothing on the way up can clip it. Omit the panel to
+render the anchor alone (a closed popover). The screen owns open and closed:
+the panel never dismisses itself.
+
+```elixir
+close = {self(), :close_menu}
+
+~MOB"""
+<Anchored side="bottom" align="start" side_offset={4} on_tap={close}>
+  <Button text="Options" on_tap={{self(), :open_menu}} />
+  <Box :if={@menu_open} background={:surface} corner_radius={:radius_md} padding={:space_sm}>
+    <Text text="Rename" />
+  </Box>
+</Anchored>
+"""
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `side` | `"top"` / `"right"` / `"bottom"` / `"left"` | Which side of the anchor the panel sits on (default `"bottom"`) |
+| `align` | `"start"` / `"center"` / `"end"` | Alignment along the other axis (default `"center"`) |
+| `side_offset` | number | Gap between anchor and panel |
+| `align_offset` | number | Nudge along the align axis; positive pushes inward on `"end"` |
+| `panel_offset_x`, `panel_offset_y` | number | Raw nudge applied last (the node's own `offset_x`/`offset_y` would move the anchor) |
+| `flip` | boolean | Swap to the opposite side when the requested one has no room and the other does (default `true`) |
+| `clamp` | boolean | Keep the panel inside the window while the anchor is on screen (default `true`) |
+| `edge_padding` | number | Distance kept from the window edges, added to the safe area (default `8`) |
+| `panel_max_width`, `panel_max_height` | number | Caps on the panel (default: window minus twice `edge_padding`) |
+| `on_tap` | `{pid, tag}` | A tap **outside** the panel delivers `{:tap, tag}` — the dismiss request. Without it an outside tap does nothing. |
+
+Placement is the same arithmetic on both platforms (the web `positionPopup()`
+transliterated): a main-axis flip only when both conditions hold, then a clamp
+on both axes. Android renders the panel in its own window; iOS collects the
+anchor's bounds with an anchor preference and draws the panel at the root.
+The Mishka Chelekom popover, tooltip, menu, select and combobox ports build on
+it.
+
 ## Native view components
 
 ### `:webview`

--- a/ios/MobAnchored.swift
+++ b/ios/MobAnchored.swift
@@ -38,25 +38,47 @@ struct MobAnchoredKey: PreferenceKey {
 struct MobAnchoredView: View {
     let node: MobNode
 
+    // A screen parked behind a push keeps its tree (depth-1 retention, see
+    // MobRootView) and a preference bubbles through `.offset`, `.opacity` and
+    // `.allowsHitTesting(false)` alike — so a panel left open on the outgoing
+    // screen would keep drawing its scrim over the incoming one, at the root,
+    // where the slot's hit-test block does not reach. Publish nothing while
+    // parked; the environment read is tracked past `.equatable()`.
+    @Environment(\.mobScreenIsActive) private var isActive
+
     var body: some View {
         let children = node.childNodes
-        let anchor = children.first
         let panel = children.count > 1 ? children[1] : nil
 
+        // The anchor is rendered unconditionally, in the same structural
+        // position whether or not a panel is present, so opening the panel
+        // does not change the trigger's identity (a combobox's text field
+        // would otherwise lose the keyboard the moment typing opens the list).
+        // A lone child of either kind renders in flow; only a real
+        // [anchor, panel] pair on the active screen publishes an entry.
         Group {
-            if let anchor, let panel {
+            if let anchor = children.first {
                 MobNodeView(node: anchor)
                     .anchorPreference(key: MobAnchoredKey.self, value: .bounds) { bounds in
-                        [MobAnchoredEntry(owner: node, panel: panel, bounds: bounds)]
+                        guard isActive, let panel else { return [] }
+                        return [MobAnchoredEntry(owner: node, panel: panel, bounds: bounds)]
                     }
-            } else if let only = anchor ?? panel {
-                // Closed (anchor alone) and pinned-open-with-no-trigger both
-                // degrade to a plain in-flow child, so the node keeps its id,
-                // its frame and its identity either way.
-                MobNodeView(node: only)
             }
         }
+        // The node's own decoration, as the Android bridge's `Box(modifier = m)`
+        // keeps it — everything but the clickable branch, since `on_tap` on an
+        // anchored node is the dismiss handler, not a tap on the anchor.
+        .frame(
+            width: node.fixedWidth > 0 ? CGFloat(node.fixedWidth) : nil,
+            height: node.fixedHeight > 0 ? CGFloat(node.fixedHeight) : nil,
+            alignment: .leading
+        )
+        .ifLet((node.fillWidthSet && node.fillWidth && node.fixedWidth <= 0) ? () : nil) { view, _ in
+            view.frame(maxWidth: .infinity, alignment: .leading)
+        }
         .padding(node.paddingEdgeInsets)
+        .background(node.backgroundColor.map { Color($0) } ?? Color.clear)
+        .mobGestures(node)
     }
 }
 
@@ -68,14 +90,22 @@ struct MobAnchoredPanelHost: View {
         if !entries.isEmpty {
             GeometryReader { proxy in
                 ZStack(alignment: .topLeading) {
+                    // Every scrim below every panel: with a panel open inside
+                    // another (a select inside a popover) a tap on the outer
+                    // panel must reach it, not a scrim layered over it. A tap
+                    // outside all panels lands on the topmost scrim, the
+                    // innermost entry's — the one Android's focusable inner
+                    // Popup would consume.
                     ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
                         if let dismiss = entry.owner.onTap {
-                            // A tap anywhere outside the panel is a dismiss
+                            // A tap anywhere outside the panels is a dismiss
                             // request. Reported, not acted on: the BEAM decides.
                             Color.clear
                                 .contentShape(Rectangle())
                                 .onTapGesture { dismiss() }
                         }
+                    }
+                    ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
                         MobAnchoredPanel(
                             entry: entry,
                             anchorRect: proxy[entry.bounds],

--- a/ios/MobAnchored.swift
+++ b/ios/MobAnchored.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+
+// ── Anchored (MOB-190) ───────────────────────────────────────────────────────
+//
+// `:anchored` takes exactly two children: [0] the ANCHOR (a popover's trigger),
+// rendered in flow, and [1] the PANEL, rendered by `MobAnchoredPanelHost` at the
+// root ZStack so that it OVERLAYS the page. That is the only arrangement no
+// ancestor can defeat: a Box with corner_radius clips, a vertical Scroll clips
+// its main axis, and an in-flow overlay inside either measures (0,0,0,0) —
+// invisible AND untappable. Not `.popover(isPresented:)` either: it adapts to
+// a sheet on iPhone, brings its own arrow and dimming, and dismisses itself,
+// while the BEAM owns open/closed here.
+//
+// The anchor publishes its bounds through an anchorPreference; the host
+// resolves them against the root and places the panel with
+// `MobAnchoredPosition`, a verbatim port of the Android bridge's
+// `MobAnchoredPositionProvider` (itself the web's positionPopup()): a
+// main-axis flip when the requested side has no room AND the opposite one
+// does, then a clamp to the window (edge_padding plus the safe area) while the
+// anchor is on screen. `on_tap` on the node means DISMISS: with a handler, a
+// tap outside the panel is reported and the screen flips its assign — the
+// panel never closes itself, so its state cannot disagree with the screen's.
+
+struct MobAnchoredEntry {
+    let owner: MobNode
+    let panel: MobNode
+    let bounds: Anchor<CGRect>
+}
+
+struct MobAnchoredKey: PreferenceKey {
+    static var defaultValue: [MobAnchoredEntry] = []
+
+    static func reduce(value: inout [MobAnchoredEntry], nextValue: () -> [MobAnchoredEntry]) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
+struct MobAnchoredView: View {
+    let node: MobNode
+
+    var body: some View {
+        let children = node.childNodes
+        let anchor = children.first
+        let panel = children.count > 1 ? children[1] : nil
+
+        Group {
+            if let anchor, let panel {
+                MobNodeView(node: anchor)
+                    .anchorPreference(key: MobAnchoredKey.self, value: .bounds) { bounds in
+                        [MobAnchoredEntry(owner: node, panel: panel, bounds: bounds)]
+                    }
+            } else if let only = anchor ?? panel {
+                // Closed (anchor alone) and pinned-open-with-no-trigger both
+                // degrade to a plain in-flow child, so the node keeps its id,
+                // its frame and its identity either way.
+                MobNodeView(node: only)
+            }
+        }
+        .padding(node.paddingEdgeInsets)
+    }
+}
+
+struct MobAnchoredPanelHost: View {
+    let entries: [MobAnchoredEntry]
+    @Environment(\.layoutDirection) private var layoutDirection
+
+    var body: some View {
+        if !entries.isEmpty {
+            GeometryReader { proxy in
+                ZStack(alignment: .topLeading) {
+                    ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+                        if let dismiss = entry.owner.onTap {
+                            // A tap anywhere outside the panel is a dismiss
+                            // request. Reported, not acted on: the BEAM decides.
+                            Color.clear
+                                .contentShape(Rectangle())
+                                .onTapGesture { dismiss() }
+                        }
+                        MobAnchoredPanel(
+                            entry: entry,
+                            anchorRect: proxy[entry.bounds],
+                            container: proxy.size,
+                            safeArea: proxy.safeAreaInsets,
+                            rightToLeft: layoutDirection == .rightToLeft
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct MobAnchoredPanel: View {
+    let entry: MobAnchoredEntry
+    let anchorRect: CGRect
+    let container: CGSize
+    let safeArea: EdgeInsets
+    let rightToLeft: Bool
+
+    @State private var panelSize: CGSize = .zero
+
+    var body: some View {
+        let owner = entry.owner
+        let edge = CGFloat(owner.anchoredEdgePadding)
+        // The panel is measured against the whole window, so a fill_width
+        // column inside it would be screen wide and a long paragraph would never
+        // wrap short. Cap it here rather than making every component carry a
+        // width — same defaults as the Android bridge.
+        let maxWidth = owner.anchoredPanelMaxWidth > 0
+            ? CGFloat(owner.anchoredPanelMaxWidth) : max(1, container.width - 2 * edge)
+        let maxHeight = owner.anchoredPanelMaxHeight > 0
+            ? CGFloat(owner.anchoredPanelMaxHeight) : max(1, container.height - 2 * edge)
+        let origin = MobAnchoredPosition.origin(
+            anchor: anchorRect,
+            panel: panelSize,
+            container: container,
+            params: MobAnchoredPosition.Params(owner: owner, edge: edge, safeArea: safeArea),
+            rightToLeft: rightToLeft
+        )
+
+        MobNodeView(node: entry.panel)
+            .frame(maxWidth: maxWidth, maxHeight: maxHeight, alignment: .topLeading)
+            .background(
+                GeometryReader { geo in
+                    Color.clear.onChange(of: geo.size, initial: true) { _, size in
+                        panelSize = size
+                    }
+                }
+            )
+            // Hidden until measured: the first pass positions a zero-size
+            // panel, and showing it would flash the content at the wrong spot.
+            .opacity(panelSize == .zero ? 0 : 1)
+            .offset(x: origin.x, y: origin.y)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+// The web's positionPopup(), transliterated — byte-for-byte the same arithmetic
+// as the Android bridge's MobAnchoredPositionProvider, so the two platforms
+// cannot drift: a main-axis-only flip when BOTH halves hold, then an
+// unconditional clamp on both axes while the anchor is on screen. `align` is
+// never flipped, and there is no shift-along-align fallback.
+enum MobAnchoredPosition {
+    struct Params {
+        let side: String
+        let align: String
+        let sideOffset: CGFloat
+        let alignOffset: CGFloat
+        let nudgeX: CGFloat
+        let nudgeY: CGFloat
+        let padLeft: CGFloat
+        let padTop: CGFloat
+        let padRight: CGFloat
+        let padBottom: CGFloat
+        let flip: Bool
+        let clamp: Bool
+
+        init(owner: MobNode, edge: CGFloat, safeArea: EdgeInsets) {
+            side = owner.anchoredSide ?? "bottom"
+            // `align` lands in boxAlign for every node; anchored only knows
+            // start / end, and anything else (including the box default
+            // "top_leading") is the Android default, center.
+            align = ["start", "end"].contains(owner.boxAlign) ? owner.boxAlign : "center"
+            sideOffset = CGFloat(owner.anchoredSideOffset)
+            alignOffset = CGFloat(owner.anchoredAlignOffset)
+            nudgeX = CGFloat(owner.anchoredPanelOffsetX)
+            nudgeY = CGFloat(owner.anchoredPanelOffsetY)
+            // The safe area is added per edge; it is zero on edges without a bar.
+            padLeft = edge + safeArea.leading
+            padTop = edge + safeArea.top
+            padRight = edge + safeArea.trailing
+            padBottom = edge + safeArea.bottom
+            flip = owner.anchoredFlip
+            clamp = owner.anchoredClamp
+        }
+    }
+
+    static func origin(
+        anchor: CGRect, panel: CGSize, container: CGSize, params: Params, rightToLeft rtl: Bool
+    ) -> CGPoint {
+        let vw = container.width
+        let vh = container.height
+        let pw = panel.width
+        let ph = panel.height
+
+        // Mirror once, up front, the way the web does with isRTL; everything
+        // after this is absolute arithmetic.
+        var side = params.side
+        if rtl {
+            switch side {
+            case "left": side = "right"
+            case "right": side = "left"
+            default: break
+            }
+        }
+        let vertical = side == "top" || side == "bottom"
+        var align = params.align
+        if rtl && vertical {
+            switch align {
+            case "start": align = "end"
+            case "end": align = "start"
+            default: break
+            }
+        }
+        let alignOffset = (rtl && vertical) ? -params.alignOffset : params.alignOffset
+
+        if params.flip {
+            switch side {
+            case "bottom":
+                if anchor.maxY + params.sideOffset + ph > vh - params.padBottom &&
+                    anchor.minY - params.sideOffset - ph > params.padTop {
+                    side = "top"
+                }
+            case "top":
+                if anchor.minY - params.sideOffset - ph < params.padTop &&
+                    anchor.maxY + params.sideOffset + ph < vh - params.padBottom {
+                    side = "bottom"
+                }
+            case "right":
+                if anchor.maxX + params.sideOffset + pw > vw - params.padRight &&
+                    anchor.minX - params.sideOffset - pw > params.padLeft {
+                    side = "left"
+                }
+            case "left":
+                if anchor.minX - params.sideOffset - pw < params.padLeft &&
+                    anchor.maxX + params.sideOffset + pw < vw - params.padRight {
+                    side = "right"
+                }
+            default: break
+            }
+        }
+
+        var x: CGFloat
+        var y: CGFloat
+        if side == "top" || side == "bottom" {
+            y = side == "bottom" ? anchor.maxY + params.sideOffset : anchor.minY - ph - params.sideOffset
+            // Note the sign asymmetry on "end": a positive align_offset pushes
+            // the panel INWARD, exactly as the web engines do.
+            switch align {
+            case "start": x = anchor.minX + alignOffset
+            case "end": x = anchor.maxX - pw - alignOffset
+            default: x = anchor.minX + (anchor.width - pw) / 2 + alignOffset
+            }
+        } else {
+            x = side == "right" ? anchor.maxX + params.sideOffset : anchor.minX - pw - params.sideOffset
+            switch align {
+            case "start": y = anchor.minY + alignOffset
+            case "end": y = anchor.maxY - ph - alignOffset
+            default: y = anchor.minY + (anchor.height - ph) / 2 + alignOffset
+            }
+        }
+
+        x += params.nudgeX
+        y += params.nudgeY
+
+        // Clamp only while the ANCHOR is on screen. Clamping unconditionally is
+        // what made an open panel park itself at the top of the window and
+        // follow the user down the page after its trigger had scrolled away.
+        let anchorOnScreen = anchor.maxY > 0 && anchor.minY < vh && anchor.maxX > 0 && anchor.minX < vw
+        if params.clamp && anchorOnScreen {
+            // If the panel is wider than the room, the upper bound collapses to
+            // the lower one and it pins flush at the leading edge — the edge
+            // carrying the title. Same as the web's Math.min(Math.max(...)).
+            x = min(max(x, params.padLeft), max(params.padLeft, vw - pw - params.padRight))
+            y = min(max(y, params.padTop), max(params.padTop, vh - ph - params.padBottom))
+        }
+        return CGPoint(x: x, y: y)
+    }
+}

--- a/ios/MobNode.h
+++ b/ios/MobNode.h
@@ -248,7 +248,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Anchored — a floating panel positioned relative to an in-flow anchor
 // (children[0] = anchor, children[1] = panel). `align` reuses boxAlign
-// ("start" | "center" | "end"). See MobAnchoredView in MobRootView.swift.
+// ("start" | "center" | "end"). See MobAnchoredView in MobAnchored.swift.
 @property(nonatomic, copy, nullable) NSString *anchoredSide; // top|right|bottom|left; nil = bottom
 @property(nonatomic) CGFloat anchoredSideOffset;             // pt gap between anchor and panel
 @property(nonatomic) CGFloat anchoredAlignOffset;            // pt nudge along the align axis

--- a/ios/MobNode.h
+++ b/ios/MobNode.h
@@ -43,6 +43,7 @@ typedef NS_ENUM(NSInteger, MobNodeType) {
     MobNodeTypeCanvas,
     MobNodeTypeGpuView,
     MobNodeTypeSheet,
+    MobNodeTypeAnchored,
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -244,6 +245,20 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) int nativeViewHandle; // NIF component handle for event callbacks
 @property(nonatomic, strong, nullable)
     NSDictionary *nativeViewProps; // full props dict forwarded to the factory
+
+// Anchored — a floating panel positioned relative to an in-flow anchor
+// (children[0] = anchor, children[1] = panel). `align` reuses boxAlign
+// ("start" | "center" | "end"). See MobAnchoredView in MobRootView.swift.
+@property(nonatomic, copy, nullable) NSString *anchoredSide; // top|right|bottom|left; nil = bottom
+@property(nonatomic) CGFloat anchoredSideOffset;             // pt gap between anchor and panel
+@property(nonatomic) CGFloat anchoredAlignOffset;            // pt nudge along the align axis
+@property(nonatomic) CGFloat anchoredPanelOffsetX;           // pt raw nudge, applied last
+@property(nonatomic) CGFloat anchoredPanelOffsetY;
+@property(nonatomic) CGFloat anchoredEdgePadding;    // pt kept clear of the window edges; 8
+@property(nonatomic) BOOL anchoredFlip;              // flip sides when out of room; YES
+@property(nonatomic) BOOL anchoredClamp;             // keep the panel in the window; YES
+@property(nonatomic) CGFloat anchoredPanelMaxWidth;  // 0 = window - 2 * edge
+@property(nonatomic) CGFloat anchoredPanelMaxHeight; // 0 = window - 2 * edge
 
 // Accessibility — identifiers support test addressing; labels and disabled
 // state describe composite controls such as tappable boxes.

--- a/ios/MobNode.m
+++ b/ios/MobNode.m
@@ -32,6 +32,9 @@
         _wrapRunSpacing = 0.0;
         _boxAlign = @"top_leading";
         _offsetX = 0.0;
+        _anchoredEdgePadding = 8.0;
+        _anchoredFlip = YES;
+        _anchoredClamp = YES;
         _offsetY = 0.0;
         _keyboardTypeStr = @"default";
         _returnKeyStr = @"done";

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -605,6 +605,9 @@ struct MobNodeView: View {
             case .sheet:
                 MobSheetView(node: node)
 
+            case .anchored:
+                MobAnchoredView(node: node)
+
             @unknown default:
                 EmptyView()
             }
@@ -2687,6 +2690,11 @@ public struct MobRootView: View {
             }
         }
         .environment(\.mobAvailableSheetHeight, availableSheetHeight)
+        // Every open `:anchored` panel on the active screen is drawn here, at
+        // the root, so no Box or Scroll between it and its anchor can clip it.
+        .overlayPreferenceValue(MobAnchoredKey.self) { entries in
+            MobAnchoredPanelHost(entries: entries)
+        }
         .ignoresSafeArea(.container, edges: [.bottom, .horizontal])
         .onChange(of: model.rootVersion) {
             applyRoot(

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -976,6 +976,17 @@ typedef NS_ENUM(NSUInteger, MobPropKey) {
     MOB_PROP_value,
     MOB_PROP_weight,
     MOB_PROP_width,
+    // anchored (MOB-190)
+    MOB_PROP_align_offset,
+    MOB_PROP_clamp,
+    MOB_PROP_edge_padding,
+    MOB_PROP_flip,
+    MOB_PROP_panel_max_height,
+    MOB_PROP_panel_max_width,
+    MOB_PROP_panel_offset_x,
+    MOB_PROP_panel_offset_y,
+    MOB_PROP_side,
+    MOB_PROP_side_offset,
     MOB_PROP__COUNT
 };
 
@@ -1073,6 +1084,16 @@ static NSDictionary<NSString *, NSNumber *> *mob_prop_slots(void) {
           [MOB_PROP_return_key] = @"return_key",
           [MOB_PROP_run_spacing] = @"run_spacing",
           [MOB_PROP_scrolled_past_threshold] = @"scrolled_past_threshold",
+          [MOB_PROP_align_offset] = @"align_offset",
+          [MOB_PROP_clamp] = @"clamp",
+          [MOB_PROP_edge_padding] = @"edge_padding",
+          [MOB_PROP_flip] = @"flip",
+          [MOB_PROP_panel_max_height] = @"panel_max_height",
+          [MOB_PROP_panel_max_width] = @"panel_max_width",
+          [MOB_PROP_panel_offset_x] = @"panel_offset_x",
+          [MOB_PROP_panel_offset_y] = @"panel_offset_y",
+          [MOB_PROP_side] = @"side",
+          [MOB_PROP_side_offset] = @"side_offset",
           [MOB_PROP_secure] = @"secure",
           [MOB_PROP_shader] = @"shader",
           [MOB_PROP_show_indicator] = @"show_indicator",
@@ -1160,6 +1181,8 @@ static MobNode *mob_node_from_dict(NSDictionary *dict) {
         node.nodeType = MobNodeTypeGpuView;
     else if ([type isEqualToString:@"sheet"])
         node.nodeType = MobNodeTypeSheet;
+    else if ([type isEqualToString:@"anchored"])
+        node.nodeType = MobNodeTypeAnchored;
 
     NSDictionary *props = dict[@"props"];
 
@@ -1301,6 +1324,38 @@ static MobNode *mob_node_from_dict(NSDictionary *dict) {
         id offsetY = pv[MOB_PROP_offset_y];
         if (offsetY)
             node.offsetY = [offsetY doubleValue];
+
+        // anchored — all read off THIS node, never off a child (MOB-190).
+        id anchoredSide = pv[MOB_PROP_side];
+        if ([anchoredSide isKindOfClass:[NSString class]])
+            node.anchoredSide = anchoredSide;
+        id sideOffset = pv[MOB_PROP_side_offset];
+        if (sideOffset)
+            node.anchoredSideOffset = [sideOffset doubleValue];
+        id alignOffset = pv[MOB_PROP_align_offset];
+        if (alignOffset)
+            node.anchoredAlignOffset = [alignOffset doubleValue];
+        id panelOffsetX = pv[MOB_PROP_panel_offset_x];
+        if (panelOffsetX)
+            node.anchoredPanelOffsetX = [panelOffsetX doubleValue];
+        id panelOffsetY = pv[MOB_PROP_panel_offset_y];
+        if (panelOffsetY)
+            node.anchoredPanelOffsetY = [panelOffsetY doubleValue];
+        id edgePadding = pv[MOB_PROP_edge_padding];
+        if (edgePadding)
+            node.anchoredEdgePadding = [edgePadding doubleValue];
+        id flip = pv[MOB_PROP_flip];
+        if (flip)
+            node.anchoredFlip = [flip boolValue];
+        id clamp = pv[MOB_PROP_clamp];
+        if (clamp)
+            node.anchoredClamp = [clamp boolValue];
+        id panelMaxWidth = pv[MOB_PROP_panel_max_width];
+        if (panelMaxWidth)
+            node.anchoredPanelMaxWidth = [panelMaxWidth doubleValue];
+        id panelMaxHeight = pv[MOB_PROP_panel_max_height];
+        if (panelMaxHeight)
+            node.anchoredPanelMaxHeight = [panelMaxHeight doubleValue];
 
         id showIndicator = pv[MOB_PROP_show_indicator];
         if (showIndicator)

--- a/priv/tags/ios.txt
+++ b/priv/tags/ios.txt
@@ -26,3 +26,4 @@ Video
 CameraPreview
 WebView
 GpuView
+Anchored

--- a/test/mob/anchored_test.exs
+++ b/test/mob/anchored_test.exs
@@ -1,0 +1,42 @@
+defmodule Mob.AnchoredTest do
+  # The `:anchored` node type: children[0] is the anchor (in flow), children[1]
+  # the panel (floated over the page). These tests pin the Elixir-visible
+  # contract — the whitelist, the sigil, ScreenCase's renderability — not the
+  # native placement, which only a device run can verify.
+  use Mob.ScreenCase, async: true
+
+  import Mob.Sigil
+
+  test "anchored is a renderable type on iOS" do
+    assert :anchored in renderable_types()
+  end
+
+  test "a two-child anchored node passes assert_renderable" do
+    dismiss = {self(), :close}
+
+    tree = ~MOB"""
+    <Anchored side="bottom" align="start" side_offset={4} on_tap={dismiss}>
+      <Button text="Open" />
+      <Box background={:surface} corner_radius={:radius_md} padding={:space_sm}>
+        <Text text="Panel" />
+      </Box>
+    </Anchored>
+    """
+
+    assert tree.type == :anchored
+    assert tree.props.side == "bottom"
+    assert [%{type: :button}, %{type: :box}] = tree.children
+    assert_renderable(tree)
+  end
+
+  test "a closed anchored node (anchor only) is still renderable" do
+    tree = ~MOB"""
+    <Anchored>
+      <Button text="Open" />
+    </Anchored>
+    """
+
+    assert [%{type: :button}] = tree.children
+    assert_renderable(tree)
+  end
+end


### PR DESCRIPTION
## What

A new `:anchored` node type on iOS, the half of Mishka Chelekom parity that lives in mob (the Android half is the mob_new bridge template, MOB-189).

- Children `[anchor, panel]`: the anchor renders in flow and publishes its bounds through an anchor preference; `MobRootView`'s root ZStack draws the panel above every Box and Scroll (`.overlayPreferenceValue`), so nothing on the way up can clip it. Not `.overlay` (clipped by ancestors) and not `.popover(isPresented:)` (adapts to a sheet on iPhone, self-dismisses). Rationale in `decisions/2026-09-12-ios-anchored-is-a-root-overlay.md`.
- Placement is `MobAnchoredPosition.origin/5`, a line-for-line port of the Android bridge's `MobAnchoredPositionProvider` (the web's `positionPopup()`): RTL mirroring, main-axis flip only when both conditions hold, raw nudge, clamp to the window (edge padding plus safe area) while the anchor is on screen. Props: `side`, `align`, `side_offset`, `align_offset`, `panel_offset_x/y`, `flip`, `clamp`, `edge_padding`, `panel_max_width/height`.
- `on_tap` on the node is the outside-tap dismiss request; the panel never closes itself, so its state cannot disagree with the screen's.
- `mob_nif.m` maps the type string and parses the props. Before this the type fell to the zero-initialised `MobNodeTypeColumn`, so every Mishka popover, tooltip, menu, select and combobox stacked inline.
- New file `ios/MobAnchored.swift` (the generated `build.zig` globs `ios/*.swift`; `MobRootView.swift` was already past swiftlint's file-length limit). `Anchored` on `priv/tags/ios.txt`; `guides/components.md` section; `test/mob/anchored_test.exs`.

## Verification

- `mix test` green (anchored + sigil + screen_case), format, credo, clang-format, swiftlint clean.
- iPhone 11 Pro Max simulator, Mishka showcase app built from this branch (`mix mob.deploy --native --ios`): the Popover page's panel floats above its trigger with the beak pointing at it; a tap outside flips `pop_details` to `false` through the screen.
- Adversarial review in progress; findings will be applied before merge.

## Not in this PR

- Android: `MobAnchored` lives in the mob_new bridge template (MOB-189). Until it lands, `Anchored` is iOS-only on the whitelist, which is the truth.
- A panel inside a presented `:sheet` is not seen by the root host (separate window); no Mishka component does that today.

Linear: MOB-190 (parent MOB-188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skG2QLaK9jFJBbJpW9VS8