### PR TITLE
MOB-51: implement iOS continuous input and composition events

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -390,13 +390,12 @@ A platform-native scrolling list optimised for rendering many rows efficiently. 
 
 | Prop | Type | Description |
 |------|------|-------------|
+| `id` | atom | Required list identity; selections arrive as `{:select, id, index}`. |
 | `items` | list | Data items. Each renders as a child. |
-| `on_select` | `{pid, tag}` | Called when a row is tapped: `{:select, tag, index}` |
 
 ```elixir
-select = {self(), :item_tapped}
 ~MOB"""
-<List items={assigns.names} on_select={select}>
+<List id={:names} items={assigns.names}>
   {Enum.map(assigns.names, fn name ->
     ~MOB(<Text text={name} padding={:space_md} />)
   end)}
@@ -491,9 +490,9 @@ An editable text input. Has defaults injected by the renderer (surface_raised ba
 | `value` | string | Current text (controlled) |
 | `placeholder` | string | Hint text when empty |
 | `on_change` | `{pid, tag}` | Fires as the user types. Delivers `{:change, tag, value}` to `handle_info/2`. |
-| `on_submit` | `{pid, tag}` | Fires on keyboard return. Delivers `{:tap, tag}`. |
-| `on_focus` | `{pid, tag}` | Fires when the field gains focus. Delivers `{:tap, tag}`. |
-| `on_blur` | `{pid, tag}` | Fires when the field loses focus. Delivers `{:tap, tag}`. |
+| `on_submit` | `{pid, tag}` | Fires on keyboard return. Delivers `{:submit, tag}`. |
+| `on_focus` | `{pid, tag}` | Fires when the field gains focus. Delivers `{:focus, tag}`. |
+| `on_blur` | `{pid, tag}` | Fires when the field loses focus. Delivers `{:blur, tag}`. |
 | `secure` | boolean | Password masking |
 | `keyboard_type` | `:default` / `:email` / `:number` / `:phone` | Keyboard variant |
 | `background` | color | Background (default `:surface_raised`) |
@@ -987,16 +986,16 @@ end
 
 ## Event routing
 
-**All events are delivered to the screen process via `handle_info/2`.** `self()` inside `render/1` is always the screen's GenServer pid. Every `on_tap`, `on_change`, `on_select`, and similar handler sends its message directly to the screen process — regardless of how deeply the component is nested in the tree.
+**All events are delivered to the screen process via `handle_info/2`.** `self()` inside `render/1` is always the screen's GenServer pid. Event handler props such as `on_tap` and `on_change` send directly to that process, regardless of how deeply the component is nested in the tree. `Mob.List` selections are routed separately through the list's `id`.
 
-| Handler prop | Message delivered to `handle_info/2` |
+| Handler or component | Message delivered to `handle_info/2` |
 |---|---|
 | `on_tap: {pid, tag}` | `{:tap, tag}` |
 | `on_change: {pid, tag}` | `{:change, tag, value}` |
-| `on_select: {pid, tag}` (list) | `{:select, tag, index}` |
-| `on_submit: {pid, tag}` | `{:tap, tag}` |
-| `on_focus: {pid, tag}` | `{:tap, tag}` |
-| `on_blur: {pid, tag}` | `{:tap, tag}` |
+| `Mob.List` with `id: id` | `{:select, id, index}` |
+| `on_submit: {pid, tag}` | `{:submit, tag}` |
+| `on_focus: {pid, tag}` | `{:focus, tag}` |
+| `on_blur: {pid, tag}` | `{:blur, tag}` |
 
 ### Handle limits
 

--- a/guides/event_audit.md
+++ b/guides/event_audit.md
@@ -24,7 +24,7 @@ registrations. Each is opt-in per widget; absence means no event delivery.
 
 | Prop | Form accepted | Native message | Status |
 |------|---------------|----------------|--------|
-| `on_select` | `{pid, tag}` | `{:select, tag}` | Renderer + iOS NIF wired; Android wired |
+| `on_select` | `{pid, tag}` | `{:select, tag}` | Reserved for a future native selection primitive; no core picker/menu currently emits it. `Mob.List` routes indexed selection through row taps instead. |
 | `on_long_press` | `{pid, tag}` | `{:long_press, tag}` | Renderer + iOS NIF + native gesture; Android wired |
 | `on_double_tap` | `{pid, tag}` | `{:double_tap, tag}` | Same |
 | `on_swipe` | `{pid, tag}` | `{:swipe, tag, direction}` | Direction is `:left \| :right \| :up \| :down` |

--- a/guides/events.md
+++ b/guides/events.md
@@ -41,13 +41,18 @@ def handle_info({:tap, :save}, socket), do: ...
 def handle_info({:change, :email_changed, value}, socket), do: ...
 ```
 
-### Selection (pickers, menus)
+### Selection (lists)
 
 ```elixir
-picker(items: @options, on_select: {self(), :picked})
+%{type: :list, props: %{id: :options, items: @options}, children: []}
 
-def handle_info({:select, :picked}, socket), do: ...
+def handle_info({:select, :options, index}, socket), do: ...
 ```
+
+Mob does not currently expose a core picker, menu, or segmented-control
+primitive. The native `on_select` bridge slot is reserved for a future
+selection primitive; ordinary list selection is implemented by tappable rows
+and includes the row index as shown above.
 
 ### Gestures
 

--- a/ios/MobInputEvents.swift
+++ b/ios/MobInputEvents.swift
@@ -1,0 +1,282 @@
+// MobInputEvents.swift — continuous gesture/hover and IME composition bridges.
+
+import Foundation
+import SwiftUI
+import UIKit
+
+// High-frequency spatial input. Native NIF-side throttling still decides
+// which dragging samples cross into BEAM; began/ended boundaries always do.
+// Separate simultaneous gestures allow pinch and rotation to be recognised
+// together and avoid replacing a ScrollView's own pan gesture.
+struct MobContinuousInputModifier: ViewModifier {
+    let node: MobNode
+
+    // Retained by SwiftUI, but its plain properties do not publish changes.
+    // Gesture callbacks run on the main thread, so this avoids multiple view
+    // invalidations per raw sample while remaining stable across node rebuilds.
+    @State private var state = GestureState()
+
+    private final class GestureState {
+        var pinchActive = false
+        var lastScale: CGFloat = 1
+        var lastPinchTime: TimeInterval = 0
+        var lastPinchVelocity: CGFloat = 0
+
+        var rotationActive = false
+        var lastDegrees: CGFloat = 0
+        var lastRotationTime: TimeInterval = 0
+        var lastRotationVelocity: CGFloat = 0
+    }
+
+    private func sampleVelocity(
+        current: CGFloat,
+        previous: CGFloat,
+        now: TimeInterval,
+        previousTime: TimeInterval
+    ) -> CGFloat {
+        let elapsed = now - previousTime
+        guard elapsed > 0 else { return 0 }
+        return (current - previous) / CGFloat(elapsed)
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .ifLet(node.onPinch != nil ? () : nil) { view, _ in
+                view
+                    .contentShape(Rectangle())
+                    .simultaneousGesture(
+                        MagnificationGesture()
+                            .onChanged { scale in
+                                let now = ProcessInfo.processInfo.systemUptime
+                                let phase = state.pinchActive ? "dragging" : "began"
+                                let velocity = state.pinchActive
+                                    ? sampleVelocity(
+                                        current: scale,
+                                        previous: state.lastScale,
+                                        now: now,
+                                        previousTime: state.lastPinchTime
+                                    )
+                                    : 0
+
+                                state.pinchActive = true
+                                state.lastScale = scale
+                                state.lastPinchTime = now
+                                state.lastPinchVelocity = velocity
+                                node.onPinch?(scale, velocity, phase)
+                            }
+                            .onEnded { scale in
+                                node.onPinch?(scale, state.lastPinchVelocity, "ended")
+                                state.pinchActive = false
+                                state.lastScale = 1
+                                state.lastPinchTime = 0
+                                state.lastPinchVelocity = 0
+                            }
+                    )
+            }
+            .ifLet(node.onRotate != nil ? () : nil) { view, _ in
+                view
+                    .contentShape(Rectangle())
+                    .simultaneousGesture(
+                        RotationGesture()
+                            .onChanged { angle in
+                                let degrees = CGFloat(angle.degrees)
+                                let now = ProcessInfo.processInfo.systemUptime
+                                let phase = state.rotationActive ? "dragging" : "began"
+                                let velocity = state.rotationActive
+                                    ? sampleVelocity(
+                                        current: degrees,
+                                        previous: state.lastDegrees,
+                                        now: now,
+                                        previousTime: state.lastRotationTime
+                                    )
+                                    : 0
+
+                                state.rotationActive = true
+                                state.lastDegrees = degrees
+                                state.lastRotationTime = now
+                                state.lastRotationVelocity = velocity
+                                node.onRotate?(degrees, velocity, phase)
+                            }
+                            .onEnded { angle in
+                                node.onRotate?(
+                                    CGFloat(angle.degrees),
+                                    state.lastRotationVelocity,
+                                    "ended"
+                                )
+                                state.rotationActive = false
+                                state.lastDegrees = 0
+                                state.lastRotationTime = 0
+                                state.lastRotationVelocity = 0
+                            }
+                    )
+            }
+            .ifLet(node.onPointerMove != nil ? () : nil) { view, _ in
+                view
+                    .contentShape(Rectangle())
+                    .onContinuousHover(coordinateSpace: .local) { phase in
+                        switch phase {
+                        case .active(let location):
+                            node.onPointerMove?(location.x, location.y)
+                        case .ended:
+                            break
+                        }
+                    }
+            }
+    }
+}
+
+// SwiftUI's TextField does not expose UITextInput.markedTextRange. Opt into a
+// UIKit-backed field only when on_compose is registered; ordinary fields keep
+// their existing SwiftUI implementation and behavior.
+struct MobComposingTextField: UIViewRepresentable {
+    let node: MobNode
+    let placeholder: String
+    let keyboardType: UIKeyboardType
+    let returnKeyType: UIReturnKeyType
+    @Binding var text: String
+    let isFocused: Bool
+    let onFocusChange: (Bool) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> UITextField {
+        let field = UITextField(frame: .zero)
+        field.borderStyle = .roundedRect
+        field.delegate = context.coordinator
+        field.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.textDidChange(_:)),
+            for: .editingChanged
+        )
+        configure(field)
+        context.coordinator.synchronizeProgrammaticText(text)
+        return field
+    }
+
+    func updateUIView(_ field: UITextField, context: Context) {
+        context.coordinator.parent = self
+        configure(field)
+
+        // Never replace marked text underneath an active IME. MobTextField
+        // already defers controlled-value re-seeds while focused; this guard
+        // also protects against a parent update racing the native callback.
+        if field.markedTextRange == nil && field.text != text {
+            field.text = text
+            context.coordinator.synchronizeProgrammaticText(text)
+        }
+
+        if isFocused && !field.isFirstResponder {
+            field.becomeFirstResponder()
+        } else if !isFocused && field.isFirstResponder {
+            field.resignFirstResponder()
+        }
+    }
+
+    private func configure(_ field: UITextField) {
+        field.placeholder = placeholder
+        field.keyboardType = keyboardType
+        field.returnKeyType = returnKeyType
+        field.isSecureTextEntry = node.isSecure
+        field.autocorrectionType = .default
+        field.autocapitalizationType = .sentences
+    }
+
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: MobComposingTextField
+        private var composing = false
+        private var lastMarkedText = ""
+        private var textBeforeComposition = ""
+        private var lastFullText: String
+
+        init(parent: MobComposingTextField) {
+            self.parent = parent
+            lastFullText = parent.text
+        }
+
+        func synchronizeProgrammaticText(_ text: String) {
+            guard !composing else { return }
+            lastFullText = text
+        }
+
+        @objc func textDidChange(_ textField: UITextField) {
+            observeComposition(in: textField)
+
+            let current = textField.text ?? ""
+            lastFullText = current
+            if parent.text != current {
+                parent.text = current
+            }
+        }
+
+        func textFieldDidChangeSelection(_ textField: UITextField) {
+            // Some IMEs change markedTextRange before UIControl emits
+            // editingChanged. Observing both hooks makes phase transitions
+            // reliable; identical marked text is deduplicated below.
+            observeComposition(in: textField)
+        }
+
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            if !parent.isFocused { parent.onFocusChange(true) }
+        }
+
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            observeComposition(in: textField)
+            if parent.isFocused { parent.onFocusChange(false) }
+        }
+
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            parent.node.onSubmit?()
+            guard parent.node.returnKeyStr != "next" else { return false }
+            textField.resignFirstResponder()
+            parent.onFocusChange(false)
+            return true
+        }
+
+        private func observeComposition(in textField: UITextField) {
+            if let range = textField.markedTextRange {
+                let markedText = textField.text(in: range) ?? ""
+
+                if !composing {
+                    composing = true
+                    textBeforeComposition = lastFullText
+                    lastMarkedText = markedText
+                    parent.node.onCompose?(markedText, "began")
+                } else if markedText != lastMarkedText {
+                    lastMarkedText = markedText
+                    parent.node.onCompose?(markedText, "updating")
+                }
+
+                return
+            }
+
+            guard composing else { return }
+
+            let current = textField.text ?? ""
+            let committedText = Self.insertedText(from: textBeforeComposition, to: current)
+            lastFullText = current
+            if committedText.isEmpty {
+                parent.node.onCompose?("", "cancelled")
+            } else {
+                parent.node.onCompose?(committedText, "committed")
+            }
+
+            composing = false
+            lastMarkedText = ""
+            textBeforeComposition = ""
+        }
+
+        // Return only the graphemes introduced by the IME, rather than the
+        // entire field value. CollectionDifference offsets are sorted because
+        // replacement edits can report removals and insertions interleaved.
+        private static func insertedText(from before: String, to after: String) -> String {
+            let inserted = after.difference(from: before).compactMap { change -> (Int, Character)? in
+                guard case let .insert(offset, character, _) = change else { return nil }
+                return (offset, character)
+            }
+
+            return String(inserted.sorted { $0.0 < $1.0 }.map { $0.1 })
+        }
+    }
+}

--- a/ios/MobRootView.swift
+++ b/ios/MobRootView.swift
@@ -626,6 +626,10 @@ struct MobNodeView: View {
         // carrying an :id, so the agent can read positions via the
         // element_frames NIF without a screenshot.
         .modifier(MobFrameTracker(node: node))
+        // Pinch, rotation, and pointer hover belong to the rendered node as a
+        // whole. Keeping this outside the type switch covers every primitive,
+        // including GPU/native views that do not use mobGestures().
+        .modifier(MobContinuousInputModifier(node: node))
     }
 }
 
@@ -1779,18 +1783,39 @@ private struct MobTextField: View {
         }
     }
 
+    private var returnKeyType: UIReturnKeyType {
+        switch node.returnKeyStr {
+        case "next":   return .next
+        case "go":     return .go
+        case "search": return .search
+        case "send":   return .send
+        default:       return .done
+        }
+    }
+
     @ViewBuilder
     private var field: some View {
-        if node.isSecure {
+        if node.onCompose != nil {
+            MobComposingTextField(
+                node: node,
+                placeholder: placeholder,
+                keyboardType: keyboardType,
+                returnKeyType: returnKeyType,
+                text: $text,
+                isFocused: isFocused,
+                onFocusChange: { focused in isFocused = focused }
+            )
+        } else if node.isSecure {
             SecureField(placeholder, text: $text)
+                .focused($isFocused)
         } else {
             TextField(placeholder, text: $text)
+                .focused($isFocused)
         }
     }
 
     var body: some View {
         field
-            .focused($isFocused)
             .keyboardType(keyboardType)
             .submitLabel(submitLabel)
             .onSubmit {

--- a/ios/mob_nif.m
+++ b/ios/mob_nif.m
@@ -515,10 +515,18 @@ static void mob_send_compose(int handle, const char *text, const char *phase) {
         enif_make_atom(msg_env, "text"),
         enif_make_atom(msg_env, "phase"),
     };
-    ERL_NIF_TERM vals[2] = {
-        enif_make_string(msg_env, text ? text : "", ERL_NIF_LATIN1),
-        enif_make_atom(msg_env, phase),
-    };
+    const char *utf8 = text ? text : "";
+    size_t text_len = strlen(utf8);
+    ERL_NIF_TERM text_term;
+    unsigned char *text_data = enif_make_new_binary(msg_env, text_len, &text_term);
+    if (text_len > 0 && !text_data) {
+        enif_free_env(msg_env);
+        return;
+    }
+    if (text_len > 0)
+        memcpy(text_data, utf8, text_len);
+
+    ERL_NIF_TERM vals[2] = {text_term, enif_make_atom(msg_env, phase)};
     ERL_NIF_TERM payload;
     enif_make_map_from_arrays(msg_env, keys, vals, 2, &payload);
     ERL_NIF_TERM msg =

--- a/test/mob/native_ios_input_events_test.exs
+++ b/test/mob/native_ios_input_events_test.exs
@@ -1,0 +1,74 @@
+# These source-contract tests guard iOS behavior that host-side Elixir cannot execute.
+# credo:disable-for-this-file Jump.CredoChecks.VacuousTest
+defmodule Mob.NativeIOSInputEventsTest do
+  use ExUnit.Case, async: true
+
+  import Mob.Test.NativeSource
+
+  @root_swift Path.expand("../../ios/MobRootView.swift", __DIR__) |> File.read!() |> code_only()
+  @input_swift Path.expand("../../ios/MobInputEvents.swift", __DIR__)
+               |> File.read!()
+               |> code_only()
+  @objc Path.expand("../../ios/mob_nif.m", __DIR__) |> File.read!() |> code_only(:objc)
+
+  test "every rendered node receives opt-in pinch, rotation, and pointer movement" do
+    modifier =
+      region(
+        @input_swift,
+        "struct MobContinuousInputModifier: ViewModifier {",
+        "struct MobComposingTextField: UIViewRepresentable {"
+      )
+
+    assert modifier =~ "MagnificationGesture()"
+    assert modifier =~ "node.onPinch?(scale, velocity, phase)"
+    assert modifier =~ "node.onPinch?(scale, state.lastPinchVelocity, \"ended\")"
+    assert modifier =~ "RotationGesture()"
+    assert modifier =~ "node.onRotate?(degrees, velocity, phase)"
+
+    assert modifier =~
+             ~r/node\.onRotate\?\(\s*CGFloat\(angle\.degrees\),\s*state\.lastRotationVelocity,\s*"ended"/
+
+    assert modifier =~ ".onContinuousHover(coordinateSpace: .local)"
+    assert modifier =~ "node.onPointerMove?(location.x, location.y)"
+    assert modifier =~ "@State private var state = GestureState()"
+    refute modifier =~ "@State private var pinchActive"
+
+    node_view =
+      region(@root_swift, "struct MobNodeView: View {", "private struct MobLayoutWeight")
+
+    assert node_view =~ ".modifier(MobContinuousInputModifier(node: node))"
+  end
+
+  test "text fields with on_compose observe UIKit marked text and emit every phase" do
+    composing_field =
+      region(
+        @input_swift,
+        "struct MobComposingTextField: UIViewRepresentable {",
+        "final class Coordinator: NSObject, UITextFieldDelegate {"
+      ) <>
+        region(
+          @input_swift,
+          "final class Coordinator: NSObject, UITextFieldDelegate {",
+          "private static func insertedText"
+        )
+
+    assert composing_field =~ "textField.markedTextRange"
+    assert composing_field =~ "node.onCompose?(markedText, \"began\")"
+    assert composing_field =~ "node.onCompose?(markedText, \"updating\")"
+    assert composing_field =~ "node.onCompose?(committedText, \"committed\")"
+    assert composing_field =~ "node.onCompose?(\"\", \"cancelled\")"
+    assert composing_field =~ "lastFullText = current"
+
+    field = region(@root_swift, "private struct MobTextField: View {", "private struct MobToggle")
+    assert field =~ "if node.onCompose != nil"
+    assert field =~ "MobComposingTextField("
+  end
+
+  test "composition text crosses the NIF as a UTF-8 binary" do
+    sender = region(@objc, "static void mob_send_compose", "static void mob_send_long_press")
+
+    assert sender =~ "enif_make_new_binary"
+    assert sender =~ "memcpy(text_data, utf8, text_len)"
+    refute sender =~ "ERL_NIF_LATIN1"
+  end
+end


### PR DESCRIPTION
Implements MOB-51.

What changed:
- attach opt-in pinch, rotation, and pointer-move handling to every rendered iOS node
- add a UIKit-backed text field only when `on_compose` is registered, with began/updating/committed/cancelled IME phases
- encode composition payload text as UTF-8 binaries across the NIF boundary
- correct event/list documentation; `on_select` remains reserved because mob has no native selection primitive
- add source-contract regression coverage

Validation:
- initial adversarial review: approved for device validation after all findings were addressed
- `mix format --check-formatted`
- `mix credo --strict`
- `mix compile --warnings-as-errors`
- `mix test`: 1800 passed, 38 excluded
- focused mutation proof: 3 intentional regressions → 3 failures; restored → 3 passed
- `xcrun clang-format --dry-run --Werror ios/mob_nif.m`
- iOS simulator native build/install/launch
- fresh current `mob_new` blank host built and signed for arm64, installed on a physical iPhone SE (3rd generation), launched through mob_dev's safety-scoped restart path, remained alive, and appeared in `mix mob.devices` as a physical iOS node

Physical-device notes:
- The first manual launches exited inside `erl_start` because another registered Mob test app held the single in-process EPMD port. Using mob_dev's normal restart path cleared only registered Mob test apps and the fresh target remained alive.
- USB distribution connection later timed out at the tunnel layer, so no automated physical multi-touch or marked-text callback is claimed. Exact native source compiled and booted on-device; callback behavior is covered by focused source-contract tests and simulator native builds.
- The separate selector mismatch discovered along the way is tracked as MOB-211.
